### PR TITLE
Fix mobile slider pickers not scrolling on iOS Safari

### DIFF
--- a/components/knobs/knobs.css
+++ b/components/knobs/knobs.css
@@ -20,9 +20,17 @@
   gap: var(--gap);
   height: 100%;
 
-  /* Padding to center first/last items in the window */
-  padding-inline: calc((100% - var(--item-w)) / 2);
   scroll-padding-inline: calc((100% - var(--item-w)) / 2);
+}
+
+/* Spacer elements to center first/last items in the scroll container.
+   Replaces padding-inline which Safari excludes from scrollable overflow,
+   making pickers with few items (e.g. 3) unable to scroll. */
+.mobile-style-knobs__options::before,
+.mobile-style-knobs__options::after {
+  content: "";
+  flex-shrink: 0;
+  width: calc((100% - var(--item-w)) / 2 - var(--gap));
 }
 
 .mobile-style-knobs__item {


### PR DESCRIPTION
## Summary
- iOS Safari excludes `padding-inline-end` from scrollable overflow (WebKit bug), so pickers with only 3 items (glass type, shape) had no overflow and couldn't scroll or respond to clicks
- Replaced `padding-inline` on the scroll container with `::before`/`::after` flex spacers that Safari correctly includes in scrollable content

## Test plan
- [ ] On iOS Safari, open glass type picker (3 items) — verify scrolling and tapping items works
- [ ] On iOS Safari, open shape picker (3 items) — verify scrolling and tapping items works
- [ ] Verify pickers with more items (dithering, shader type) still work correctly
- [ ] Verify first/last items still center correctly when selected