### PR TITLE
Fix action layer and long-press animations by invalidating render state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,17 @@ React 19 + Compiler, rolldown-vite 7, WebGPU, TypeScript (strict), Bun, oxlint +
 bun run lint:all    # oxlint with type-checking. Always run after changes.
 ```
 
+## Testing
+
+```bash
+# Never use `bun test` in this repo. Use Vitest via the project scripts.
+# Prefer running whole test suite
+bun run test
+# if working on specific area, run a set of tests as follows
+bun run test -- __tests__/engine/action-layer-controller.spec.ts
+# Add `-t "test name"` to target a single test, or use `bun run test:watch -- <path>` while iterating.
+```
+
 ## Key Patterns
 
 1. **Enum pattern**: Use `createEnum()` from `types/index.ts`, not TypeScript `enum`. Produces both value object and type via `.infer`. Example: `ShaderType.dithering` (value), `ShaderType` (type).

--- a/__tests__/engine/action-layer-controller.spec.ts
+++ b/__tests__/engine/action-layer-controller.spec.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import { ActionLayerController } from "../../engine/action-layer-controller.ts";
+import { canvasStore } from "../../engine/canvas-store.ts";
 import { config } from "#config";
 import { TestClock } from "../helpers/test-clock.ts";
 
@@ -8,6 +9,7 @@ describe("ActionLayerController", () => {
   let controller: ActionLayerController;
 
   beforeEach(() => {
+    canvasStore.reset();
     clock = new TestClock();
     controller = new ActionLayerController(clock.scheduler);
   });
@@ -76,6 +78,30 @@ describe("ActionLayerController", () => {
 
     // BUG: without fix, offset stays at 0 because no animation is running
     expect(Math.abs(controller.getEntityOffset().x)).toBeGreaterThan(1);
+  });
+
+  test("returning inside deadzone after settling springs back to origin", () => {
+    controller.activate({ x: 200, y: 200 });
+
+    controller.updateFingerPosition({ x: 400, y: 200 });
+    clock.advanceUntilSettled();
+    expect(Math.abs(controller.getEntityOffset().x)).toBeGreaterThan(1);
+
+    controller.updateFingerPosition({ x: 200 + config.actionLayer.deadzone - 1, y: 200 });
+    clock.advanceUntilSettled();
+
+    expect(Math.abs(controller.getEntityOffset().x)).toBeLessThan(0.5);
+  });
+
+  test("active animation marks render state dirty while values are changing", () => {
+    controller.activate({ x: 200, y: 200 });
+    canvasStore.clearDirtyFlags();
+
+    clock.advanceBy(16);
+    canvasStore.clearDirtyFlags();
+    clock.advanceBy(16);
+
+    expect(canvasStore.getRenderState().dirty).toBe(true);
   });
 
   // ── Core behavior tests ─────────────────────────────────────────────────

--- a/engine/action-layer-controller.ts
+++ b/engine/action-layer-controller.ts
@@ -96,6 +96,7 @@ export class ActionLayerController {
     this.#blurTarget = 1;
     this.#blurStartTime = performance.now();
 
+    canvasStore.setContainerDirty();
     this.#registerAnimation();
   }
 
@@ -113,6 +114,13 @@ export class ActionLayerController {
     if (rawDist <= deadzone) {
       this.#targetOffsetX = 0;
       this.#targetOffsetY = 0;
+      if (
+        !this.#handle?.isActive &&
+        (Math.abs(this.#currentOffsetX) > 0.05 || Math.abs(this.#currentOffsetY) > 0.05)
+      ) {
+        this.#registerAnimation();
+      }
+      canvasStore.setContainerDirty();
       return;
     }
 
@@ -129,6 +137,7 @@ export class ActionLayerController {
 
     this.#targetOffsetX = rubberBand(dx, entityRubberBandMax);
     this.#targetOffsetY = rubberBand(dy, entityRubberBandMax);
+    canvasStore.setContainerDirty();
   }
 
   /**
@@ -145,6 +154,10 @@ export class ActionLayerController {
     this.#blurTarget = newTarget;
     this.#blurStartValue = this.#blurIntensity;
     this.#blurStartTime = performance.now();
+    if (!this.#handle?.isActive && Math.abs(this.#blurIntensity - newTarget) > 0.001) {
+      this.#registerAnimation();
+    }
+    canvasStore.setContainerDirty();
   }
 
   /** Get entity offset from rubber-banding (screen-space CSS pixels). */
@@ -206,6 +219,7 @@ export class ActionLayerController {
     if (!this.#handle?.isActive) {
       this.#registerAnimation();
     }
+    canvasStore.setContainerDirty();
   }
 
   /** Dismiss the action layer. Spring entity back to origin, fade blur. */
@@ -234,6 +248,7 @@ export class ActionLayerController {
     if (!this.#handle?.isActive) {
       this.#registerAnimation();
     }
+    canvasStore.setContainerDirty();
   }
 
   /** Immediately reset to idle. */
@@ -253,6 +268,7 @@ export class ActionLayerController {
     this.#entityIds = new Set();
     this.#dismissSpringX.reset();
     this.#dismissSpringY.reset();
+    canvasStore.setContainerDirty();
   }
 
   #registerAnimation(): void {
@@ -261,6 +277,7 @@ export class ActionLayerController {
       tag: "action-layer",
       tick: (now) => {
         if (this.#phase === ActionLayerPhase.idle) return false;
+        let visualChanged = false;
 
         // Animate blur intensity toward target
         if (this.#blurIntensity !== this.#blurTarget) {
@@ -275,6 +292,7 @@ export class ActionLayerController {
           if (t >= 1) {
             this.#blurIntensity = this.#blurTarget;
           }
+          visualChanged = true;
         }
 
         // Active phase: exact analytical damped harmonic oscillator
@@ -307,6 +325,7 @@ export class ActionLayerController {
               decay *
               ((bY * this.#omegaD - aY * this.#zetaOmega) * cosD -
                 (aY * this.#omegaD + bY * this.#zetaOmega) * sinD);
+            visualChanged = true;
           }
 
           // Spring settled: no meaningful motion — let scheduler remove us.
@@ -345,6 +364,7 @@ export class ActionLayerController {
           } else {
             this.#currentOffsetY = 0;
           }
+          visualChanged = true;
 
           // If all animations settled, return to idle
           if (valX === null && valY === null && this.#blurIntensity === this.#blurTarget) {
@@ -356,6 +376,9 @@ export class ActionLayerController {
           }
         }
 
+        if (visualChanged) {
+          canvasStore.setContainerDirty();
+        }
         return true;
       },
     });

--- a/engine/entity-drag-visual.ts
+++ b/engine/entity-drag-visual.ts
@@ -88,6 +88,7 @@ class EntityDragVisualController {
     }, timeout);
     // Phase stays idle until timer fires — no visual change during delay
     this.#phase = DragVisualPhase.idle;
+    canvasStore.setContainerDirty();
   }
 
   /**
@@ -106,6 +107,7 @@ class EntityDragVisualController {
     // Pop-back: animate from current scale to 1.0
     this.#targetScale = 1;
     this.#phase = DragVisualPhase.dragging;
+    canvasStore.setContainerDirty();
     this.#registerAnimation(config.touch.dragVisual.popBackSpring);
   }
 
@@ -175,6 +177,7 @@ class EntityDragVisualController {
       settleThreshold: EntityDragVisualController.#SETTLE_THRESHOLD,
       onUpdate: (value) => {
         this.#currentScale = Math.max(0.8, Math.min(value, 1.05));
+        canvasStore.setContainerDirty();
       },
       onComplete: () => {
         this.#currentScale = targetScale;


### PR DESCRIPTION
## Summary
- mark action layer animation updates as dirty so blur, rubber-band, and dismiss transitions re-render smoothly
- mark long-press drag visual scale updates as dirty so scale-down and pop-back animations do not hitch on static canvases
- add controller tests for deadzone return behavior and render invalidation during active animation
- document the repo testing convention to use Vitest via project scripts instead of `bun test`

## Testing
- `bun run test -- __tests__/engine/action-layer-controller.spec.ts`
- `bun run lint:all`