### PR TITLE
Fix dropped and pasted media placement on the canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ bun run lint:all    # oxlint with type-checking. Always run after changes.
 ## Anti-Patterns
 
 - Do not use TypeScript `enum` keyword. Use `createEnum()`.
+- Do not use `typeof import("...").Type` anywhere. Ever. Use a regular type import, a namespace type import, or an explicit local type alias instead.
 - Do not add `"use client"` / `"use server"` — this is a SPA, not Next.js.
-- Do not import from `node_modules` internals. Use `opensrc/` for source reading.
+- Do not import from `node_modules` internals. Use opensrc cli for source reading.
 - Do not create new context providers without discussion.
 
 ## Export Pipeline

--- a/__tests__/hooks/use-image-input.spec.tsx
+++ b/__tests__/hooks/use-image-input.spec.tsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useRef } from "react";
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import { CanvasProvider } from "#context/canvas-context.tsx";
+import { canvasStore } from "#engine";
+import { getViewportCenter, screenToWorld } from "#lib/canvas-math.ts";
+import { setupCanvasTest } from "../helpers/test-setup.ts";
+
+const mocks = vi.hoisted(() => ({
+  addFilesToCanvas: vi.fn(),
+  addUrlToCanvas: vi.fn(),
+  addUrlsToCanvas: vi.fn(),
+  fitEntitiesToView: vi.fn(),
+  wait: vi.fn(async () => {}),
+  importStudioWithToasts: vi.fn(),
+}));
+
+vi.mock("#lib/entity-placement.ts", () => ({
+  addFilesToCanvas: mocks.addFilesToCanvas,
+  addUrlToCanvas: mocks.addUrlToCanvas,
+  addUrlsToCanvas: mocks.addUrlsToCanvas,
+  fitEntitiesToView: mocks.fitEntitiesToView,
+}));
+
+vi.mock("#hooks/use-clipboard-paste.ts", () => ({
+  useClipboardPaste: () => {},
+}));
+
+vi.mock("#hooks/use-is-mobile.ts", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("#hooks/use-studio-file.ts", () => ({
+  importStudioWithToasts: mocks.importStudioWithToasts,
+}));
+
+vi.mock("#lib/util.ts", async () => {
+  const actual = await vi.importActual<typeof import("#lib/util.ts")>("#lib/util.ts");
+  return {
+    ...actual,
+    wait: mocks.wait,
+  };
+});
+
+const { useImageInput } = await import("#hooks/use-image-input.ts");
+
+type Handlers = ReturnType<typeof useImageInput>;
+
+function Harness({ onReady }: { onReady: (handlers: Handlers, element: HTMLDivElement) => void }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handlers = useImageInput({ containerRef, multipleFiles: true });
+
+  useEffect(() => {
+    if (containerRef.current) {
+      onReady(handlers, containerRef.current);
+    }
+  }, [handlers, onReady]);
+
+  return <div ref={containerRef} />;
+}
+
+function makeProviders(children: React.ReactNode) {
+  const NuqsTestingWrapper = withNuqsTestingAdapter({ searchParams: {} });
+
+  return (
+    <NuqsTestingWrapper>
+      <CanvasProvider>{children}</CanvasProvider>
+    </NuqsTestingWrapper>
+  );
+}
+
+function makeFile(name: string, type = "image/png"): File {
+  return new File(["test"], name, { type });
+}
+
+describe("useImageInput", () => {
+  let cleanup: () => void;
+  let handlers: Handlers | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    cleanup?.();
+    cleanup = setupCanvasTest();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    handlers = null;
+    container = null;
+    Object.defineProperty(window, "devicePixelRatio", { value: 1, configurable: true });
+    canvasStore.setViewport({ offset: { x: 100, y: 40 }, zoom: 2 });
+
+    render(
+      makeProviders(
+        <Harness
+          onReady={(nextHandlers, element) => {
+            handlers = nextHandlers;
+            container = element;
+            element.getBoundingClientRect = () =>
+              ({
+                left: 10,
+                top: 20,
+                width: 800,
+                height: 600,
+                right: 810,
+                bottom: 620,
+                x: 10,
+                y: 20,
+                toJSON: () => ({}),
+              }) as DOMRect;
+          }}
+        />,
+      ),
+    );
+  });
+
+  test("file picker imports use viewport center and fit to view", async () => {
+    expect(handlers).not.toBeNull();
+    expect(container).not.toBeNull();
+
+    const expectedAnchor = getViewportCenter(
+      canvasStore.getViewport(),
+      container!.getBoundingClientRect(),
+      1,
+    );
+
+    await act(async () => {
+      await handlers!.handleFileSelect([makeFile("picked.png")] as unknown as FileList);
+    });
+
+    expect(mocks.addFilesToCanvas).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: "picked.png" })],
+      expect.any(Function),
+      container,
+      {
+        anchor: expectedAnchor,
+        select: true,
+        fitToView: true,
+        bottomInset: 0,
+      },
+    );
+  });
+
+  test("dropped files use drop coordinates and skip fit to view", async () => {
+    expect(handlers).not.toBeNull();
+    expect(container).not.toBeNull();
+
+    const expectedAnchor = screenToWorld(
+      { x: 210, y: 180 },
+      canvasStore.getViewport(),
+      container!.getBoundingClientRect(),
+      1,
+    );
+
+    await act(async () => {
+      await handlers!.handleDrop({
+        clientX: 210,
+        clientY: 180,
+        dataTransfer: {
+          files: [makeFile("drop.png")],
+          items: [],
+          getData: () => "",
+        },
+      } as unknown as React.DragEvent<HTMLDivElement>);
+    });
+
+    expect(mocks.addFilesToCanvas).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: "drop.png" })],
+      expect.any(Function),
+      container,
+      {
+        anchor: expectedAnchor,
+        select: true,
+        fitToView: false,
+        bottomInset: 0,
+      },
+    );
+  });
+
+  test("dropped URLs use grouped placement at the drop point", async () => {
+    expect(handlers).not.toBeNull();
+    expect(container).not.toBeNull();
+
+    const expectedAnchor = screenToWorld(
+      { x: 410, y: 260 },
+      canvasStore.getViewport(),
+      container!.getBoundingClientRect(),
+      1,
+    );
+
+    await act(async () => {
+      await handlers!.handleDrop({
+        clientX: 410,
+        clientY: 260,
+        dataTransfer: {
+          files: [],
+          items: [],
+          getData: (type: string) =>
+            type === "text/uri-list" ? "https://example.com/a.png\nhttps://example.com/b.png" : "",
+        },
+      } as unknown as React.DragEvent<HTMLDivElement>);
+    });
+
+    expect(mocks.addUrlsToCanvas).toHaveBeenCalledWith(
+      ["https://example.com/a.png", "https://example.com/b.png"],
+      expect.any(Function),
+      container,
+      {
+        anchor: expectedAnchor,
+        select: true,
+        fitToView: false,
+        bottomInset: 0,
+      },
+    );
+  });
+
+  test("pasted items can opt into an explicit anchor without fitting the view", async () => {
+    expect(handlers).not.toBeNull();
+    expect(container).not.toBeNull();
+
+    const anchor = { x: 512, y: 384 };
+
+    await act(async () => {
+      await handlers!.handlePastedItems([makeFile("pasted.png")], {
+        anchor,
+        fitToView: false,
+      });
+    });
+
+    expect(mocks.addFilesToCanvas).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: "pasted.png" })],
+      expect.any(Function),
+      container,
+      {
+        anchor,
+        select: true,
+        fitToView: false,
+        bottomInset: 0,
+      },
+    );
+  });
+
+  test("studio file drops still import the workspace instead of adding media", async () => {
+    expect(handlers).not.toBeNull();
+
+    await act(async () => {
+      await handlers!.handleDrop({
+        clientX: 100,
+        clientY: 100,
+        dataTransfer: {
+          files: [makeFile("workspace.vdmsh", "application/vdmsh")],
+          items: [],
+          getData: () => "",
+        },
+      } as unknown as React.DragEvent<HTMLDivElement>);
+    });
+
+    expect(mocks.importStudioWithToasts).toHaveBeenCalledTimes(1);
+    expect(mocks.addFilesToCanvas).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/use-image-input.spec.tsx
+++ b/__tests__/hooks/use-image-input.spec.tsx
@@ -36,9 +36,9 @@ vi.mock("#hooks/use-studio-file.ts", () => ({
 }));
 
 vi.mock("#lib/util.ts", async () => {
-  const actual = await vi.importActual<typeof import("#lib/util.ts")>("#lib/util.ts");
+  const actual = await vi.importActual("#lib/util.ts");
   return {
-    ...actual,
+    ...(actual as object),
     wait: mocks.wait,
   };
 });

--- a/__tests__/lib/entity-placement.spec.ts
+++ b/__tests__/lib/entity-placement.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ShaderCanvasEntity } from "#types/canvas.ts";
+import { setupCanvasTest } from "../helpers/test-setup.ts";
+import { createEntityInput } from "../helpers/test-entity.ts";
+
+const { addFilesToCanvas, addUrlsToCanvas } = await import("#lib/entity-placement.ts");
+const { canvasStore, gameLoop, viewportAnimation } = await import("#engine");
+const mediaLoader = await import("#lib/media-loader.ts");
+
+function makeContainer(): HTMLElement {
+  const element = document.createElement("div");
+  Object.defineProperty(element, "clientWidth", { value: 1200, configurable: true });
+  Object.defineProperty(element, "clientHeight", { value: 800, configurable: true });
+  element.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      width: 1200,
+      height: 800,
+      right: 1200,
+      bottom: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return element;
+}
+
+function makeFile(name: string, type = "image/png"): File {
+  return new File(["test"], name, { type });
+}
+
+function makeEntityInput(size: { width: number; height: number }) {
+  return createEntityInput({ size });
+}
+
+function createAddEntityRecorder() {
+  const added: Array<{
+    entity: Omit<ShaderCanvasEntity, "id" | "zIndex" | "name">;
+    filename?: string;
+  }> = [];
+
+  const addEntity = (
+    entity: Omit<ShaderCanvasEntity, "id" | "zIndex" | "name">,
+    filename?: string,
+  ) => {
+    const id = filename ?? `entity-${added.length + 1}`;
+    added.push({ entity, filename });
+    canvasStore.addEntity({
+      ...entity,
+      id,
+      zIndex: added.length,
+      name: filename ?? id,
+    } as ShaderCanvasEntity);
+    return id;
+  };
+
+  return { addEntity, added };
+}
+
+describe("entity placement", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    cleanup?.();
+    cleanup = setupCanvasTest();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    Object.defineProperty(window, "devicePixelRatio", { value: 1, configurable: true });
+  });
+
+  test("single file drop anchors entity center at the provided point", async () => {
+    const animateTo = vi.spyOn(viewportAnimation, "animateTo");
+    vi.spyOn(mediaLoader, "loadMediaFile").mockResolvedValue(
+      makeEntityInput({ width: 120, height: 80 }),
+    );
+    const { addEntity, added } = createAddEntityRecorder();
+
+    const ids = await addFilesToCanvas([makeFile("one.png")], addEntity, makeContainer(), {
+      anchor: { x: 400, y: 300 },
+      select: true,
+      fitToView: false,
+      bottomInset: 0,
+    });
+
+    expect(ids).toEqual(["one.png"]);
+    expect(added).toHaveLength(1);
+    expect(added[0]!.entity.position).toEqual({ x: 340, y: 260 });
+    expect(canvasStore.getSelectedEntityIds()).toEqual(new Set(["one.png"]));
+    expect(animateTo).not.toHaveBeenCalled();
+  });
+
+  test("multiple file drop centers the combined bounds on the provided point", async () => {
+    vi.spyOn(mediaLoader, "loadMediaFile")
+      .mockResolvedValueOnce(makeEntityInput({ width: 100, height: 80 }))
+      .mockResolvedValueOnce(makeEntityInput({ width: 220, height: 160 }));
+
+    const { addEntity, added } = createAddEntityRecorder();
+
+    await addFilesToCanvas(
+      [makeFile("small.png"), makeFile("large.png")],
+      addEntity,
+      makeContainer(),
+      {
+        anchor: { x: 600, y: 450 },
+        select: true,
+        fitToView: false,
+        bottomInset: 0,
+      },
+    );
+
+    expect(added).toHaveLength(2);
+
+    const minX = Math.min(...added.map(({ entity }) => entity.position.x));
+    const minY = Math.min(...added.map(({ entity }) => entity.position.y));
+    const maxX = Math.max(...added.map(({ entity }) => entity.position.x + entity.size.width));
+    const maxY = Math.max(...added.map(({ entity }) => entity.position.y + entity.size.height));
+
+    expect((minX + maxX) / 2).toBe(600);
+    expect((minY + maxY) / 2).toBe(450);
+  });
+
+  test("fit-to-view remains opt-in", async () => {
+    const stopMomentum = vi.spyOn(gameLoop, "stopMomentum");
+    const animateTo = vi.spyOn(viewportAnimation, "animateTo");
+    vi.spyOn(mediaLoader, "loadMediaFile").mockResolvedValue(
+      makeEntityInput({ width: 100, height: 100 }),
+    );
+    const { addEntity } = createAddEntityRecorder();
+    const container = makeContainer();
+
+    await addFilesToCanvas([makeFile("fit.png")], addEntity, container, {
+      anchor: { x: 100, y: 100 },
+      select: true,
+      fitToView: true,
+      bottomInset: 24,
+    });
+
+    expect(stopMomentum).toHaveBeenCalled();
+    expect(animateTo).toHaveBeenCalledTimes(1);
+  });
+
+  test("multiple dropped URLs are laid out as a group around the drop point", async () => {
+    const animateTo = vi.spyOn(viewportAnimation, "animateTo");
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(new Blob(["a"], { type: "image/png" }), {
+            headers: { "content-type": "image/png" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(new Blob(["b"], { type: "image/png" }), {
+            headers: { "content-type": "image/png" },
+          }),
+        ),
+    );
+
+    vi.spyOn(mediaLoader, "loadMediaFromBlob")
+      .mockResolvedValueOnce(makeEntityInput({ width: 80, height: 80 }))
+      .mockResolvedValueOnce(makeEntityInput({ width: 160, height: 120 }));
+
+    const { addEntity, added } = createAddEntityRecorder();
+
+    await addUrlsToCanvas(
+      ["https://example.com/a.png", "https://example.com/b.png"],
+      addEntity,
+      makeContainer(),
+      {
+        anchor: { x: 320, y: 240 },
+        select: true,
+        fitToView: false,
+        bottomInset: 0,
+      },
+    );
+
+    const minX = Math.min(...added.map(({ entity }) => entity.position.x));
+    const minY = Math.min(...added.map(({ entity }) => entity.position.y));
+    const maxX = Math.max(...added.map(({ entity }) => entity.position.x + entity.size.width));
+    const maxY = Math.max(...added.map(({ entity }) => entity.position.y + entity.size.height));
+
+    expect((minX + maxX) / 2).toBe(320);
+    expect((minY + maxY) / 2).toBe(240);
+    expect(animateTo).not.toHaveBeenCalled();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "mediabunny": "^1.40.1",
         "miniray": "^0.3.1",
         "nuqs": "^2.8.9",
-        "posthog-js": "^1.366.2",
+        "posthog-js": "^1.367.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-resizable-panels": "^4.9.0",
@@ -31,11 +31,11 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.12",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/wicg-file-system-access": "2023.10.7",
-        "@typescript/native-preview": "^7.0.0-dev.20260409.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260411.1",
         "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@webgpu/types": "^0.1.69",
@@ -581,21 +581,21 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260411.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260411.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260411.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260411.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260411.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260411.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260411.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260411.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-cBk+dPa5x5r9wnh5lz3zSnj7YJM1s/tSCf5owex+OkjJLji3iJu7J9kTH1SvvxA5kmkY76qFYw3vFN9h8W3gBA=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260412.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260412.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260412.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260412.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260412.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260412.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260412.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260412.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-tDw3XZt2BkjAlt/MJmnFGmbe9lgKmc5wezmrMoBIEvJcqz+/KVpVBVvjbkZoaiABnJmuG3G3b6IUFrEveTw6UQ=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260411.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qdSDz0o4l4cEZhAn92ayzf7cKiMLrzSp9Xdk5mfaXpiahvxT39fNj5jiwDnRO+kHkHMMIYYL1nQbslSadargyg=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260412.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sSkFG+hjtRWffg6FddF3dEkk7N3TRMEqfiUpixwcWhXgyocMdPw8wutTvQRBxQdgxeL9y01M2SO8A8YPPiEgVg=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260411.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-2Nea85rMeBZe2UV6V8vBVJ3mSFHn4XZ+ceXGFpnfsU2nay0l1ncoYw91JA/yPwM5ui3+pxAYwl8PWLCxlZCB3Q=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260412.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2BTeaLkrHEEDg0D9snigddy01qTY+wgx+W+GpXAfx36PPvW4xWuGXNVWfSaB8bqAC9C8NeLnT/C9/G/rJ5v2w=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260411.1", "", { "os": "linux", "cpu": "arm" }, "sha512-8/LqqQDp73kvT7aWh3sAFglGaSxtjxHIhEgqZ7XWG7+1aHHJeL1bcmRnk7JyP3BE5SPzs3bQhFC6Cvj6WQwTqQ=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260412.1", "", { "os": "linux", "cpu": "arm" }, "sha512-wDLekbfsfmKMWORg7CTnEnpKj8oXpU/6AEBrtVN9CEUCiQAe6yH878nZHhJNzWQXHtrtFf3lY49Yplqmdxja3w=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260411.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-5QRz/eMIb1JtojvB0oeBbIc6ZNqZiiMUSRDsyp1qMJacdrs+1fbQ8MYFft5ceJe94mcolGHnbcozwPg8hf5fDg=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260412.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JAdsG6MlVV1hoAUKPy8zxAL7xLeNxz8JgCbLCJVqW8EyH29R9FD4cFTqr7CSIRTNUEDzDTrgnXUyoRtDe1gr+w=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260411.1", "", { "os": "linux", "cpu": "x64" }, "sha512-H5NWP+ot/L+Tn9ds4W/t4Xx/CuxZF4iHDdRx2hCr/O0l8pBBq8C/MBJ/eUgVZXO4lD+8J6eQ7nOlGtJ0SS8Sbg=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260412.1", "", { "os": "linux", "cpu": "x64" }, "sha512-gYgppiQIqid3jZ7D8THh4k3Q+4bwidrQH6SL9Xgbk1qfP6/jwv8twuPqDOfZ+cK2OD55lQHp15fOh2lMNAC40Q=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260411.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-/Zc1rotE/NS72xNc4UjaEKCBanBsQ/0/fS2sYLcN9yd6p6AYFYzmTWfbGy5qvv1ckXOI0dkOolLzK8nYbrJzbA=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260412.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-TOh7rH5H3jisHJqRXJSjmUGMzcbNBocS/hufhXPQIv+g3pdG5IKZoSnv3SV62I5d12FFDSS5KQon5MQPnOKAHg=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260411.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PhFL0w2Uz9jKdTtm7uy2PPl3nJiacX24jxzDD0R0eBHOY/49L3V5iD7eyBACPSzyWp0/dD7pPdKSnRbS3nVRng=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260412.1", "", { "os": "win32", "cpu": "x64" }, "sha512-u+70wL89wspN1wKoX6FVNUATRGCG3BpleByP3H/UqOZvlwuMm8N7Gy8hEbM0U8bDyAuyP/daUfTBVkqXjjv9mA=="],
 
     "@vercel/blob": ["@vercel/blob@2.3.3", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg=="],
 
@@ -1157,7 +1157,7 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "react-resizable-panels": ["react-resizable-panels@4.9.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-sEl+hA6y9/kxa0aPlrUC+G1lcShAf/PiIjoeC8kWXxa53RfAVplVCIxEl01Nwa4L2iRa5JXBXq1/mI8ch6qOZQ=="],
+    "react-resizable-panels": ["react-resizable-panels@4.10.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 

--- a/components/infinite-canvas/canvas-context-menu.tsx
+++ b/components/infinite-canvas/canvas-context-menu.tsx
@@ -37,6 +37,7 @@ import { MaterialSymbolsFlipToBackRounded } from "../icons/flip-to-back.tsx";
 import { IonDuplicateOutline } from "../icons/duplicate.tsx";
 import { config } from "#config";
 import { logger } from "#lib/client.logger.ts";
+import { screenToWorld } from "#lib/canvas-math.ts";
 import { AsciiMenuKnobs } from "../ascii-knobs.tsx";
 import { DitheringMenuKnobs } from "../dithering-knobs.tsx";
 import { GlassMenuKnobs } from "../glass-knobs.tsx";
@@ -51,6 +52,7 @@ import {
   IMAGE_FORMAT_OPTIONS,
   imageExportOptionsForFormat,
 } from "#renderer/export-formats.ts";
+import type { Point } from "#types/canvas.ts";
 
 const IMAGE_FORMAT_ICONS: Record<ImageExportFormat, typeof PngFormat> = {
   png: PngFormat,
@@ -80,6 +82,7 @@ export default function CanvasContextMenu({
   const paletteInputRef = useRef<HTMLInputElement>(null);
   const [frozenEntity, setFrozenEntity] = useState<ShaderCanvasEntity | undefined>(undefined);
   const [frozenSelection, setFrozenSelection] = useState<FrozenSelectionState | null>(null);
+  const frozenContextMenuScreenPointRef = useRef<Point | null>(null);
 
   const handleOpenChange = (open: boolean) => {
     onOpenChange(open);
@@ -112,6 +115,7 @@ export default function CanvasContextMenu({
     if (!open) {
       setFrozenEntity(undefined);
       setFrozenSelection(null);
+      frozenContextMenuScreenPointRef.current = null;
     }
   };
 
@@ -135,13 +139,21 @@ export default function CanvasContextMenu({
         onOpenChange={handleOpenChange}
         onOpenChangeComplete={handleOpenChangeComplete}
       >
-        <ContextMenu.Trigger className="canvas-menu-trigger">{children}</ContextMenu.Trigger>
+        <ContextMenu.Trigger
+          className="canvas-menu-trigger"
+          onContextMenuCapture={(e) => {
+            frozenContextMenuScreenPointRef.current = { x: e.clientX, y: e.clientY };
+          }}
+        >
+          {children}
+        </ContextMenu.Trigger>
         <ContextMenu.Portal>
           <ContextMenu.Positioner className="menu-positioner">
             <ContextMenu.Popup className="menu-popup">
               <CanvasContextMenuItems
                 contextOpenEntity={frozenEntity}
                 frozenSelection={frozenSelection}
+                frozenContextMenuScreenPointRef={frozenContextMenuScreenPointRef}
                 containerRef={containerRef}
                 paletteInputRef={paletteInputRef}
               />
@@ -169,6 +181,7 @@ function FilePickerButton({ onClick, children }: FilePickerButtonProps) {
 interface CanvasContextMenuItemsProps {
   contextOpenEntity: ShaderCanvasEntity | undefined;
   frozenSelection: FrozenSelectionState | null;
+  frozenContextMenuScreenPointRef: RefObject<Point | null>;
   containerRef: RefObject<HTMLDivElement | null>;
   paletteInputRef: RefObject<HTMLInputElement | null>;
 }
@@ -176,6 +189,7 @@ interface CanvasContextMenuItemsProps {
 function CanvasContextMenuItems({
   contextOpenEntity,
   frozenSelection,
+  frozenContextMenuScreenPointRef,
   containerRef,
   paletteInputRef,
 }: CanvasContextMenuItemsProps) {
@@ -288,7 +302,20 @@ function CanvasContextMenuItems({
       }
     }
     if (collected.length > 0) {
-      await handlePastedItems(collected);
+      const anchor =
+        frozenContextMenuScreenPointRef.current && containerRef.current
+          ? screenToWorld(
+              frozenContextMenuScreenPointRef.current,
+              canvasStore.getViewport(),
+              containerRef.current.getBoundingClientRect(),
+              window.devicePixelRatio,
+            )
+          : undefined;
+
+      await handlePastedItems(collected, {
+        anchor,
+        fitToView: false,
+      });
     }
   };
 

--- a/components/upload-button-controls.tsx
+++ b/components/upload-button-controls.tsx
@@ -1,9 +1,11 @@
 import { useCanvasCommands, useHasEntities } from "#context/use-canvas.ts";
 import { useIsMobile } from "#hooks/use-is-mobile.ts";
+import { getViewportCenter } from "#lib/canvas-math.ts";
 import { addFilesToCanvas } from "#lib/entity-placement.ts";
 import { MediaImagePlus } from "iconoir-react";
 import { useRef } from "react";
 import { config } from "../lib/config";
+import { canvasStore } from "../engine/canvas-store.ts";
 import { Button } from "./ui/button";
 
 export function UploadControls() {
@@ -34,7 +36,18 @@ export function FileUploadComponent() {
     const container = document.querySelector(".infinite-canvas");
     if (!(container instanceof HTMLElement)) return;
 
-    await addFilesToCanvas(Array.from(files), addEntity, container, bottomInset);
+    const anchor = getViewportCenter(
+      canvasStore.getViewport(),
+      container.getBoundingClientRect(),
+      window.devicePixelRatio,
+    );
+
+    await addFilesToCanvas(Array.from(files), addEntity, container, {
+      anchor,
+      select: true,
+      fitToView: true,
+      bottomInset,
+    });
   };
 
   return (

--- a/hooks/use-image-input.ts
+++ b/hooks/use-image-input.ts
@@ -1,7 +1,13 @@
 import { toastManager } from "#components/ui/toast/toast-manager.ts";
 import { config } from "#config";
-import { addFilesToCanvas, addUrlToCanvas, fitEntitiesToView } from "#lib/entity-placement.ts";
+import {
+  addFilesToCanvas,
+  addUrlsToCanvas,
+  addUrlToCanvas,
+  fitEntitiesToView,
+} from "#lib/entity-placement.ts";
 import { fileHandleStore } from "#lib/files/file-handle.ts";
+import { getViewportCenter, screenToWorld } from "#lib/canvas-math.ts";
 import { wait } from "#lib/util.ts";
 import { useRef } from "react";
 import { useCanvasCommands } from "../context/use-canvas.ts";
@@ -15,6 +21,11 @@ interface UseImageInputOptions {
   multipleFiles?: boolean;
 }
 
+interface PastePlacementOptions {
+  anchor?: { x: number; y: number };
+  fitToView?: boolean;
+}
+
 function isStudioFile(file: File): boolean {
   return file.name.endsWith(".studio") || file.name.endsWith(".vdmsh");
 }
@@ -26,10 +37,25 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
   const isMobile = useIsMobile();
   const bottomInset = isMobile ? config.canvas.mobile.bottomInset : 0;
 
+  const getAnchor = (screenPoint?: { x: number; y: number }) => {
+    const container = containerRef.current;
+    if (!container) return null;
+
+    const viewport = canvasStore.getViewport();
+    const rect = container.getBoundingClientRect();
+    const dpr = window.devicePixelRatio;
+    return screenPoint
+      ? screenToWorld(screenPoint, viewport, rect, dpr)
+      : getViewportCenter(viewport, rect, dpr);
+  };
+
   /**
    * Handle pasted items from clipboard (files or URLs)
    */
-  const handlePastedItems = async (items: (File | string)[]) => {
+  const handlePastedItems = async (
+    items: (File | string)[],
+    placementOptions: PastePlacementOptions = {},
+  ) => {
     if (isLoadingRef.current || items.length === 0) return;
     isLoadingRef.current = true;
 
@@ -38,6 +64,13 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
       isLoadingRef.current = false;
       return;
     }
+
+    const anchor = placementOptions.anchor ?? getAnchor();
+    if (!anchor) {
+      isLoadingRef.current = false;
+      return;
+    }
+    const shouldFitToView = placementOptions.fitToView ?? true;
 
     const files: File[] = [];
     const urls: string[] = [];
@@ -53,7 +86,12 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
     // Handle pasted files (images and videos)
     if (files.length > 0) {
       const maxFiles = multipleFiles ? files.length : 1;
-      await addFilesToCanvas(files.slice(0, maxFiles), addEntity, container, bottomInset);
+      await addFilesToCanvas(files.slice(0, maxFiles), addEntity, container, {
+        anchor,
+        select: true,
+        fitToView: shouldFitToView,
+        bottomInset,
+      });
     }
 
     // Handle pasted URLs or voidmesh effects JSON
@@ -84,7 +122,12 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
           continue;
         }
 
-        const entityId = await addUrlToCanvas(urlString, addEntity, container, bottomInset);
+        const entityId = await addUrlToCanvas(urlString, addEntity, container, {
+          anchor,
+          select: true,
+          fitToView: shouldFitToView,
+          bottomInset,
+        });
         if (entityId) {
           entityIds.push(entityId);
           toastManager.add({ title: "Pasted Link" });
@@ -98,7 +141,7 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
       }
 
       // If multiple URLs were pasted, re-select all and fit-to-view together
-      if (entityIds.length > 1) {
+      if (entityIds.length > 1 && shouldFitToView) {
         canvasStore.replaceSelection(entityIds);
         fitEntitiesToView(entityIds, container, bottomInset);
       }
@@ -123,11 +166,22 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
       return;
     }
 
+    const anchor = getAnchor();
+    if (!anchor) {
+      isLoadingRef.current = false;
+      return;
+    }
+
     const fileArray = Array.from(files);
     const maxFiles = multipleFiles ? fileArray.length : 1;
     const filesToProcess = fileArray.slice(0, maxFiles);
 
-    await addFilesToCanvas(filesToProcess, addEntity, container, bottomInset);
+    await addFilesToCanvas(filesToProcess, addEntity, container, {
+      anchor,
+      select: true,
+      fitToView: true,
+      bottomInset,
+    });
 
     isLoadingRef.current = false;
   };
@@ -141,6 +195,12 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
 
     const container = containerRef.current;
     if (!container) {
+      isLoadingRef.current = false;
+      return;
+    }
+
+    const dropAnchor = getAnchor({ x: e.clientX, y: e.clientY });
+    if (!dropAnchor) {
       isLoadingRef.current = false;
       return;
     }
@@ -174,7 +234,12 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
     if (dataTransfer.files.length > 0) {
       const fileArray = Array.from(dataTransfer.files);
       const maxFiles = multipleFiles ? fileArray.length : 1;
-      await addFilesToCanvas(fileArray.slice(0, maxFiles), addEntity, container, bottomInset);
+      await addFilesToCanvas(fileArray.slice(0, maxFiles), addEntity, container, {
+        anchor: dropAnchor,
+        select: true,
+        fitToView: false,
+        bottomInset,
+      });
     }
     // Handle dropped URLs
     else {
@@ -185,38 +250,38 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
 
         const maxUrls = multipleFiles ? urls.length : 1;
         const urlsToProcess = urls.slice(0, maxUrls);
-        const entityIds: string[] = [];
+        const validUrls: string[] = [];
+        const toastIds: string[] = [];
 
         for (const uriString of urlsToProcess) {
           if (URL.canParse(uriString)) {
-            const url = new URL(uriString);
-            const toastId = toastManager.add({
-              title: "Dropped Link",
-              timeout: 0,
-            });
-
-            const loadPromise = async () => {
-              const entityId = await addUrlToCanvas(
-                url.toString(),
-                addEntity,
-                container,
-                bottomInset,
-              );
-              if (entityId) {
-                entityIds.push(entityId);
-              }
-            };
-            // show the toast for at least N ms
-            await Promise.all([loadPromise(), wait(2000)]);
-
-            toastManager.close(toastId);
+            validUrls.push(uriString);
+            toastIds.push(
+              toastManager.add({
+                title: "Dropped Link",
+                timeout: 0,
+              }),
+            );
           }
         }
 
-        // If multiple URLs were dropped, re-select all and fit-to-view together
-        if (entityIds.length > 1) {
-          canvasStore.replaceSelection(entityIds);
-          fitEntitiesToView(entityIds, container, bottomInset);
+        if (validUrls.length > 0) {
+          try {
+            // Keep the loading toast visible long enough to be noticeable.
+            await Promise.all([
+              addUrlsToCanvas(validUrls, addEntity, container, {
+                anchor: dropAnchor,
+                select: true,
+                fitToView: false,
+                bottomInset,
+              }),
+              wait(2000),
+            ]);
+          } finally {
+            for (const toastId of toastIds) {
+              toastManager.close(toastId);
+            }
+          }
         }
       }
     }

--- a/lib/entity-placement.ts
+++ b/lib/entity-placement.ts
@@ -1,11 +1,5 @@
 import type { Point, Size, ShaderCanvasEntity } from "#types/canvas.ts";
-import {
-  calculateFitToView,
-  getViewportCenter,
-  easings,
-  snapToGrid,
-  SNAP_GRID_SIZE,
-} from "./canvas-math.ts";
+import { calculateFitToView, easings, snapToGrid, SNAP_GRID_SIZE } from "./canvas-math.ts";
 import { canvasStore } from "../engine/canvas-store.ts";
 import { viewportAnimation } from "../engine/viewport-animation.ts";
 import { gameLoop } from "../engine/game-loop.ts";
@@ -15,6 +9,7 @@ import { logger } from "./client.logger.ts";
 
 type EntityData = Omit<ShaderCanvasEntity, "id" | "zIndex" | "name"> & { name?: string };
 type AddEntityFn = (entity: EntityData, filename?: string) => string;
+type LoadedEntity = { data: EntityData; filename?: string };
 
 interface LayoutOptions {
   gap: number;
@@ -22,6 +17,13 @@ interface LayoutOptions {
 }
 
 export type LayoutAlgorithm = (sizes: Size[], options: LayoutOptions) => Point[];
+
+export interface ImportPlacementOptions {
+  anchor: Point;
+  select: boolean;
+  fitToView: boolean;
+  bottomInset: number;
+}
 
 /**
  * Shelf-packing layout: pack items left-to-right into rows.
@@ -169,22 +171,43 @@ export function fitEntitiesToView(
   });
 }
 
-/**
- * Load files, lay them out in a grid, add to canvas, select all, and fit-to-view.
- */
-export async function addFilesToCanvas(
-  files: File[],
+function placeLoadedEntities(
+  loaded: LoadedEntity[],
   addEntity: AddEntityFn,
   container: HTMLElement,
-  bottomInset: number = 0,
-): Promise<string[]> {
-  if (files.length === 0) return [];
+  options: ImportPlacementOptions,
+): string[] {
+  if (loaded.length === 0) return [];
 
-  // 1. Load all files in parallel (position at origin, will be repositioned)
+  const positions = calculateLayout(
+    loaded.map((entity) => entity.data.size),
+    options.anchor,
+  );
+
+  const snapEnabled = canvasStore.getState().snapToGrid;
+  const entityIds: string[] = [];
+
+  for (let i = 0; i < loaded.length; i++) {
+    const position = snapEnabled ? snapToGrid(positions[i]!, SNAP_GRID_SIZE) : positions[i]!;
+    const entity = loaded[i]!;
+    const id = addEntity({ ...entity.data, position }, entity.filename);
+    entityIds.push(id);
+  }
+
+  if (options.select) {
+    canvasStore.replaceSelection(entityIds);
+  }
+  if (options.fitToView) {
+    fitEntitiesToView(entityIds, container, options.bottomInset);
+  }
+
+  return entityIds;
+}
+
+async function loadFilesForCanvas(files: File[]): Promise<LoadedEntity[]> {
   const results = await Promise.allSettled(files.map((file) => loadMediaFile(file)));
 
-  // 2. Collect successful loads (preserve original order)
-  const loaded: { data: EntityData; filename: string }[] = [];
+  const loaded: LoadedEntity[] = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i]!;
     if (result.status === "fulfilled" && result.value) {
@@ -192,89 +215,86 @@ export async function addFilesToCanvas(
     }
   }
 
-  if (loaded.length === 0) return [];
+  return loaded;
+}
 
-  // 3. Calculate grid positions centered at viewport center
-  const viewport = canvasStore.getViewport();
-  const rect = container.getBoundingClientRect();
-  const centerWorld = getViewportCenter(viewport, rect, window.devicePixelRatio);
+async function loadUrlForCanvas(url: string): Promise<LoadedEntity | null> {
+  const response = await fetch(url);
+  const blob = await response.blob();
 
-  const positions = calculateLayout(
-    loaded.map((l) => l.data.size),
-    centerWorld,
-  );
+  const rawContentType = response.headers.get("content-type") ?? "";
+  const mimeType = (rawContentType.split(";")[0]?.trim() || blob.type).toLowerCase();
 
-  // 4. Add entities with calculated positions (snap if enabled)
-  const snapEnabled = canvasStore.getState().snapToGrid;
-  const entityIds: string[] = [];
-  for (let i = 0; i < loaded.length; i++) {
-    loaded[i]!.data.position = snapEnabled
-      ? snapToGrid(positions[i]!, SNAP_GRID_SIZE)
-      : positions[i]!;
-    const id = addEntity(loaded[i]!.data, loaded[i]!.filename);
-    entityIds.push(id);
+  let filename: string | undefined;
+  try {
+    const urlObj = new URL(url);
+    const pathParts = urlObj.pathname.split("/");
+    const lastPart = pathParts[pathParts.length - 1];
+    if (lastPart && lastPart.includes(".")) {
+      filename = decodeURIComponent(lastPart);
+    }
+  } catch {
+    // Ignore URL parsing errors
   }
 
-  // 5. Select all new entities and fit-to-view
-  canvasStore.replaceSelection(entityIds);
-  fitEntitiesToView(entityIds, container, bottomInset);
+  const entityData = await loadMediaFromBlob(blob, mimeType, { x: 0, y: 0 }, filename);
+  if (!entityData) return null;
 
-  return entityIds;
+  return { data: entityData, filename };
 }
 
 /**
- * Load an image from a URL, add to canvas, select, and fit-to-view.
+ * Load files, lay them out around the provided anchor, then optionally select and fit.
+ */
+export async function addFilesToCanvas(
+  files: File[],
+  addEntity: AddEntityFn,
+  container: HTMLElement,
+  options: ImportPlacementOptions,
+): Promise<string[]> {
+  if (files.length === 0) return [];
+
+  const loaded = await loadFilesForCanvas(files);
+  return placeLoadedEntities(loaded, addEntity, container, options);
+}
+
+/**
+ * Load media from URLs, lay them out around the provided anchor, then optionally select and fit.
+ */
+export async function addUrlsToCanvas(
+  urls: string[],
+  addEntity: AddEntityFn,
+  container: HTMLElement,
+  options: ImportPlacementOptions,
+): Promise<string[]> {
+  if (urls.length === 0) return [];
+
+  const results = await Promise.allSettled(urls.map((url) => loadUrlForCanvas(url)));
+  const loaded: LoadedEntity[] = [];
+
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value) {
+      loaded.push(result.value);
+    } else if (result.status === "rejected") {
+      logger.error("Failed to load media from URL:", result.reason);
+    }
+  }
+
+  return placeLoadedEntities(loaded, addEntity, container, options);
+}
+
+/**
+ * Load media from a URL, add to canvas, and return the new entity ID.
  */
 export async function addUrlToCanvas(
   url: string,
   addEntity: AddEntityFn,
   container: HTMLElement,
-  bottomInset: number = 0,
+  options: ImportPlacementOptions,
 ): Promise<string | null> {
   try {
-    const response = await fetch(url);
-    const blob = await response.blob();
-
-    // Resolve MIME type: prefer Content-Type header, fall back to blob.type
-    const rawContentType = response.headers.get("content-type") ?? "";
-    const mimeType = (rawContentType.split(";")[0]?.trim() || blob.type).toLowerCase();
-
-    // Extract filename from URL
-    let filename: string | undefined;
-    try {
-      const urlObj = new URL(url);
-      const pathParts = urlObj.pathname.split("/");
-      const lastPart = pathParts[pathParts.length - 1];
-      if (lastPart && lastPart.includes(".")) {
-        filename = decodeURIComponent(lastPart);
-      }
-    } catch {
-      // Ignore URL parsing errors
-    }
-
-    const entityData = await loadMediaFromBlob(blob, mimeType, { x: 0, y: 0 }, filename);
-    if (!entityData) return null;
-
-    // Calculate centered position
-    const viewport = canvasStore.getViewport();
-    const rect = container.getBoundingClientRect();
-    const centerWorld = getViewportCenter(viewport, rect, window.devicePixelRatio);
-
-    let position: Point = {
-      x: centerWorld.x - entityData.size.width / 2,
-      y: centerWorld.y - entityData.size.height / 2,
-    };
-    if (canvasStore.getState().snapToGrid) {
-      position = snapToGrid(position, SNAP_GRID_SIZE);
-    }
-    entityData.position = position;
-
-    const entityId = addEntity(entityData, filename);
-
-    canvasStore.replaceSelection([entityId]);
-    fitEntitiesToView([entityId], container, bottomInset);
-
-    return entityId;
+    const entityIds = await addUrlsToCanvas([url], addEntity, container, options);
+    return entityIds[0] ?? null;
   } catch (err) {
     logger.error("Failed to load media from URL:", err);
     return null;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "posthog-js": "^1.367.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-resizable-panels": "^4.9.0",
+    "react-resizable-panels": "^4.10.0",
     "thumbhash": "^0.1.1",
     "unstorage": "^1.17.5"
   },
@@ -66,7 +66,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/wicg-file-system-access": "2023.10.7",
-    "@typescript/native-preview": "^7.0.0-dev.20260411.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260412.1",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@webgpu/types": "^0.1.69",


### PR DESCRIPTION
## Summary
- place drag-and-drop imports at the actual drop position instead of always centering them in the viewport
- keep file-picker imports centered with fit-to-view, while drag/drop and context-menu paste keep selection without auto-fitting
- refactor media placement into shared anchor-based helpers and add focused tests for drop, paste, and layout behavior
- update repo guidance to forbid `typeof import("...").Type` usage

## Testing
- `bun run --bun vitest run __tests__/components/canvas-context-menu.spec.tsx __tests__/hooks/use-image-input.spec.tsx __tests__/lib/entity-placement.spec.ts`
- `bun run lint:all`
- `bun run lint:typecheck`