### PR TITLE
Replace toggle info panels with on/off slider pickers

### DIFF
--- a/components/knobs/mobile-color-knobs.css
+++ b/components/knobs/mobile-color-knobs.css
@@ -10,13 +10,16 @@
 
 .mobile-color__palette {
   padding: var(--spacing-2);
-  background: color-mix(in srgb, var(--gray-50) 60%, transparent);
-  backdrop-filter: blur(8px);
   border-radius: var(--radius-xl);
   margin: 0 var(--spacing-2) var(--spacing-2);
 
   .field-label {
     font-size: var(--text-xxs);
+    text-shadow: 1px 1px 6px #353535;
+
+    @media (prefers-color-scheme: dark) {
+      text-shadow: 1px 1px 0px #353535;
+    }
   }
 }
 
@@ -68,57 +71,6 @@
   text-align: center;
 }
 
-.mobile-color__preserve-colors {
-  font-size: var(--text-sm);
-  padding: var(--spacing-2);
-  background: color-mix(in srgb, var(--gray-50) 60%, transparent);
-  backdrop-filter: blur(8px);
-  border-radius: var(--radius-xl);
-  margin: 0 var(--spacing-2) var(--spacing-2);
-  height: 100%;
-}
-
-.preserve-colors-label {
-  color: var(--gray-900);
-  font-weight: 500;
-  font-size: var(--text-xs);
-  display: grid;
-  grid-auto-flow: column;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: var(--spacing);
-  margin-block-end: var(--spacing);
-}
-
-.preserve-colors-hint {
-  font-size: var(--text-xs);
-}
-
-.preserve-colors-status {
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  border-radius: 50%;
-  border: 1px solid var(--border);
-  scale: 1;
-  transition: scale 200ms ease-out;
-
-  &.preserve-colors-status--on {
-    background-color: light-dark(var(--green-400), var(--green-100));
-    border-color: light-dark(var(--green-800), var(--green-500));
-  }
-
-  &.preserve-colors-status--off {
-    background-color: light-dark(var(--red-600), var(--red-200));
-    border-color: light-dark(var(--red-1000), var(--red));
-  }
-
-  &.preserve-colors-status--mixed {
-    background-color: var(--amber-400);
-    border-color: var(--amber);
-  }
-
-  @starting-style {
-    scale: 0.86;
-  }
+.mobile-color-knobs__toggle-picker {
+  padding-bottom: 0;
 }

--- a/components/knobs/mobile-color-knobs.css
+++ b/components/knobs/mobile-color-knobs.css
@@ -11,7 +11,7 @@
 .mobile-color__palette {
   padding: var(--spacing-2);
   border-radius: var(--radius-xl);
-  margin: 0 var(--spacing-2) var(--spacing-2);
+  margin: 0 0 var(--spacing-2);
 
   .field-label {
     font-size: var(--text-xxs);

--- a/components/knobs/mobile-color-knobs.tsx
+++ b/components/knobs/mobile-color-knobs.tsx
@@ -179,6 +179,8 @@ export function MobileColorKnobs() {
       showFloatingLabel("Preserve Colors");
     } else if (id === REVERSE_PALETTE_ID) {
       showFloatingLabel("Reverse Palette");
+    } else if (id === "") {
+      showFloatingLabel("Mixed Palettes");
     }
   };
 
@@ -224,7 +226,7 @@ export function MobileColorKnobs() {
             aria-label="Color palette selection"
           >
             {paletteParam.isMixed && (
-              <SliderPickerMixedItem className="mobile-style-knobs__item mobile-color-knobs__item">
+              <SliderPickerMixedItem className="mobile-style-knobs__item">
                 <button type="button" className="ui-button" data-variant="primary" tabIndex={-1}>
                   <QuestionMark />
                 </button>

--- a/components/knobs/mobile-color-knobs.tsx
+++ b/components/knobs/mobile-color-knobs.tsx
@@ -28,7 +28,6 @@ import { PaletteUpload } from "../palette-upload/index.ts";
 import { ColorPaletteThumbnail } from "../color-palette-thumbnail/index.ts";
 import "./knobs.css";
 import "./mobile-color-knobs.css";
-import clsx from "clsx";
 
 // Special IDs for non-palette items
 const PRESERVE_COLORS_ID = "__preserve_colors__";
@@ -276,13 +275,23 @@ export function MobileColorKnobs() {
         </SliderPickerWindow>
       </SliderPicker>
 
-      {/* Conditional content: Upload or ColorPalette editor or preserve colors note */}
+      {/* Conditional content: Upload, toggle picker, or ColorPalette editor */}
       {isUploadMode ? (
         <PaletteUpload onUpload={uploadPalette} variant="mobile" />
       ) : isPreserveColorsSelected ? (
-        <PreserveColors on={preserveColors.value} isMixed={preserveColors.isMixed} />
+        <BooleanSliderPicker
+          value={!!preserveColors.value}
+          isMixed={preserveColors.isMixed}
+          onValueChange={(v) => updateSelectedEntityParams({ preserveColors: v })}
+          ariaLabel="Preserve colors"
+        />
       ) : isReversePaletteSelected ? (
-        <ReversePaletteInfo on={reversePalette.value} isMixed={reversePalette.isMixed} />
+        <BooleanSliderPicker
+          value={!!reversePalette.value}
+          isMixed={reversePalette.isMixed}
+          onValueChange={(v) => updateSelectedEntityParams({ reversePalette: v })}
+          ariaLabel="Reverse palette"
+        />
       ) : // show nothing if mixed
       paletteParam.isMixed ? null : (
         <ColorPalette
@@ -303,40 +312,53 @@ export function MobileColorKnobs() {
   );
 }
 
-function PreserveColors({ on, isMixed }: { on: boolean; isMixed: boolean }) {
+function BooleanSliderPicker({
+  value,
+  isMixed,
+  onValueChange,
+  ariaLabel,
+}: {
+  value: boolean;
+  isMixed: boolean;
+  onValueChange: (value: boolean) => void;
+  ariaLabel: string;
+}) {
   return (
-    <div className="mobile-color__preserve-colors">
-      <p className="preserve-colors-label">
-        <span
-          key={`${on}${isMixed}`}
-          className={clsx("preserve-colors-status", {
-            "preserve-colors-status--on": on,
-            "preserve-colors-status--off": !on,
-            "preserve-colors-status--mixed": isMixed,
-          })}
-        />
-        <span>Preserve Colors Mode</span>
-      </p>
-      <p className="preserve-colors-hint">Original colors with the palette’s background</p>
-    </div>
-  );
-}
-
-function ReversePaletteInfo({ on, isMixed }: { on: boolean; isMixed: boolean }) {
-  return (
-    <div className="mobile-color__preserve-colors">
-      <p className="preserve-colors-label">
-        <span
-          key={`${on}${isMixed}`}
-          className={clsx("preserve-colors-status", {
-            "preserve-colors-status--on": on,
-            "preserve-colors-status--off": !on,
-            "preserve-colors-status--mixed": isMixed,
-          })}
-        />
-        <span>Reverse Palette</span>
-      </p>
-      <p className="preserve-colors-hint">Lightest color becomes the background</p>
-    </div>
+    <SliderPicker
+      value={isMixed ? "" : value ? "on" : "off"}
+      onValueChange={(v) => {
+        if (v === "on") onValueChange(true);
+        else if (v === "off") onValueChange(false);
+      }}
+      onInteractionStart={() => undo.beginTransaction()}
+      onValueCommit={() => undo.commitTransaction()}
+      className="mobile-style-knobs mobile-color-knobs__toggle-picker"
+    >
+      <SliderPickerWindow className="mobile-style-knobs__window">
+        <SliderPickerOptions className="mobile-style-knobs__options" aria-label={ariaLabel}>
+          {isMixed && (
+            <SliderPickerMixedItem className="mobile-style-knobs__item">
+              <button type="button" className="ui-button" data-variant="primary" tabIndex={-1}>
+                <QuestionMark />
+              </button>
+              <span className="mobile-style-knobs__label">Mixed</span>
+            </SliderPickerMixedItem>
+          )}
+          <SliderPickerItem value="on" className="mobile-style-knobs__item">
+            <button type="button" tabIndex={-1} className="ui-button" data-variant="primary">
+              On
+            </button>
+            <span className="mobile-style-knobs__label">On</span>
+          </SliderPickerItem>
+          <SliderPickerItem value="off" className="mobile-style-knobs__item">
+            <button type="button" tabIndex={-1} className="ui-button" data-variant="primary">
+              Off
+            </button>
+            <span className="mobile-style-knobs__label">Off</span>
+          </SliderPickerItem>
+        </SliderPickerOptions>
+        <div className="mobile-style-knobs__highlight" aria-hidden="true" />
+      </SliderPickerWindow>
+    </SliderPicker>
   );
 }

--- a/components/ui/color-picker/color-picker.css
+++ b/components/ui/color-picker/color-picker.css
@@ -31,7 +31,7 @@
   width: var(--spacing-8);
   height: var(--spacing-8);
   border-radius: 9999px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-75);
   transition:
     transform 0.15s ease,
     box-shadow 0.15s ease;


### PR DESCRIPTION
## Summary
- Replace the static preserve colors / reverse palette description panels with a secondary `SliderPicker` showing On/Off options (and Mixed when applicable), following the existing mixed-item pattern
- Remove dead CSS for the old info panels (`.preserve-colors-*`, `.mobile-color__preserve-colors`)
- Minor color-picker border tweak

## Test plan
- [ ] Select preserve colors in mobile palette picker → verify On/Off slider picker appears below
- [ ] Select reverse palette → verify same On/Off picker
- [ ] Multi-select entities with different preserve colors values → verify Mixed item appears and disappears when resolved
- [ ] Toggle via main picker item tap still works
- [ ] Undo/redo works for changes made via the secondary picker