### PR TITLE
Fix iOS workspace import hangs and add cancellable import progress

### DIFF
--- a/__tests__/hooks/use-image-input.spec.tsx
+++ b/__tests__/hooks/use-image-input.spec.tsx
@@ -257,4 +257,40 @@ describe("useImageInput", () => {
     expect(mocks.importStudioWithToasts).toHaveBeenCalledTimes(1);
     expect(mocks.addFilesToCanvas).not.toHaveBeenCalled();
   });
+
+  test("failed workspace drops do not leave drag-and-drop stuck loading", async () => {
+    expect(handlers).not.toBeNull();
+
+    const abortError = new Error("Workspace import cancelled");
+    abortError.name = "AbortError";
+    mocks.importStudioWithToasts.mockRejectedValueOnce(abortError);
+
+    await act(async () => {
+      await expect(
+        handlers!.handleDrop({
+          clientX: 100,
+          clientY: 100,
+          dataTransfer: {
+            files: [makeFile("workspace.vdmsh", "application/vdmsh")],
+            items: [],
+            getData: () => "",
+          },
+        } as unknown as React.DragEvent<HTMLDivElement>),
+      ).rejects.toThrow("Workspace import cancelled");
+    });
+
+    await act(async () => {
+      await handlers!.handleDrop({
+        clientX: 100,
+        clientY: 100,
+        dataTransfer: {
+          files: [makeFile("drop.png")],
+          items: [],
+          getData: () => "",
+        },
+      } as unknown as React.DragEvent<HTMLDivElement>);
+    });
+
+    expect(mocks.addFilesToCanvas).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/lib/serialization-deserialize.spec.ts
+++ b/__tests__/lib/serialization-deserialize.spec.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { strToU8, zipSync } from "fflate";
+import { canvasStore } from "#engine";
+import { config } from "#config";
+import { deserialize } from "#lib/serialization/deserialize.ts";
+import { CURRENT_VERSION } from "#lib/serialization/version.ts";
+import { setupCanvasTest } from "../helpers/test-setup.ts";
+
+function createImageWorkspace(entityCount = 1): ArrayBuffer {
+  const entities = Array.from({ length: entityCount }, (_, index) => ({
+    id: `entity-${index + 1}`,
+    name: `Image ${index + 1}`,
+    mediaType: "image" as const,
+    mediaFile: `media/image-${index + 1}.png`,
+    position: { x: index * 10, y: index * 20 },
+    size: { width: 100, height: 100 },
+    originalSize: { width: 100, height: 100 },
+    zIndex: index,
+    rotation: 0,
+    locked: false,
+    edited: false,
+    shaderType: config.defaults.shader,
+    shaderParams: structuredClone(config.defaults.shaderParams),
+  }));
+
+  const archive = zipSync({
+    "manifest.json": strToU8(
+      JSON.stringify({
+        type: "studio-canvas",
+        version: CURRENT_VERSION,
+        createdAt: new Date("2026-04-15T10:00:00.000Z").toISOString(),
+        viewport: {
+          offset: { x: 42, y: 24 },
+          zoom: 1.5,
+        },
+        entities,
+        palettes: [],
+      }),
+    ),
+    ...Object.fromEntries(entities.map((entity) => [entity.mediaFile, new Uint8Array([1, 2, 3])])),
+  });
+
+  return new Uint8Array(archive).buffer;
+}
+
+describe("deserialize workspace", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    cleanup?.();
+    cleanup = setupCanvasTest();
+  });
+
+  test("reports import progress stages in order", async () => {
+    const stages: string[] = [];
+    const progressEvents: Array<{ stage: string; entityIndex?: number; entityName?: string }> = [];
+
+    const result = await deserialize(createImageWorkspace(), {
+      onProgress: (progress) => {
+        stages.push(progress.stage);
+        progressEvents.push({
+          stage: progress.stage,
+          entityIndex: progress.entityIndex,
+          entityName: progress.entityName,
+        });
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.entityCount).toBe(1);
+    expect(stages).toEqual(["reading", "unzipping", "parsing", "decoding", "restoring", "done"]);
+    expect(progressEvents[3]).toEqual({
+      stage: "decoding",
+      entityIndex: 1,
+      entityName: "Image 1",
+    });
+    expect(canvasStore.getState().entities.size).toBe(1);
+  });
+
+  test("aborting during decode keeps the current canvas intact", async () => {
+    canvasStore.setViewport({ offset: { x: 900, y: 450 }, zoom: 3 });
+
+    const controller = new AbortController();
+    await expect(
+      deserialize(createImageWorkspace(2), {
+        signal: controller.signal,
+        onProgress: (progress) => {
+          if (progress.stage === "decoding" && progress.entityIndex === 2) {
+            controller.abort();
+          }
+        },
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(canvasStore.getState().entities.size).toBe(0);
+    expect(canvasStore.getViewport()).toEqual({
+      offset: { x: 900, y: 450 },
+      zoom: 3,
+    });
+  });
+});

--- a/context/canvas-context.tsx
+++ b/context/canvas-context.tsx
@@ -41,7 +41,7 @@ import {
   generatePaletteShortName,
 } from "#components/palette-preset/palette-presets.ts";
 import type { InfiniteCanvasRenderer } from "#renderer/canvas-renderer.ts";
-import type { DeserializeResult } from "#lib/serialization/types.ts";
+import type { DeserializeOptions, DeserializeResult } from "#lib/serialization/types.ts";
 import { type ImageExportOptions, getImageExtension } from "#renderer/export-formats.ts";
 import { canvasStore, disintegrationController, gameLoop } from "#engine";
 
@@ -1777,9 +1777,12 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     return serialize();
   };
 
-  const deserializeCanvas = async (source: Blob | ArrayBuffer): Promise<DeserializeResult> => {
+  const deserializeCanvas = async (
+    source: Blob | ArrayBuffer,
+    options?: DeserializeOptions,
+  ): Promise<DeserializeResult> => {
     const { deserialize, getMaxCounters } = await import("#lib/serialization/index.ts");
-    const result = await deserialize(source);
+    const result = await deserialize(source, options);
 
     // Update ID counters to avoid collisions with future entities
     const { maxId, maxZIndex } = getMaxCounters(result);

--- a/context/use-canvas.ts
+++ b/context/use-canvas.ts
@@ -14,7 +14,7 @@ import type { ColorSpace } from "#types/enums.ts";
 import type { InfiniteCanvasRenderer } from "#renderer/canvas-renderer.ts";
 import type { ImageExportOptions } from "#renderer/export-formats.ts";
 import type { WlurOverlayDebugConfig } from "#renderer/wlur-debug.ts";
-import type { DeserializeResult } from "#lib/serialization/types.ts";
+import type { DeserializeOptions, DeserializeResult } from "#lib/serialization/types.ts";
 import type { Options } from "nuqs";
 import type { PartialDeep } from "type-fest";
 
@@ -76,7 +76,10 @@ export interface CanvasCommands {
   copySelectedEntityToClipboard: () => Promise<boolean>;
   saveSelectedEntityToFile: (options?: ImageExportOptions) => Promise<void>;
   serializeCanvas: () => Promise<Blob | null>;
-  deserializeCanvas: (source: Blob | ArrayBuffer) => Promise<DeserializeResult>;
+  deserializeCanvas: (
+    source: Blob | ArrayBuffer,
+    options?: DeserializeOptions,
+  ) => Promise<DeserializeResult>;
   applyUrlState: (params: URLSearchParams) => void;
   applyEffectsToSelection: (data: {
     shaderType: ShaderType;

--- a/hooks/use-image-input.ts
+++ b/hooks/use-image-input.ts
@@ -193,100 +193,101 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
     if (isLoadingRef.current) return;
     isLoadingRef.current = true;
 
-    const container = containerRef.current;
-    if (!container) {
-      isLoadingRef.current = false;
-      return;
-    }
-
-    const dropAnchor = getAnchor({ x: e.clientX, y: e.clientY });
-    if (!dropAnchor) {
-      isLoadingRef.current = false;
-      return;
-    }
-
-    const { dataTransfer } = e;
-
-    // Handle dropped .studio files — deserialize instead of adding as media
-    if (dataTransfer.files.length > 0) {
-      const studioFile = Array.from(dataTransfer.files).find(isStudioFile);
-      if (studioFile) {
-        // Capture file handle from drop for "save to same file" on Chromium
-        if (fileHandleStore.supportsFileSystemAccess) {
-          const items = Array.from(dataTransfer.items);
-          const studioItem = items.find(
-            (item) => item.kind === "file" && item.getAsFile()?.name === studioFile.name,
-          );
-          if (studioItem) {
-            const handle = await studioItem.getAsFileSystemHandle();
-            if (handle?.kind === "file") {
-              fileHandleStore.handle = handle as FileSystemFileHandle;
-            }
-          }
-        }
-        await importStudioWithToasts(studioFile, deserializeCanvas);
-        isLoadingRef.current = false;
+    try {
+      const container = containerRef.current;
+      if (!container) {
         return;
       }
-    }
 
-    // Handle dropped files (images and videos)
-    if (dataTransfer.files.length > 0) {
-      const fileArray = Array.from(dataTransfer.files);
-      const maxFiles = multipleFiles ? fileArray.length : 1;
-      await addFilesToCanvas(fileArray.slice(0, maxFiles), addEntity, container, {
-        anchor: dropAnchor,
-        select: true,
-        fitToView: false,
-        bottomInset,
-      });
-    }
-    // Handle dropped URLs
-    else {
-      const uriList = dataTransfer.getData("text/uri-list") || dataTransfer.getData("text/plain");
-      if (uriList) {
-        // text/uri-list: newline-separated URIs, lines starting with # are comments (RFC 2483)
-        const urls = uriList.split(/\r?\n/).filter((line) => line.trim() && !line.startsWith("#"));
+      const dropAnchor = getAnchor({ x: e.clientX, y: e.clientY });
+      if (!dropAnchor) {
+        return;
+      }
 
-        const maxUrls = multipleFiles ? urls.length : 1;
-        const urlsToProcess = urls.slice(0, maxUrls);
-        const validUrls: string[] = [];
-        const toastIds: string[] = [];
+      const { dataTransfer } = e;
 
-        for (const uriString of urlsToProcess) {
-          if (URL.canParse(uriString)) {
-            validUrls.push(uriString);
-            toastIds.push(
-              toastManager.add({
-                title: "Dropped Link",
-                timeout: 0,
-              }),
+      // Handle dropped .studio files — deserialize instead of adding as media
+      if (dataTransfer.files.length > 0) {
+        const studioFile = Array.from(dataTransfer.files).find(isStudioFile);
+        if (studioFile) {
+          // Capture file handle from drop for "save to same file" on Chromium
+          if (fileHandleStore.supportsFileSystemAccess) {
+            const items = Array.from(dataTransfer.items);
+            const studioItem = items.find(
+              (item) => item.kind === "file" && item.getAsFile()?.name === studioFile.name,
             );
+            if (studioItem) {
+              const handle = await studioItem.getAsFileSystemHandle();
+              if (handle?.kind === "file") {
+                fileHandleStore.handle = handle as FileSystemFileHandle;
+              }
+            }
           }
+          await importStudioWithToasts(studioFile, deserializeCanvas);
+          return;
         }
+      }
 
-        if (validUrls.length > 0) {
-          try {
-            // Keep the loading toast visible long enough to be noticeable.
-            await Promise.all([
-              addUrlsToCanvas(validUrls, addEntity, container, {
-                anchor: dropAnchor,
-                select: true,
-                fitToView: false,
-                bottomInset,
-              }),
-              wait(2000),
-            ]);
-          } finally {
-            for (const toastId of toastIds) {
-              toastManager.close(toastId);
+      // Handle dropped files (images and videos)
+      if (dataTransfer.files.length > 0) {
+        const fileArray = Array.from(dataTransfer.files);
+        const maxFiles = multipleFiles ? fileArray.length : 1;
+        await addFilesToCanvas(fileArray.slice(0, maxFiles), addEntity, container, {
+          anchor: dropAnchor,
+          select: true,
+          fitToView: false,
+          bottomInset,
+        });
+      }
+      // Handle dropped URLs
+      else {
+        const uriList = dataTransfer.getData("text/uri-list") || dataTransfer.getData("text/plain");
+        if (uriList) {
+          // text/uri-list: newline-separated URIs, lines starting with # are comments (RFC 2483)
+          const urls = uriList
+            .split(/\r?\n/)
+            .filter((line) => line.trim() && !line.startsWith("#"));
+
+          const maxUrls = multipleFiles ? urls.length : 1;
+          const urlsToProcess = urls.slice(0, maxUrls);
+          const validUrls: string[] = [];
+          const toastIds: string[] = [];
+
+          for (const uriString of urlsToProcess) {
+            if (URL.canParse(uriString)) {
+              validUrls.push(uriString);
+              toastIds.push(
+                toastManager.add({
+                  title: "Dropped Link",
+                  timeout: 0,
+                }),
+              );
+            }
+          }
+
+          if (validUrls.length > 0) {
+            try {
+              // Keep the loading toast visible long enough to be noticeable.
+              await Promise.all([
+                addUrlsToCanvas(validUrls, addEntity, container, {
+                  anchor: dropAnchor,
+                  select: true,
+                  fitToView: false,
+                  bottomInset,
+                }),
+                wait(2000),
+              ]);
+            } finally {
+              for (const toastId of toastIds) {
+                toastManager.close(toastId);
+              }
             }
           }
         }
       }
+    } finally {
+      isLoadingRef.current = false;
     }
-
-    isLoadingRef.current = false;
   };
 
   return {

--- a/hooks/use-studio-file.ts
+++ b/hooks/use-studio-file.ts
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import { useCanvasCommands } from "../context/use-canvas.ts";
 import { toastManager, ToastType } from "#components/ui/toast/toast-manager.ts";
-import type { DeserializeResult } from "#lib/serialization/types.ts";
+import type {
+  DeserializeOptions,
+  DeserializeProgress,
+  DeserializeResult,
+} from "#lib/serialization/types.ts";
 import {
   acquireSaveHandle,
   downloadBlob,
@@ -24,26 +28,124 @@ export type StudioFileStatus = typeof StudioFileStatus.infer;
 
 export async function importStudioWithToasts(
   source: Blob | ArrayBuffer,
-  deserializeCanvas: (source: Blob | ArrayBuffer) => Promise<DeserializeResult>,
+  deserializeCanvas: (
+    source: Blob | ArrayBuffer,
+    options?: DeserializeOptions,
+  ) => Promise<DeserializeResult>,
 ): Promise<DeserializeResult> {
-  return toastManager.promise(deserializeCanvas(source), {
-    loading: { title: "Importing voidmesh workspace..." },
-    success: (r) => {
-      if (r.errors.length > 0) {
-        const total = r.entityCount + r.errors.length;
-        return {
-          title: `Failed to import ${r.errors.length} of ${total} files`,
-          type: ToastType.destructive,
-        };
-      }
-      return { title: "Imported successfully", timeout: 2500 };
-    },
-    error: (err) => ({
-      title: "Import failed",
-      description: err instanceof Error ? err.message : "Unknown error",
-      type: ToastType.destructive,
-    }),
+  const controller = new AbortController();
+  let lastProgress: DeserializeProgress | null = null;
+  const startedAt = performance.now();
+  logger.debug("[workspace-import] ui import requested", {
+    fileSizeBytes: source instanceof Blob ? source.size : source.byteLength,
+    sourceType: source instanceof Blob ? "blob" : "array-buffer",
   });
+
+  const toastId = toastManager.add({
+    title: "Importing voidmesh workspace",
+    description: "Preparing",
+    timeout: 0,
+    actionProps: {
+      children: "Cancel",
+      onClick: () => controller.abort(),
+    },
+  });
+
+  const updateToast = (updates: {
+    title?: string;
+    description?: string;
+    timeout?: number;
+    type?: (typeof ToastType)[keyof typeof ToastType];
+    showAction?: boolean;
+  }) => {
+    toastManager.update(toastId, {
+      ...updates,
+      actionProps: updates.showAction
+        ? {
+            children: "Cancel",
+            onClick: () => controller.abort(),
+          }
+        : {
+            children: null,
+          },
+    });
+  };
+
+  try {
+    const result = await deserializeCanvas(source, {
+      signal: controller.signal,
+      onProgress: (progress) => {
+        lastProgress = progress;
+        logger.debug("[workspace-import] ui progress", progress);
+        updateToast({
+          description: formatImportProgress(progress),
+          showAction: progress.stage !== "done",
+        });
+      },
+    });
+
+    if (result.errors.length > 0) {
+      const total = result.entityCount + result.errors.length;
+      updateToast({
+        title:
+          result.entityCount > 0
+            ? `Failed to import ${result.errors.length} of ${total} files`
+            : "Import failed",
+        description: result.errors[0]?.error ?? "Some items could not be restored",
+        timeout: 5000,
+        type: ToastType.destructive,
+        showAction: false,
+      });
+      logger.debug("[workspace-import] ui import completed with entity errors", {
+        durationMs: Math.round(performance.now() - startedAt),
+        entityCount: result.entityCount,
+        errorCount: result.errors.length,
+        firstError: result.errors[0]?.error,
+      });
+      return result;
+    }
+
+    updateToast({
+      title: "Imported successfully",
+      description: result.warnings[0] ?? undefined,
+      timeout: 2500,
+      showAction: false,
+    });
+    logger.debug("[workspace-import] ui import succeeded", {
+      durationMs: Math.round(performance.now() - startedAt),
+      entityCount: result.entityCount,
+      warningCount: result.warnings.length,
+    });
+    return result;
+  } catch (err) {
+    if (isAbortError(err)) {
+      updateToast({
+        title: "Import cancelled",
+        description: lastProgress ? formatImportProgress(lastProgress) : undefined,
+        timeout: 2500,
+        showAction: false,
+      });
+      logger.debug("[workspace-import] ui import cancelled", {
+        durationMs: Math.round(performance.now() - startedAt),
+        lastProgress,
+      });
+      throw err;
+    }
+
+    updateToast({
+      title: "Import failed",
+      description: formatImportError(err, lastProgress),
+      timeout: 5000,
+      type: ToastType.destructive,
+      showAction: false,
+    });
+    logger.debug("[workspace-import] ui import failed", {
+      durationMs: Math.round(performance.now() - startedAt),
+      lastProgress,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
 }
 
 async function serializeAndSave(
@@ -220,8 +322,11 @@ export function useStudioFile() {
           const result = await importStudioWithToasts(file, deserializeCanvas);
           if (result.success) onSuccess?.();
         } catch (err) {
-          logger.error("[importStudioFile] Import failed:", err);
+          if (!isAbortError(err)) {
+            logger.error("[importStudioFile] Import failed:", err);
+          }
         } finally {
+          logger.debug("[workspace-import] picker import finished");
           setStatus(StudioFileStatus.idle);
         }
       })
@@ -239,4 +344,34 @@ export function useStudioFile() {
     isExporting: status === StudioFileStatus.saving,
     isImporting: status === StudioFileStatus.opening,
   };
+}
+
+function formatImportProgress(progress: DeserializeProgress): string {
+  switch (progress.stage) {
+    case "reading":
+      return "Reading workspace file";
+    case "unzipping":
+      return "Unpacking workspace archive";
+    case "parsing":
+      return "Reading workspace manifest";
+    case "decoding":
+      if (progress.entityCount && progress.entityIndex) {
+        return `Importing item ${progress.entityIndex} of ${progress.entityCount}`;
+      }
+      return "Importing workspace media";
+    case "restoring":
+      return "Importing workspace into canvas";
+    case "done":
+      return "Imported successfully";
+  }
+}
+
+function formatImportError(err: unknown, progress: DeserializeProgress | null): string {
+  const message = err instanceof Error ? err.message : "Unknown error";
+  if (!progress) return message;
+  return `${formatImportProgress(progress)} ${message}`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }

--- a/lib/serialization/deserialize.ts
+++ b/lib/serialization/deserialize.ts
@@ -1,14 +1,21 @@
 import { ShaderType, type ShaderCanvasEntity, type ShaderParams } from "#types/canvas.ts";
-import { unzipSync } from "fflate";
+import { unzip, type AsyncTerminable } from "fflate";
 import { canvasStore } from "#engine";
 import { config } from "#config";
 import { deepMerge } from "../deep-merge.ts";
 import { decodeGif } from "../gif-decoder.ts";
 import { rasterizeSvg } from "../media-loader.ts";
 import { paletteStore } from "../palette-store.ts";
+import { logger } from "../client.logger.ts";
 import { bytesToImageBitmap, bytesToVideoElement } from "./media.ts";
 import { runMigrations } from "./migrations.ts";
-import type { DeserializeResult, SerializedEntity, StudioManifest } from "./types.ts";
+import type {
+  DeserializeOptions,
+  DeserializeProgress,
+  DeserializeResult,
+  SerializedEntity,
+  StudioManifest,
+} from "./types.ts";
 import { isStudioManifest, toPlaybackState } from "./types.ts";
 import { CURRENT_VERSION } from "./version.ts";
 
@@ -26,9 +33,26 @@ const MIME_BY_EXT: Record<string, string> = {
  * Clears the existing canvas state, restores viewport, and adds all entities.
  * Returns a result object with success status, warnings, and per-entity errors.
  */
-export async function deserialize(source: Blob | ArrayBuffer): Promise<DeserializeResult> {
+export async function deserialize(
+  source: Blob | ArrayBuffer,
+  options: DeserializeOptions = {},
+): Promise<DeserializeResult> {
+  const { signal, onProgress } = options;
   const warnings: string[] = [];
   const errors: { entityId: string; entityName: string; error: string }[] = [];
+  const startedAt = performance.now();
+  let lastStage: DeserializeProgress["stage"] | null = null;
+
+  const reportProgress = (progress: DeserializeProgress) => {
+    throwIfAborted(signal);
+    if (progress.stage !== lastStage) {
+      lastStage = progress.stage;
+      logger.debug("[workspace-import] stage", progress);
+    } else if (progress.stage === "decoding") {
+      logger.debug("[workspace-import] decoding entity", progress);
+    }
+    onProgress?.(progress);
+  };
 
   // 0. Validate input type
   if (!(source instanceof Blob) && !(source instanceof ArrayBuffer)) {
@@ -37,11 +61,23 @@ export async function deserialize(source: Blob | ArrayBuffer): Promise<Deseriali
     );
   }
 
+  const fileSizeBytes = source instanceof Blob ? source.size : source.byteLength;
+  logger.debug("[workspace-import] deserialize start", {
+    fileSizeBytes,
+    sourceType: source instanceof Blob ? "blob" : "array-buffer",
+  });
+
+  reportProgress({ stage: "reading", fileSizeBytes });
+
   // 1. Unzip the archive
   const buffer = source instanceof Blob ? await source.arrayBuffer() : source;
-  const zipEntries = unzipSync(new Uint8Array(buffer));
+  throwIfAborted(signal);
+  reportProgress({ stage: "unzipping", fileSizeBytes: buffer.byteLength });
+  const zipEntries = await unzipArchive(buffer, signal);
+  throwIfAborted(signal);
 
   // 2. Read and parse manifest
+  reportProgress({ stage: "parsing", fileSizeBytes: buffer.byteLength });
   const manifestBytes = zipEntries["manifest.json"];
   if (!manifestBytes) {
     throw new Error("Invalid .vdmsh file: missing manifest.json");
@@ -60,6 +96,12 @@ export async function deserialize(source: Blob | ArrayBuffer): Promise<Deseriali
       "Invalid .vdmsh file: manifest missing 'type: \"studio-canvas\"' or 'version' field",
     );
   }
+  throwIfAborted(signal);
+  logger.debug("[workspace-import] manifest parsed", {
+    version: (manifest as StudioManifest).version,
+    entityCount: (manifest as StudioManifest).entities.length,
+    paletteCount: (manifest as StudioManifest).palettes?.length ?? 0,
+  });
 
   // 3. Run migrations if needed
   let doc = manifest as StudioManifest;
@@ -72,6 +114,9 @@ export async function deserialize(source: Blob | ArrayBuffer): Promise<Deseriali
       `Document is from a newer version (v${doc.version}). Some features may not restore correctly.`,
     );
   }
+  if (warnings.length > 0) {
+    logger.debug("[workspace-import] manifest warnings", warnings);
+  }
 
   // 4. Import custom/extracted palettes that don't already exist locally
   if (doc.palettes?.length) {
@@ -83,23 +128,45 @@ export async function deserialize(source: Blob | ArrayBuffer): Promise<Deseriali
     }
   }
 
-  // 5. Decode all entities BEFORE clearing canvas (so we don't destroy existing
-  //    state if decoding fails entirely)
-  const entityPromises = doc.entities.map(async (serialized) => {
+  // 5. Decode entities BEFORE clearing canvas so a failed import does not
+  //    destroy the current workspace. Keep this sequential to reduce memory
+  //    pressure on iOS Safari and give cancellation/progress updates time to run.
+  const validEntities: ShaderCanvasEntity[] = [];
+  for (let index = 0; index < doc.entities.length; index++) {
+    const serialized = doc.entities[index]!;
+    reportProgress({
+      stage: "decoding",
+      entityIndex: index + 1,
+      entityCount: doc.entities.length,
+      entityName: serialized.name,
+      fileSizeBytes: buffer.byteLength,
+    });
+    throwIfAborted(signal);
+
+    if (index > 0) {
+      await yieldToMainThread();
+      throwIfAborted(signal);
+    }
+
     try {
-      return await deserializeEntity(serialized, zipEntries, warnings);
+      const entity = await deserializeEntity(serialized, zipEntries, warnings);
+      validEntities.push(entity);
+      logger.debug("[workspace-import] restored entity", {
+        entityId: serialized.id,
+        entityName: serialized.name,
+        mediaType: serialized.mediaType,
+        restoredCount: validEntities.length,
+      });
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       errors.push({
         entityId: serialized.id,
         entityName: serialized.name,
-        error: err instanceof Error ? err.message : String(err),
+        error: message,
       });
-      return null;
+      logger.warn(`[deserialize] Failed to restore "${serialized.name}": ${message}`);
     }
-  });
-
-  const decodedEntities = await Promise.all(entityPromises);
-  const validEntities = decodedEntities.filter((e): e is ShaderCanvasEntity => e !== null);
+  }
 
   // If nothing decoded at all, bail without touching the canvas
   if (validEntities.length === 0 && doc.entities.length > 0) {
@@ -112,6 +179,11 @@ export async function deserialize(source: Blob | ArrayBuffer): Promise<Deseriali
   }
 
   // 6. Pause all existing animated entities before clearing
+  reportProgress({
+    stage: "restoring",
+    entityCount: doc.entities.length,
+    fileSizeBytes: buffer.byteLength,
+  });
   for (const entity of canvasStore.getState().entities.values()) {
     if (entity.mediaSource.type === "video") {
       entity.mediaSource.videoElement.pause();
@@ -140,12 +212,92 @@ export async function deserialize(source: Blob | ArrayBuffer): Promise<Deseriali
     }
   }
 
+  reportProgress({
+    stage: "done",
+    entityCount: validEntities.length,
+    fileSizeBytes: buffer.byteLength,
+  });
+  logger.debug("[workspace-import] deserialize complete", {
+    durationMs: Math.round(performance.now() - startedAt),
+    entityCount: validEntities.length,
+    errorCount: errors.length,
+    warningCount: warnings.length,
+  });
+
   return {
     success: errors.length === 0,
     entityCount: validEntities.length,
     warnings,
     errors,
   };
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("Workspace import cancelled", "AbortError");
+  }
+
+  const error = new Error("Workspace import cancelled");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    logger.debug("[workspace-import] abort requested");
+    throw createAbortError();
+  }
+}
+
+async function yieldToMainThread(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+function unzipArchive(
+  buffer: ArrayBuffer,
+  signal?: AbortSignal,
+): Promise<Record<string, Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let terminate: AsyncTerminable | null = null;
+    const startedAt = performance.now();
+
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", onAbort);
+      callback();
+    };
+
+    const onAbort = () => {
+      terminate?.();
+      logger.debug("[workspace-import] unzip aborted");
+      finish(() => reject(createAbortError()));
+    };
+
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    terminate = unzip(new Uint8Array(buffer), (err, entries) => {
+      finish(() => {
+        if (err) {
+          logger.debug("[workspace-import] unzip failed", err);
+          reject(err);
+          return;
+        }
+        logger.debug("[workspace-import] unzip complete", {
+          entryCount: Object.keys(entries).length,
+          durationMs: Math.round(performance.now() - startedAt),
+        });
+        resolve(entries);
+      });
+    });
+  });
 }
 
 /**
@@ -187,6 +339,13 @@ async function deserializeEntity(
   zipEntries: Record<string, Uint8Array>,
   warnings: string[],
 ): Promise<ShaderCanvasEntity> {
+  logger.debug("[workspace-import] deserialize entity start", {
+    entityId: serialized.id,
+    entityName: serialized.name,
+    mediaType: serialized.mediaType,
+    mediaFile: serialized.mediaFile,
+  });
+
   // Validate shaderType (1b) and merge shaderParams with defaults (1c/3d)
   const shaderType = validateShaderType(serialized.shaderType);
   if (shaderType !== serialized.shaderType) {

--- a/lib/serialization/index.ts
+++ b/lib/serialization/index.ts
@@ -1,4 +1,11 @@
 export { serialize } from "./serialize.ts";
 export { deserialize, getMaxCounters } from "./deserialize.ts";
-export type { StudioManifest, SerializedEntity, DeserializeResult } from "./types.ts";
+export type {
+  StudioManifest,
+  SerializedEntity,
+  DeserializeOptions,
+  DeserializeProgress,
+  DeserializeResult,
+  DeserializeStage,
+} from "./types.ts";
 export { CURRENT_VERSION } from "./version.ts";

--- a/lib/serialization/types.ts
+++ b/lib/serialization/types.ts
@@ -112,6 +112,27 @@ export interface DeserializeResult {
   errors: { entityId: string; entityName: string; error: string }[];
 }
 
+export type DeserializeStage =
+  | "reading"
+  | "unzipping"
+  | "parsing"
+  | "decoding"
+  | "restoring"
+  | "done";
+
+export interface DeserializeProgress {
+  stage: DeserializeStage;
+  entityIndex?: number;
+  entityCount?: number;
+  entityName?: string;
+  fileSizeBytes?: number;
+}
+
+export interface DeserializeOptions {
+  signal?: AbortSignal;
+  onProgress?: (progress: DeserializeProgress) => void;
+}
+
 // ============================================================================
 // Serialize Worker
 // ============================================================================


### PR DESCRIPTION
## Summary
- add cancellable workspace import flow with staged progress updates and compact import toast copy
- switch deserialization to async unzip plus sequential entity decoding to reduce iOS Safari stalls and preserve the current canvas on abort
- add `logger.debug` instrumentation across the import pipeline and tests for progress, cancellation, and drop recovery

## Testing
- `bun run --bun vitest run __tests__/lib/serialization-deserialize.spec.ts __tests__/hooks/use-image-input.spec.tsx`
- `bun run lint:all`