### PR TITLE
Codex/move export to action layer and onboarding

### DIFF
--- a/__tests__/context/canvas-add-entity.spec.tsx
+++ b/__tests__/context/canvas-add-entity.spec.tsx
@@ -1,0 +1,68 @@
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { canvasStore } from "#engine";
+import { undo } from "#lib/undo.ts";
+import { createEntityInput } from "../helpers/test-entity.ts";
+import { renderWithCanvas } from "../helpers/render-with-providers.tsx";
+import { setupCanvasTest } from "../helpers/test-setup.ts";
+import { clearUndoHistory, performUndo } from "../helpers/undo-helpers.ts";
+
+let cleanup: () => void;
+
+const skipProviders = {
+  iconoir: true,
+  toast: true,
+  keybind: true,
+  videoExport: true,
+  exportQueue: true,
+};
+
+beforeEach(() => {
+  cleanup = setupCanvasTest();
+  clearUndoHistory();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  clearUndoHistory();
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("CanvasCommands.addEntity", () => {
+  test("adds user entities to undo history", () => {
+    const { canvas } = renderWithCanvas(undefined, { skip: skipProviders });
+
+    let id = "";
+    act(() => {
+      id = canvas.addEntity(createEntityInput());
+    });
+
+    expect(undo.canUndo()).toBe(true);
+
+    performUndo();
+
+    expect(canvasStore.getState().entities.has(id)).toBe(false);
+  });
+
+  test("can add onboarding entities without undo history", () => {
+    const { canvas } = renderWithCanvas(undefined, { skip: skipProviders });
+
+    let id = "";
+    act(() => {
+      id = canvas.addEntity(createEntityInput(), "favicon.webp", {
+        skipUndo: true,
+        source: "onboarding",
+      });
+    });
+
+    expect(canvasStore.getState().entities.has(id)).toBe(true);
+    expect(undo.canUndo()).toBe(false);
+
+    act(() => {
+      undo.undo();
+    });
+
+    expect(canvasStore.getState().entities.has(id)).toBe(true);
+  });
+});

--- a/__tests__/lib/onboarding-storage.spec.ts
+++ b/__tests__/lib/onboarding-storage.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ONBOARDING_VERSION, OnboardingStepId } from "#lib/onboarding.ts";
+
+let storedValue: unknown;
+const getItem = vi.fn<() => Promise<unknown>>(async () => storedValue);
+const setItem = vi.fn<(key: string, value: unknown) => Promise<void>>(async (_key, value) => {
+  storedValue = value;
+});
+
+vi.mock("#lib/storage.ts", () => ({
+  storage: {
+    getItem,
+    setItem,
+  },
+}));
+
+const {
+  getOnboardingProgress,
+  markOnboardingStepCompleted,
+  normalizeOnboardingProgress,
+  skipOnboardingVersion,
+} = await import("#lib/onboarding-storage.ts");
+
+describe("onboarding storage", () => {
+  beforeEach(() => {
+    storedValue = undefined;
+    getItem.mockClear();
+    setItem.mockClear();
+  });
+
+  test("defaults malformed progress", () => {
+    expect(normalizeOnboardingProgress("not progress")).toEqual({
+      version: ONBOARDING_VERSION,
+      completedStepIds: [],
+      skippedVersion: null,
+    });
+  });
+
+  test("resets progress for old versions", () => {
+    expect(
+      normalizeOnboardingProgress({
+        version: ONBOARDING_VERSION - 1,
+        completedStepIds: [OnboardingStepId.selectStarter],
+        skippedVersion: ONBOARDING_VERSION - 1,
+      }),
+    ).toEqual({
+      version: ONBOARDING_VERSION,
+      completedStepIds: [],
+      skippedVersion: null,
+    });
+  });
+
+  test("deduplicates and filters completed step ids", () => {
+    expect(
+      normalizeOnboardingProgress({
+        version: ONBOARDING_VERSION,
+        completedStepIds: [
+          OnboardingStepId.selectStarter,
+          "unknown-step",
+          OnboardingStepId.selectStarter,
+        ],
+      }).completedStepIds,
+    ).toEqual([OnboardingStepId.selectStarter]);
+  });
+
+  test("marks steps complete monotonically", async () => {
+    storedValue = {
+      version: ONBOARDING_VERSION,
+      completedStepIds: [OnboardingStepId.selectStarter],
+      skippedVersion: null,
+    };
+
+    const next = await markOnboardingStepCompleted(OnboardingStepId.openActionLayer);
+
+    expect(next.completedStepIds).toEqual([
+      OnboardingStepId.selectStarter,
+      OnboardingStepId.openActionLayer,
+    ]);
+    expect(storedValue).toEqual(next);
+  });
+
+  test("persists skip for current version", async () => {
+    const next = await skipOnboardingVersion();
+
+    expect(next.skippedVersion).toBe(ONBOARDING_VERSION);
+    expect(storedValue).toEqual(next);
+  });
+
+  test("falls back when storage throws", async () => {
+    getItem.mockRejectedValueOnce(new Error("read failed"));
+
+    await expect(getOnboardingProgress()).resolves.toEqual({
+      version: ONBOARDING_VERSION,
+      completedStepIds: [],
+      skippedVersion: null,
+    });
+  });
+});

--- a/__tests__/lib/onboarding.spec.ts
+++ b/__tests__/lib/onboarding.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import {
+  ONBOARDING_VERSION,
+  OnboardingStepId,
+  buildOnboardingCallouts,
+  completeOnboardingStep,
+  createDefaultOnboardingProgress,
+  getAvailableOnboardingStepIds,
+  isOnboardingComplete,
+  skipCurrentOnboardingVersion,
+} from "#lib/onboarding.ts";
+
+describe("onboarding controller helpers", () => {
+  test("uses only starter selection on non-action-layer devices", () => {
+    expect(getAvailableOnboardingStepIds(false)).toEqual([OnboardingStepId.selectStarter]);
+  });
+
+  test("uses action-layer steps where supported", () => {
+    expect(getAvailableOnboardingStepIds(true)).toEqual([
+      OnboardingStepId.selectStarter,
+      OnboardingStepId.openActionLayer,
+      OnboardingStepId.hoverAction,
+      OnboardingStepId.deleteFromActionLayer,
+    ]);
+  });
+
+  test("completes steps monotonically", () => {
+    const progress = createDefaultOnboardingProgress();
+    const first = completeOnboardingStep(progress, OnboardingStepId.selectStarter);
+    const second = completeOnboardingStep(first, OnboardingStepId.selectStarter);
+
+    expect(first.completedStepIds).toEqual([OnboardingStepId.selectStarter]);
+    expect(second).toBe(first);
+  });
+
+  test("does not become incomplete when external canvas state reverses", () => {
+    const completed = completeOnboardingStep(
+      createDefaultOnboardingProgress(),
+      OnboardingStepId.selectStarter,
+    );
+
+    expect(isOnboardingComplete(completed, getAvailableOnboardingStepIds(false))).toBe(true);
+  });
+
+  test("skip completes the current version", () => {
+    const skipped = skipCurrentOnboardingVersion(createDefaultOnboardingProgress());
+
+    expect(skipped.skippedVersion).toBe(ONBOARDING_VERSION);
+    expect(isOnboardingComplete(skipped, getAvailableOnboardingStepIds(true))).toBe(true);
+  });
+
+  test("builds initial entity callout", () => {
+    const callouts = buildOnboardingCallouts(createDefaultOnboardingProgress(), {
+      starterEntityId: "entity-1",
+      supportsActionLayer: true,
+      actionLayerActive: false,
+      actionLayerTouchOrigin: { x: 0, y: 0 },
+      containerRect: null,
+    });
+
+    expect(callouts.map((callout) => callout.id)).toEqual([OnboardingStepId.selectStarter]);
+    expect(callouts[0]?.anchor).toEqual({
+      type: "entity",
+      entityId: "entity-1",
+      placement: "top",
+    });
+  });
+
+  test("shows action-layer prompt only after starter selection", () => {
+    const progress = completeOnboardingStep(
+      createDefaultOnboardingProgress(),
+      OnboardingStepId.selectStarter,
+    );
+
+    const callouts = buildOnboardingCallouts(progress, {
+      starterEntityId: "entity-1",
+      supportsActionLayer: true,
+      actionLayerActive: false,
+      actionLayerTouchOrigin: { x: 0, y: 0 },
+      containerRect: null,
+    });
+
+    expect(callouts.map((callout) => callout.id)).toEqual([OnboardingStepId.openActionLayer]);
+  });
+});

--- a/components/action-layer/action-layer.tsx
+++ b/components/action-layer/action-layer.tsx
@@ -12,6 +12,8 @@ import { createPortal } from "react-dom";
 import { config } from "#config";
 import { analytics } from "#lib/analytics.ts";
 import { getCssVarPx } from "#lib/css.ts";
+import { completeOnboardingStepFromEvent } from "#lib/onboarding-runtime.ts";
+import { OnboardingStepId } from "#lib/onboarding.ts";
 import { actionLayerController } from "#engine";
 import { useActionLayer } from "#hooks/use-action-layer.ts";
 import "./action-layer.css";
@@ -220,7 +222,11 @@ function Root({ children }: PropsWithChildren) {
       if (newHovered !== hoveredIndexRef.current) {
         hoveredIndexRef.current = newHovered;
         setHoveredIndex(newHovered);
-        setTooltipLabel(newHovered !== null ? (items[newHovered]?.label ?? null) : null);
+        const label = newHovered !== null ? (items[newHovered]?.label ?? null) : null;
+        setTooltipLabel(label);
+        if (label) {
+          completeOnboardingStepFromEvent(OnboardingStepId.hoverAction);
+        }
       }
 
       // Safe zone progress (deadzone-aware)
@@ -244,6 +250,7 @@ function Root({ children }: PropsWithChildren) {
         const item = items[hovered];
         if (item) {
           analytics.track("action_layer.button_selected", { button: item.label });
+          completeOnboardingStepFromEvent(OnboardingStepId.hoverAction);
           item.onAction();
         }
         // Cancel immediately so entities return to normal render order on the next frame.

--- a/components/delete-drop-zone/delete-drop-zone.tsx
+++ b/components/delete-drop-zone/delete-drop-zone.tsx
@@ -4,6 +4,8 @@ import { useCanvasCommands } from "#context/use-canvas.ts";
 import { useEntityDrag } from "#hooks/use-entity-drag.ts";
 import { useActionLayer } from "#hooks/use-action-layer.ts";
 import { haptic } from "#lib/haptic.ts";
+import { completeOnboardingStepFromEvent } from "#lib/onboarding-runtime.ts";
+import { OnboardingStepId } from "#lib/onboarding.ts";
 import { canvasStore } from "#engine";
 import "./delete-drop-zone.css";
 
@@ -50,6 +52,7 @@ export function DeleteDropZone() {
     const handleTouchEnd = () => {
       if (isOverRef.current) {
         haptic({ wantsHaptic: canvasStore.getState().haptics });
+        completeOnboardingStepFromEvent(OnboardingStepId.deleteFromActionLayer);
         deleteSelection(undefined, "drop_zone");
         isOverRef.current = false;
         zone.removeAttribute("data-over");

--- a/components/export-knobs/export-knobs.mobile.tsx
+++ b/components/export-knobs/export-knobs.mobile.tsx
@@ -400,46 +400,68 @@ function MobileExportButtons({ imageFormat }: { imageFormat: ImageExportFormat }
   );
 }
 
-export function MobileExportKnobs() {
+interface MobileExportDrawerProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: boolean;
+}
+
+export function MobileExportDrawer({
+  open,
+  onOpenChange,
+  trigger = true,
+}: MobileExportDrawerProps) {
   const selectedEntities = useSelectedEntities();
   const hasAnimated = selectedEntities.some(isAnimatedEntity);
   const firstSnapPoint = SnapPoints.compute().at(0)!;
   const [snapPoint, setSnapPoint] = useState<number | string | null>(firstSnapPoint);
 
+  const drawer = (
+    <Drawer.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      snapPoint={snapPoint}
+      onSnapPointChange={(val) => setSnapPoint(val)}
+      snapPoints={firstSnapPoint !== null ? [firstSnapPoint, 1] : undefined}
+    >
+      {trigger && (
+        <Drawer.Trigger
+          render={(props) => (
+            <Button {...props} className="mobile-export-btn">
+              <Download />
+              <span>Export</span>
+            </Button>
+          )}
+        ></Drawer.Trigger>
+      )}
+      <Drawer.Popup
+        className="mobile-exports-drawer-content"
+        data-image-only={!hasAnimated || undefined}
+      >
+        <Drawer.Content>
+          <div className="mobile-exports-drawer-inner">
+            <div
+              className="mobile-exports-settings"
+              data-fully-snapped={snapPoint === 1 || undefined}
+            >
+              <MobileExportSettingsKnobs />
+            </div>
+            <ExportQueuePanel />
+          </div>
+        </Drawer.Content>
+      </Drawer.Popup>
+    </Drawer.Root>
+  );
+
+  if (!trigger) return drawer;
+
   return (
     <div className="mobile-exports">
-      <div className="mobile-row">
-        <Drawer.Root
-          snapPoint={snapPoint}
-          onSnapPointChange={(val) => setSnapPoint(val)}
-          snapPoints={firstSnapPoint !== null ? [firstSnapPoint, 1] : undefined}
-        >
-          <Drawer.Trigger
-            render={(props) => (
-              <Button {...props} className="mobile-export-btn">
-                <Download />
-                <span>Export</span>
-              </Button>
-            )}
-          ></Drawer.Trigger>
-          <Drawer.Popup
-            className="mobile-exports-drawer-content"
-            data-image-only={!hasAnimated || undefined}
-          >
-            <Drawer.Content>
-              <div className="mobile-exports-drawer-inner">
-                <div
-                  className="mobile-exports-settings"
-                  data-fully-snapped={snapPoint === 1 || undefined}
-                >
-                  <MobileExportSettingsKnobs />
-                </div>
-                <ExportQueuePanel />
-              </div>
-            </Drawer.Content>
-          </Drawer.Popup>
-        </Drawer.Root>
-      </div>
+      <div className="mobile-row">{drawer}</div>
     </div>
   );
+}
+
+export function MobileExportKnobs() {
+  return <MobileExportDrawer />;
 }

--- a/components/infinite-canvas/infinite-canvas.css
+++ b/components/infinite-canvas/infinite-canvas.css
@@ -85,6 +85,19 @@
 .left-controls {
   display: grid;
   grid-auto-flow: column;
+  justify-items: start;
+  align-content: start;
+  gap: var(--spacing-2);
+  pointer-events: auto;
+
+  @media screen and (max-width: 768px) {
+    grid-auto-flow: row;
+  }
+}
+
+.left-controls__top {
+  display: grid;
+  grid-auto-flow: column;
   gap: var(--spacing-2);
   pointer-events: auto;
 }
@@ -94,6 +107,16 @@
     bottom: initial;
     top: calc(var(--spacing) * 1.5);
   }
+}
+
+.onboarding-container {
+  width: 100%;
+  display: flex;
+}
+
+.infinite-canvas__skip-onboarding {
+  height: calc(7 * var(--spacing));
+  filter: drop-shadow(var(--floaty-shadow));
 }
 
 /* Controls container - covers canvas height for proper layout */

--- a/components/infinite-canvas/infinite-canvas.tsx
+++ b/components/infinite-canvas/infinite-canvas.tsx
@@ -20,6 +20,7 @@ import { useImageInput } from "#hooks/use-image-input.ts";
 import { useIsMobile } from "#hooks/use-is-mobile.ts";
 import { useMediaControlsActions } from "#hooks/use-media-controls.ts";
 import useMediaQuery from "#hooks/use-media-query.ts";
+import { useOnboarding } from "#hooks/use-onboarding.ts";
 import { useStudioFile } from "#hooks/use-studio-file.ts";
 import {
   calculateCenteredOffset,
@@ -202,6 +203,7 @@ export function InfiniteCanvas() {
 
   // Image input handlers (paste, drop, file upload)
   const { handleDrop } = useImageInput({ containerRef, multipleFiles: true });
+  const onboarding = useOnboarding({ containerRef, ready: isReady });
 
   // Studio file save/load
   const { exportStudioFile, saveAsStudioFile, importStudioFile } = useStudioFile();
@@ -890,8 +892,22 @@ export function InfiniteCanvas() {
           {!(isMobile && isFullscreen) && (
             <InfiniteCanvasToolRow>
               <div className="left-controls">
-                <About className="infinite-canvas__keyboard-shortcuts" />
-                <UndoRedoButtons />
+                <div className="left-controls__top">
+                  <About className="infinite-canvas__keyboard-shortcuts" />
+                  <UndoRedoButtons />
+                </div>
+                {onboarding.active && (
+                  <div className="onboarding-container">
+                    <Button
+                      className="infinite-canvas__skip-onboarding"
+                      onClick={onboarding.skip}
+                      type="button"
+                      size="sm"
+                    >
+                      Skip onboarding
+                    </Button>
+                  </div>
+                )}
               </div>
               <div className="infinite-canvas__controls">
                 {isMobile ? (

--- a/components/mobile-bottom/bar-items.ts
+++ b/components/mobile-bottom/bar-items.ts
@@ -1,10 +1,4 @@
-export const items = [
-  "style",
-  "colors",
-  "parameters",
-  "adjustments and post-processing",
-  "export",
-] as const;
+export const items = ["style", "colors", "parameters", "adjustments and post-processing"] as const;
 
 export type BarItem = (typeof items)[number];
 

--- a/components/mobile-controls.tsx
+++ b/components/mobile-controls.tsx
@@ -7,7 +7,6 @@ import { PostProcessMobileKnobs } from "./knobs/post-process-knobs";
 import { MobileColorKnobs } from "./knobs/mobile-color-knobs";
 import { MultiSelectionControls } from "./multi-selection-controls";
 import { UploadControls } from "./upload-button-controls";
-import { MobileExportKnobs } from "./export-knobs/export-knobs.mobile.tsx";
 
 interface MobileControlsProps {
   activeItem: BarItem | DebugBarItem | null;
@@ -35,10 +34,6 @@ export function MobileControls({ activeItem }: MobileControlsProps) {
 
   if (!hasSelection) {
     return <UploadControls />;
-  }
-
-  if (activeItem === "export") {
-    return <MobileExportKnobs />;
   }
 
   if (activeItem === "style") {

--- a/components/mobile-layout.tsx
+++ b/components/mobile-layout.tsx
@@ -5,7 +5,6 @@ import {
   ControlSlider,
   Copy,
   Download,
-  MediaVideo,
   Palette,
   ScaleFrameEnlarge,
   Settings,
@@ -20,52 +19,24 @@ import { ActionLayer } from "./action-layer/action-layer.tsx";
 import { CopyPasteDrawer } from "./action-layer/copy-paste-drawer.tsx";
 import { UpscaleDrawer } from "./action-layer/upscale-drawer.tsx";
 import { IonDuplicateOutline } from "./icons/duplicate.tsx";
+import { MobileExportDrawer } from "./export-knobs/export-knobs.mobile.tsx";
 import { Drawer } from "#ui/drawer/index.tsx";
 import {
   useCanvasCommands,
   useDebugMode,
-  useCanvasRendererService,
   useMultiSelectMode,
   useSelectedEntityIds,
 } from "#context/use-canvas.ts";
-import { useExportQueue } from "#context/use-export-queue.ts";
 import { useActionLayer } from "#hooks/use-action-layer.ts";
 import { useLayout } from "#context/use-layout.ts";
 import { useParamValue } from "#hooks/use-param-value.ts";
-import { isAnimatedEntity } from "#types/canvas.ts";
-import { canvasStore } from "#engine";
 import { useEntityDrag } from "#hooks/use-entity-drag.ts";
-import { toastManager } from "#ui/toast/toast-manager.ts";
 
 function MobileActionLayer() {
-  const { saveSelectedEntityToFile, duplicateEntities } = useCanvasCommands();
-  const { renderer } = useCanvasRendererService();
-  const { addToQueue } = useExportQueue();
+  const { duplicateEntities } = useCanvasCommands();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [upscaleDrawerOpen, setUpscaleDrawerOpen] = useState(false);
-
-  const handleSave = () => {
-    // Check if the selected entity is animated — export instead of save
-    const selectedEntities = canvasStore.getSelectedEntities();
-    const animated = selectedEntities.filter(isAnimatedEntity);
-    if (animated.length > 0 && renderer) {
-      for (const entity of animated) {
-        addToQueue(entity, renderer);
-      }
-      const n = animated.length;
-      const count = `${n} ${n === 1 ? "file" : "files"}`;
-      toastManager.add({
-        title: `Exporting ${count}`,
-        description: "See progress in exports tab",
-      });
-    } else {
-      saveSelectedEntityToFile();
-    }
-  };
-
-  // Determine label based on selection type
-  const selectedEntities = canvasStore.getSelectedEntities();
-  const hasAnimated = selectedEntities.some(isAnimatedEntity);
+  const [exportDrawerOpen, setExportDrawerOpen] = useState(false);
 
   return (
     <>
@@ -79,12 +50,17 @@ function MobileActionLayer() {
         <ActionLayer.Item order={2} onAction={() => setUpscaleDrawerOpen(true)} label="Upscale 2×">
           <ScaleFrameEnlarge />
         </ActionLayer.Item>
-        <ActionLayer.Item order={3} onAction={handleSave} label={hasAnimated ? "Export" : "Save"}>
-          {hasAnimated ? <MediaVideo /> : <Download />}
+        <ActionLayer.Item order={3} onAction={() => setExportDrawerOpen(true)} label="Export">
+          <Download />
         </ActionLayer.Item>
       </ActionLayer.Root>
       <CopyPasteDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
       <UpscaleDrawer open={upscaleDrawerOpen} onOpenChange={setUpscaleDrawerOpen} />
+      <MobileExportDrawer
+        open={exportDrawerOpen}
+        onOpenChange={setExportDrawerOpen}
+        trigger={false}
+      />
     </>
   );
 }
@@ -111,10 +87,6 @@ function MobileFloat() {
       disabled: bottomBarDisabled,
     },
     style: {
-      disabled: bottomBarDisabled,
-    },
-    export: {
-      // TODO: maybe show exports button and commit multi-selection if user clicks on it?
       disabled: bottomBarDisabled,
     },
   };
@@ -151,9 +123,6 @@ function MobileFloat() {
           {...propsMapByItem["adjustments and post-processing"]}
         >
           <ColorFilter />
-        </BottomBarItem>
-        <BottomBarItem label="export" {...propsMapByItem["export"]}>
-          <Download />
         </BottomBarItem>
         {debugMode && (
           <BottomBarItem label={debugBarItem} disabled={isFullscreen}>

--- a/components/settings/settings.desktop.content.tsx
+++ b/components/settings/settings.desktop.content.tsx
@@ -3,6 +3,7 @@ import {
   FancyDeleteToggle,
   FeedbackLink,
   LinkItem,
+  RedoOnboardingLink,
   ShareLink,
   SnapToGridToggle,
 } from "./settings.shared.tsx";
@@ -34,6 +35,12 @@ export default function DesktopSettingsContent({
         <div className="desktop-settings-ext-item field-label">
           <LinkItem>
             <FeedbackLink className="desktop-settings-link" />
+          </LinkItem>
+        </div>
+        <hr className="divider" />
+        <div className="desktop-settings-ext-item field-label">
+          <LinkItem>
+            <RedoOnboardingLink onDone={onClose} />
           </LinkItem>
         </div>
       </Modal.Content>

--- a/components/settings/settings.mobile.css
+++ b/components/settings/settings.mobile.css
@@ -17,6 +17,9 @@
   grid-auto-flow: row;
   align-items: center;
 }
+.settings-drawer-ext-item {
+  padding: var(--spacing-2);
+}
 
 .settings-drawer-link {
   color: var(--gray-900);

--- a/components/settings/settings.mobile.tsx
+++ b/components/settings/settings.mobile.tsx
@@ -11,6 +11,7 @@ import {
   FeedbackLink,
   HapticsToggle,
   LinkItem,
+  RedoOnboardingLink,
   ShareLink,
   SnapToGridToggle,
 } from "./settings.shared.tsx";
@@ -71,6 +72,12 @@ export default function SettingsDrawer() {
           <div className="settings-drawer-ext-item field-label">
             <LinkItem>
               <FeedbackLink className="settings-drawer-link" />
+            </LinkItem>
+          </div>
+          <hr className="divider" />
+          <div className="settings-drawer-ext-item field-label">
+            <LinkItem>
+              <RedoOnboardingLink onDone={() => setOpen(false)} />
             </LinkItem>
           </div>
           <WorkspaceActions

--- a/components/settings/settings.shared.tsx
+++ b/components/settings/settings.shared.tsx
@@ -1,6 +1,7 @@
 import { NavArrowRight } from "iconoir-react";
 import { Checkbox } from "#ui/checkbox/index.tsx";
 import { useCanvasCommands, useCanvasPreferences } from "#context/use-canvas.ts";
+import { resetOnboardingProgress } from "#lib/onboarding-storage.ts";
 import { shareOrCopyUrl } from "./share.ts";
 
 export function SnapToGridToggle() {
@@ -64,6 +65,22 @@ export function FeedbackLink({ className }: { className?: string }) {
     >
       <span>Send feedback</span>
     </a>
+  );
+}
+
+export function RedoOnboardingLink({ onDone }: { onDone?: () => void }) {
+  const { clearWorkspace } = useCanvasCommands();
+
+  const redoOnboarding = () => {
+    clearWorkspace();
+    void resetOnboardingProgress();
+    onDone?.();
+  };
+
+  return (
+    <button type="button" onClick={redoOnboarding}>
+      <span>Redo onboarding</span>
+    </button>
   );
 }
 

--- a/context/canvas-context.tsx
+++ b/context/canvas-context.tsx
@@ -5,6 +5,7 @@ import {
   DebugType,
   type CanvasCommands,
   type CanvasRendererService,
+  type AddEntityOptions,
 } from "./use-canvas.ts";
 import {
   useQueryState,
@@ -477,6 +478,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
   const addEntity = (
     entity: Omit<ShaderCanvasEntity, "id" | "zIndex" | "name">,
     filename?: string,
+    options?: AddEntityOptions,
   ): string => {
     const id = `entity-${nextIdRef.current++}`;
     const zIndex = nextZIndexRef.current++;
@@ -513,26 +515,28 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     });
 
     // Add undo support for entity creation
-    const ownerToken = claimResourceOwnership(newEntity.id);
-    undo.add(
-      Command.create({
-        undo: () => {
-          // Pause playback if playing
-          if (newEntity.mediaSource.type === MediaType.video) {
-            newEntity.mediaSource.videoElement.pause();
-          } else if (isGifEntity(newEntity) && newEntity.playback) {
-            newEntity.playback.isPlaying = false;
-          }
-          rendererRef.current?.removeEntityTexture(newEntity.id);
-          canvasStore.removeEntity(newEntity.id);
-        },
-        execute: () => {
-          canvasStore.addEntity(newEntity);
-        },
-        onEvict: () => tryCleanupEntityResources(newEntity, ownerToken),
-        description: `Add entity ${newEntity.name}`,
-      }),
-    );
+    if (!options?.skipUndo) {
+      const ownerToken = claimResourceOwnership(newEntity.id);
+      undo.add(
+        Command.create({
+          undo: () => {
+            // Pause playback if playing
+            if (newEntity.mediaSource.type === MediaType.video) {
+              newEntity.mediaSource.videoElement.pause();
+            } else if (isGifEntity(newEntity) && newEntity.playback) {
+              newEntity.playback.isPlaying = false;
+            }
+            rendererRef.current?.removeEntityTexture(newEntity.id);
+            canvasStore.removeEntity(newEntity.id);
+          },
+          execute: () => {
+            canvasStore.addEntity(newEntity);
+          },
+          onEvict: () => tryCleanupEntityResources(newEntity, ownerToken),
+          description: `Add entity ${newEntity.name}`,
+        }),
+      );
+    }
 
     // Async palette extraction for images, GIFs, and SVGs (use first frame for GIFs)
     if (

--- a/context/use-canvas.ts
+++ b/context/use-canvas.ts
@@ -26,6 +26,11 @@ export const DebugType = createEnum({
 });
 export type DebugType = typeof DebugType.infer;
 
+export interface AddEntityOptions {
+  skipUndo?: boolean;
+  source?: "user" | "onboarding";
+}
+
 export interface CanvasCommands {
   setViewport: (viewport: Viewport) => void;
   panBy: (delta: Point) => void;
@@ -33,6 +38,7 @@ export interface CanvasCommands {
   addEntity: (
     entity: Omit<ShaderCanvasEntity, "id" | "zIndex" | "name">,
     filename?: string,
+    options?: AddEntityOptions,
   ) => string;
   updateEntity: (id: string, updates: Partial<ShaderCanvasEntity>) => void;
   removeEntity: (id: string) => void;

--- a/engine/canvas-store.ts
+++ b/engine/canvas-store.ts
@@ -3,6 +3,7 @@ import { Store } from "#lib/store.ts";
 import { getCommonFeatures, paramVisibilityRules, shaderFeatures } from "#config";
 import {
   type Viewport,
+  type CanvasCallout,
   type ShaderCanvasEntity,
   type Point,
   type Bounds,
@@ -13,6 +14,7 @@ import {
   MediaType,
 } from "#types/canvas.ts";
 import { getFrameAtTime } from "#lib/gif-decoder.ts";
+import { completeOnboardingStarterSelectionFromEvent } from "#lib/onboarding-runtime.ts";
 
 export interface CanvasState {
   // Core state
@@ -41,6 +43,7 @@ export interface CanvasState {
   entitiesDirty: Set<string>;
   selectionDirty: boolean;
   containerSizeDirty: boolean;
+  canvasCalloutsDirty: boolean;
 
   // Frame counter for debugging
   frameCount: number;
@@ -66,6 +69,9 @@ export interface CanvasState {
   actionLayerTouchOrigin: { x: number; y: number };
   /** Version counter for action layer state changes */
   actionLayerVersion: number;
+
+  // Canvas-rendered instructional callouts (transient, not persisted)
+  canvasCallouts: readonly CanvasCallout[];
 }
 
 // Snapshot types for selective subscriptions
@@ -120,6 +126,7 @@ export interface RenderState {
   hoveredEntityId: string | null;
   debugMode: boolean;
   dirty: boolean;
+  canvasCallouts: readonly CanvasCallout[];
   /** Drag-select rectangle bounds in world coordinates (null if not active) */
   dragSelectBounds: Bounds | null;
   /** Multi-select bounding box in world coordinates (null if < 2 entities selected) */
@@ -194,6 +201,7 @@ export class CanvasStore extends Store<CanvasState> {
       entitiesDirty: new Set(),
       selectionDirty: false,
       containerSizeDirty: false,
+      canvasCalloutsDirty: false,
       frameCount: 0,
       version: 0,
       viewportVersion: 0,
@@ -206,6 +214,7 @@ export class CanvasStore extends Store<CanvasState> {
       actionLayerEntityIds: new Set(),
       actionLayerTouchOrigin: { x: 0, y: 0 },
       actionLayerVersion: 0,
+      canvasCallouts: [],
     });
 
     this.#logger = logger;
@@ -395,6 +404,7 @@ export class CanvasStore extends Store<CanvasState> {
     if (!this.state.entities.has(id)) return;
     this.state.selectedEntityIds = new Set(this.state.selectedEntityIds).add(id);
     this.state.selectionDirty = true;
+    completeOnboardingStarterSelectionFromEvent(this.state.selectedEntityIds);
     this.#logger.debug(`Added to selection: ${id}`, this.state.entities.get(id));
     this.notifySelectionChange();
   }
@@ -428,6 +438,7 @@ export class CanvasStore extends Store<CanvasState> {
     }
     this.state.selectedEntityIds = newSelection;
     this.state.selectionDirty = true;
+    completeOnboardingStarterSelectionFromEvent(this.state.selectedEntityIds);
     this.#logger.debug(`Selection replaced with: ${ids.join(", ")}`);
     this.notifySelectionChange();
   }
@@ -541,10 +552,12 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.actionLayerActive = false;
     this.state.actionLayerEntityIds = new Set();
     this.state.actionLayerTouchOrigin = { x: 0, y: 0 };
+    this.state.canvasCallouts = [];
     this.state.entitiesDirty.clear();
     this.state.selectionDirty = false;
     this.state.viewportDirty = false;
     this.state.containerSizeDirty = false;
+    this.state.canvasCalloutsDirty = false;
     // Increment versions to invalidate cached snapshots
     this.state.version++;
     this.state.selectionVersion++;
@@ -624,6 +637,12 @@ export class CanvasStore extends Store<CanvasState> {
     if (touchOrigin) this.state.actionLayerTouchOrigin = touchOrigin;
     this.state.actionLayerVersion++;
     this.notify();
+  }
+
+  setCanvasCallouts(callouts: readonly CanvasCallout[]): void {
+    if (sameCanvasCallouts(this.state.canvasCallouts, callouts)) return;
+    this.state.canvasCallouts = callouts;
+    this.state.canvasCalloutsDirty = true;
   }
 
   setMultiSelectMode(enabled: boolean): void {
@@ -877,7 +896,9 @@ export class CanvasStore extends Store<CanvasState> {
         this.state.viewportDirty ||
         this.state.entitiesDirty.size > 0 ||
         this.state.selectionDirty ||
-        this.state.containerSizeDirty,
+        this.state.containerSizeDirty ||
+        this.state.canvasCalloutsDirty,
+      canvasCallouts: this.state.canvasCallouts,
       // dragSelectBounds and multiSelectBounds are set by game-loop after calling this method
       dragSelectBounds: null,
       multiSelectBounds: null,
@@ -892,6 +913,7 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.entitiesDirty.clear();
     this.state.selectionDirty = false;
     this.state.containerSizeDirty = false;
+    this.state.canvasCalloutsDirty = false;
     this.state.frameCount++;
   }
 
@@ -1101,6 +1123,39 @@ function sameReferenceArray<T>(a: readonly T[], b: readonly T[]): boolean {
   for (let index = 0; index < a.length; index += 1) {
     if (a[index] !== b[index]) return false;
   }
+  return true;
+}
+
+function sameCanvasCallouts(a: readonly CanvasCallout[], b: readonly CanvasCallout[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index]!;
+    const right = b[index]!;
+    if (left.id !== right.id || left.text !== right.text) return false;
+    if ((left.offset?.x ?? 0) !== (right.offset?.x ?? 0)) return false;
+    if ((left.offset?.y ?? 0) !== (right.offset?.y ?? 0)) return false;
+    if (left.anchor.type !== right.anchor.type) return false;
+
+    if (left.anchor.type === "entity" && right.anchor.type === "entity") {
+      if (
+        left.anchor.entityId !== right.anchor.entityId ||
+        left.anchor.placement !== right.anchor.placement
+      ) {
+        return false;
+      }
+    } else if (left.anchor.type === "screen" && right.anchor.type === "screen") {
+      if (
+        left.anchor.position.x !== right.anchor.position.x ||
+        left.anchor.position.y !== right.anchor.position.y ||
+        left.anchor.align !== right.anchor.align
+      ) {
+        return false;
+      }
+    }
+  }
+
   return true;
 }
 

--- a/engine/game-loop.ts
+++ b/engine/game-loop.ts
@@ -32,6 +32,8 @@ import { viewportAnimation } from "./viewport-animation.ts";
 import { MomentumController, type MomentumDeps } from "./momentum-controller.ts";
 import { scheduler, type AnimationHandle } from "../lib/animation-scheduler.ts";
 import { haptic } from "#lib/haptic.ts";
+import { OnboardingStepId } from "#lib/onboarding.ts";
+import { completeOnboardingStepFromEvent } from "#lib/onboarding-runtime.ts";
 
 function createDefaultDeps() {
   return {
@@ -1297,6 +1299,7 @@ export class GameLoop {
       this.#deps.analytics.track("action_layer.opened", {
         entity_count: finalState.selectedEntityIds.size,
       });
+      completeOnboardingStepFromEvent(OnboardingStepId.openActionLayer);
     }
 
     // Haptic feedback

--- a/hooks/use-onboarding.ts
+++ b/hooks/use-onboarding.ts
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from "react";
+import { useActionLayer } from "#hooks/use-action-layer.ts";
+import { useIsMobile } from "#hooks/use-is-mobile.ts";
+import {
+  buildOnboardingCallouts,
+  completeOnboardingStep,
+  getAvailableOnboardingStepIds,
+  isOnboardingComplete,
+  isOnboardingSkipped,
+  ONBOARDING_RESET_EVENT,
+  OnboardingStepId,
+  skipCurrentOnboardingVersion,
+  type OnboardingProgress,
+} from "#lib/onboarding.ts";
+import { getOnboardingProgress, setOnboardingProgress } from "#lib/onboarding-storage.ts";
+import {
+  setOnboardingStarterEntityId,
+  setOnboardingStepCompleteHandler,
+} from "#lib/onboarding-runtime.ts";
+import { getViewportLayoutCenter } from "#lib/canvas-math.ts";
+import { logger } from "#lib/client.logger.ts";
+import { loadMediaFromBlob } from "#lib/media-loader.ts";
+import { canvasStore } from "#engine";
+import { useCanvasCommands, useCanvasSelector } from "#context/use-canvas.ts";
+
+interface UseOnboardingOptions {
+  containerRef: React.RefObject<HTMLElement | null>;
+  ready: boolean;
+}
+
+interface UseOnboardingResult {
+  active: boolean;
+  skip: () => void;
+}
+
+export function useOnboarding({ containerRef, ready }: UseOnboardingOptions): UseOnboardingResult {
+  const { addEntity } = useCanvasCommands();
+  const isMobile = useIsMobile();
+  const actionLayer = useActionLayer();
+  const entityCount = useCanvasSelector((state) => state.entities.size);
+  const [progress, setProgress] = useState<OnboardingProgress | null>(null);
+  const [starterEntityId, setStarterEntityId] = useState<string | null>(null);
+  const hasAttemptedAutoStartRef = useRef(false);
+
+  const availableStepIds = getAvailableOnboardingStepIds(isMobile);
+
+  useEffect(() => {
+    let cancelled = false;
+    const handleReset = () => {
+      hasAttemptedAutoStartRef.current = false;
+      setStarterEntityId(null);
+      setOnboardingStarterEntityId(null);
+      canvasStore.setCanvasCallouts([]);
+      getOnboardingProgress()
+        .then((stored) => {
+          setProgress(stored);
+        })
+        .catch((err) => {
+          logger.warn("Failed to reload onboarding progress", err);
+        });
+    };
+
+    window.addEventListener(ONBOARDING_RESET_EVENT, handleReset);
+    getOnboardingProgress()
+      .then((stored) => {
+        if (!cancelled) setProgress(stored);
+      })
+      .catch((err) => {
+        logger.warn("Failed to load onboarding progress", err);
+      });
+    return () => {
+      cancelled = true;
+      window.removeEventListener(ONBOARDING_RESET_EVENT, handleReset);
+      setOnboardingStarterEntityId(null);
+      canvasStore.setCanvasCallouts([]);
+    };
+  }, []);
+
+  useEffect(() => {
+    return setOnboardingStepCompleteHandler((stepId) => {
+      setProgress((current) => completeStepAndPersist(current, stepId));
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!ready || !progress || hasAttemptedAutoStartRef.current || entityCount !== 0) return;
+    if (
+      isOnboardingSkipped(progress) ||
+      isOnboardingComplete(progress, getAvailableOnboardingStepIds(isMobile))
+    ) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    hasAttemptedAutoStartRef.current = true;
+    let cancelled = false;
+
+    const start = async () => {
+      try {
+        const response = await fetch("/favicon.webp");
+        const blob = await response.blob();
+        const center = getViewportLayoutCenter(
+          canvasStore.getViewport(),
+          container,
+          window.devicePixelRatio,
+        );
+        const entity = await loadMediaFromBlob(
+          blob,
+          blob.type || "image/webp",
+          center,
+          "favicon.webp",
+        );
+        if (!entity || cancelled) return;
+
+        const id = addEntity(
+          {
+            ...entity,
+            position: {
+              x: center.x - entity.size.width / 2,
+              // slide up to not show bottom callouts under mobile controls
+              y: center.y - (isMobile ? 200 : 0) - entity.size.height / 2,
+            },
+          },
+          "voidmesh",
+          { skipUndo: true, source: "onboarding" },
+        );
+
+        setStarterEntityId(id);
+        setOnboardingStarterEntityId(id);
+      } catch (err) {
+        logger.warn("Failed to start onboarding", err);
+      }
+    };
+
+    void start();
+    return () => {
+      cancelled = true;
+    };
+  }, [addEntity, containerRef, entityCount, isMobile, progress, ready]);
+
+  const active =
+    !!progress &&
+    !!starterEntityId &&
+    !isOnboardingSkipped(progress) &&
+    !isOnboardingComplete(progress, availableStepIds);
+
+  useEffect(() => {
+    if (!progress || !active) {
+      canvasStore.setCanvasCallouts([]);
+      return;
+    }
+
+    canvasStore.setCanvasCallouts(
+      buildOnboardingCallouts(progress, {
+        starterEntityId,
+        supportsActionLayer: isMobile,
+        actionLayerActive: actionLayer.active,
+        actionLayerTouchOrigin: actionLayer.touchOrigin,
+        containerRect: containerRef.current?.getBoundingClientRect() ?? null,
+      }),
+    );
+  }, [
+    actionLayer.active,
+    actionLayer.touchOrigin,
+    active,
+    containerRef,
+    isMobile,
+    progress,
+    starterEntityId,
+  ]);
+
+  const skip = () => {
+    if (!progress) return;
+    const next = skipCurrentOnboardingVersion(progress);
+    setProgress(next);
+    setOnboardingProgress(next).catch((err) => logger.warn("Failed to persist onboarding", err));
+    canvasStore.setCanvasCallouts([]);
+  };
+
+  return { active, skip };
+}
+
+function completeStepAndPersist(
+  progress: OnboardingProgress | null,
+  stepId: OnboardingStepId,
+): OnboardingProgress | null {
+  if (!progress || progress.completedStepIds.includes(stepId)) return progress;
+
+  const next = completeOnboardingStep(progress, stepId);
+  setOnboardingProgress(next).catch((err) => logger.warn("Failed to persist onboarding step", err));
+  return next;
+}

--- a/lib/canvas-math.ts
+++ b/lib/canvas-math.ts
@@ -259,6 +259,23 @@ export function getViewportCenter(
 }
 
 /**
+ * Get the center point of an untransformed layout box in world coordinates.
+ * Use this for programmatic placement inside the rendered canvas. Unlike
+ * getBoundingClientRect(), clientWidth/clientHeight are not affected by CSS
+ * transforms such as the mobile drawer indent animation.
+ */
+export function getViewportLayoutCenter(
+  viewport: Viewport,
+  container: Pick<HTMLElement, "clientWidth" | "clientHeight">,
+  dpr: number = 1,
+): Point {
+  return {
+    x: viewport.offset.x + (container.clientWidth * dpr) / (2 * viewport.zoom),
+    y: viewport.offset.y + (container.clientHeight * dpr) / (2 * viewport.zoom),
+  };
+}
+
+/**
  * Calculate viewport offset to center world origin (0,0) at viewport center.
  * Use this for initial viewport setup and "center canvas" functionality.
  *

--- a/lib/onboarding-runtime.ts
+++ b/lib/onboarding-runtime.ts
@@ -1,0 +1,35 @@
+import { OnboardingStepId, type OnboardingStepId as OnboardingStepIdType } from "./onboarding.ts";
+
+type CompleteStepHandler = (stepId: OnboardingStepIdType) => void;
+
+let starterEntityId: string | null = null;
+let completeStepHandler: CompleteStepHandler | null = null;
+
+export function setOnboardingStarterEntityId(entityId: string | null): void {
+  starterEntityId = entityId;
+}
+
+export function setOnboardingStepCompleteHandler(handler: CompleteStepHandler | null): () => void {
+  completeStepHandler = handler;
+  return () => {
+    if (completeStepHandler === handler) {
+      completeStepHandler = null;
+    }
+  };
+}
+
+export function completeOnboardingStepFromEvent(stepId: OnboardingStepIdType): void {
+  completeStepHandler?.(stepId);
+}
+
+export function completeOnboardingStarterSelectionFromEvent(
+  selectedEntityIds: ReadonlySet<string> | readonly string[],
+): void {
+  if (!starterEntityId) return;
+  for (const id of selectedEntityIds) {
+    if (id === starterEntityId) {
+      completeOnboardingStepFromEvent(OnboardingStepId.selectStarter);
+      return;
+    }
+  }
+}

--- a/lib/onboarding-storage.ts
+++ b/lib/onboarding-storage.ts
@@ -1,0 +1,75 @@
+import { storage } from "./storage.ts";
+import {
+  ALL_ONBOARDING_STEP_IDS,
+  ONBOARDING_RESET_EVENT,
+  ONBOARDING_VERSION,
+  createDefaultOnboardingProgress,
+  type OnboardingProgress,
+  type OnboardingStepId,
+} from "./onboarding.ts";
+
+const STORAGE_KEY = "onboarding";
+const STEP_IDS = new Set<string>(ALL_ONBOARDING_STEP_IDS);
+
+export function normalizeOnboardingProgress(value: unknown): OnboardingProgress {
+  if (!isRecord(value) || value.version !== ONBOARDING_VERSION) {
+    return createDefaultOnboardingProgress();
+  }
+
+  const completedStepIds = Array.isArray(value.completedStepIds)
+    ? value.completedStepIds.filter((id): id is OnboardingStepId => STEP_IDS.has(id))
+    : [];
+
+  return {
+    version: ONBOARDING_VERSION,
+    completedStepIds: Array.from(new Set(completedStepIds)),
+    skippedVersion: value.skippedVersion === ONBOARDING_VERSION ? ONBOARDING_VERSION : null,
+  };
+}
+
+export async function getOnboardingProgress(): Promise<OnboardingProgress> {
+  try {
+    return normalizeOnboardingProgress(await storage.getItem<unknown>(STORAGE_KEY));
+  } catch {
+    return createDefaultOnboardingProgress();
+  }
+}
+
+export async function setOnboardingProgress(progress: OnboardingProgress): Promise<void> {
+  await storage.setItem(STORAGE_KEY, normalizeOnboardingProgress(progress));
+}
+
+export async function markOnboardingStepCompleted(
+  stepId: OnboardingStepId,
+): Promise<OnboardingProgress> {
+  const progress = await getOnboardingProgress();
+  if (progress.completedStepIds.includes(stepId)) return progress;
+
+  const next = normalizeOnboardingProgress({
+    ...progress,
+    completedStepIds: [...progress.completedStepIds, stepId],
+  });
+  await setOnboardingProgress(next);
+  return next;
+}
+
+export async function skipOnboardingVersion(): Promise<OnboardingProgress> {
+  const progress = await getOnboardingProgress();
+  const next = normalizeOnboardingProgress({
+    ...progress,
+    skippedVersion: ONBOARDING_VERSION,
+  });
+  await setOnboardingProgress(next);
+  return next;
+}
+
+export async function resetOnboardingProgress(): Promise<OnboardingProgress> {
+  const next = createDefaultOnboardingProgress();
+  await setOnboardingProgress(next);
+  window.dispatchEvent(new Event(ONBOARDING_RESET_EVENT));
+  return next;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -1,0 +1,155 @@
+import type { CanvasCallout } from "#types/canvas.ts";
+
+export const ONBOARDING_VERSION = 1;
+export const ONBOARDING_RESET_EVENT = "voidmesh:onboarding-reset";
+
+export const OnboardingStepId = {
+  selectStarter: "select-starter",
+  openActionLayer: "open-action-layer",
+  hoverAction: "hover-action",
+  deleteFromActionLayer: "delete-from-action-layer",
+} as const;
+
+export type OnboardingStepId = (typeof OnboardingStepId)[keyof typeof OnboardingStepId];
+
+export interface OnboardingProgress {
+  version: number;
+  completedStepIds: OnboardingStepId[];
+  skippedVersion: number | null;
+}
+
+export interface OnboardingRuntime {
+  starterEntityId: string | null;
+  supportsActionLayer: boolean;
+  actionLayerActive: boolean;
+  actionLayerTouchOrigin: { x: number; y: number };
+  containerRect: DOMRect | null;
+}
+
+export const ALL_ONBOARDING_STEP_IDS: readonly OnboardingStepId[] = [
+  OnboardingStepId.selectStarter,
+  OnboardingStepId.openActionLayer,
+  OnboardingStepId.hoverAction,
+  OnboardingStepId.deleteFromActionLayer,
+];
+
+export function createDefaultOnboardingProgress(): OnboardingProgress {
+  return {
+    version: ONBOARDING_VERSION,
+    completedStepIds: [],
+    skippedVersion: null,
+  };
+}
+
+export function getAvailableOnboardingStepIds(
+  supportsActionLayer: boolean,
+): readonly OnboardingStepId[] {
+  if (supportsActionLayer) return ALL_ONBOARDING_STEP_IDS;
+  return [OnboardingStepId.selectStarter];
+}
+
+export function isOnboardingSkipped(progress: OnboardingProgress): boolean {
+  return progress.skippedVersion === ONBOARDING_VERSION;
+}
+
+export function isOnboardingComplete(
+  progress: OnboardingProgress,
+  availableStepIds: readonly OnboardingStepId[],
+): boolean {
+  if (isOnboardingSkipped(progress)) return true;
+  const completed = new Set(progress.completedStepIds);
+  return availableStepIds.every((id) => completed.has(id));
+}
+
+export function completeOnboardingStep(
+  progress: OnboardingProgress,
+  stepId: OnboardingStepId,
+): OnboardingProgress {
+  if (progress.completedStepIds.includes(stepId)) return progress;
+  return {
+    ...progress,
+    completedStepIds: [...progress.completedStepIds, stepId],
+  };
+}
+
+export function skipCurrentOnboardingVersion(progress: OnboardingProgress): OnboardingProgress {
+  return {
+    ...progress,
+    skippedVersion: ONBOARDING_VERSION,
+  };
+}
+
+export function buildOnboardingCallouts(
+  progress: OnboardingProgress,
+  runtime: OnboardingRuntime,
+): CanvasCallout[] {
+  if (!runtime.starterEntityId || isOnboardingSkipped(progress)) return [];
+
+  const completed = new Set(progress.completedStepIds);
+  const callouts: CanvasCallout[] = [];
+
+  if (!completed.has(OnboardingStepId.selectStarter)) {
+    callouts.push({
+      id: OnboardingStepId.selectStarter,
+      text: "Select this image to edit its effects",
+      anchor: {
+        type: "entity",
+        entityId: runtime.starterEntityId,
+        placement: "top",
+      },
+    });
+  }
+
+  if (
+    runtime.supportsActionLayer &&
+    completed.has(OnboardingStepId.selectStarter) &&
+    !completed.has(OnboardingStepId.openActionLayer)
+  ) {
+    callouts.push({
+      id: OnboardingStepId.openActionLayer,
+      text: "Long press it to move, save, delete and more",
+      anchor: {
+        type: "entity",
+        entityId: runtime.starterEntityId,
+        placement: "bottom",
+      },
+    });
+  }
+
+  if (
+    runtime.supportsActionLayer &&
+    runtime.actionLayerActive &&
+    completed.has(OnboardingStepId.openActionLayer) &&
+    !completed.has(OnboardingStepId.hoverAction) &&
+    runtime.containerRect
+  ) {
+    callouts.push({
+      id: OnboardingStepId.hoverAction,
+      text: "Move your finger over actions and release to do the action",
+      anchor: {
+        type: "entity",
+        entityId: runtime.starterEntityId,
+        placement: "top",
+      },
+    });
+  }
+
+  if (
+    runtime.supportsActionLayer &&
+    completed.has(OnboardingStepId.hoverAction) &&
+    !completed.has(OnboardingStepId.deleteFromActionLayer) &&
+    runtime.containerRect
+  ) {
+    callouts.push({
+      id: OnboardingStepId.deleteFromActionLayer,
+      text: "Move your finger over the X and release to delete",
+      anchor: {
+        type: "entity",
+        entityId: runtime.starterEntityId,
+        placement: "top",
+      },
+    });
+  }
+
+  return callouts;
+}

--- a/renderer/canvas-callout-pass.ts
+++ b/renderer/canvas-callout-pass.ts
@@ -1,0 +1,354 @@
+import type { CanvasCallout, ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
+import shaderSource from "./entity-label.wgsl?raw";
+
+const FONT_SIZE_DESKTOP = 15;
+const FONT_SIZE_MOBILE = 13;
+const PADDING_X = 10;
+const PADDING_Y = 7;
+const MAX_TEXT_WIDTH_DESKTOP = 300;
+const MAX_TEXT_WIDTH_MOBILE = 230;
+const LINE_HEIGHT = 1.25;
+const ENTITY_GAP = 12;
+const SHADOW_PAD = 8;
+const UNIFORM_SIZE = 32;
+const MOBILE_BREAKPOINT = 768;
+const FONT_FAMILY =
+  'ui-rounded, "Hiragino Maru Gothic ProN", Quicksand, Comfortaa, "Arial Rounded MT", Calibri, system-ui, sans-serif';
+
+interface CalloutRasterState {
+  text: string;
+  dpr: number;
+  isMobile: boolean;
+}
+
+interface CalloutCacheEntry {
+  texture: GPUTexture;
+  bindGroup: GPUBindGroup;
+  uniformBuffer: GPUBuffer;
+  textureWidth: number;
+  textureHeight: number;
+  rasterState: CalloutRasterState;
+}
+
+export class CanvasCalloutPass {
+  #device: GPUDevice;
+  #canvasFormat: GPUTextureFormat;
+  #viewportUniformBuffer: GPUBuffer;
+  #pipeline: GPURenderPipeline | null = null;
+  #sampler: GPUSampler | null = null;
+  #bindGroupLayout: GPUBindGroupLayout | null = null;
+  #canvas = new OffscreenCanvas(1, 1);
+  #ctx = this.#canvas.getContext("2d")!;
+  #cache = new Map<string, CalloutCacheEntry>();
+  #viewport: Viewport | null = null;
+  #dpr = 1;
+  #isMobile = false;
+
+  constructor(device: GPUDevice, canvasFormat: GPUTextureFormat, viewportUniformBuffer: GPUBuffer) {
+    this.#device = device;
+    this.#canvasFormat = canvasFormat;
+    this.#viewportUniformBuffer = viewportUniformBuffer;
+  }
+
+  initialize(): void {
+    this.#sampler = this.#device.createSampler({
+      label: "Canvas callout sampler",
+      magFilter: "linear",
+      minFilter: "linear",
+    });
+
+    this.#bindGroupLayout = this.#device.createBindGroupLayout({
+      label: "Canvas callout bind group layout",
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: "uniform" } },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+        { binding: 3, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
+      ],
+    });
+
+    const shaderModule = this.#device.createShaderModule({
+      label: "Canvas callout shader",
+      code: shaderSource,
+    });
+
+    this.#pipeline = this.#device.createRenderPipeline({
+      label: "Canvas callout pipeline",
+      layout: this.#device.createPipelineLayout({
+        bindGroupLayouts: [this.#bindGroupLayout],
+      }),
+      vertex: { module: shaderModule, entryPoint: "vs_main" },
+      fragment: {
+        module: shaderModule,
+        entryPoint: "fs_main",
+        targets: [
+          {
+            format: this.#canvasFormat,
+            blend: {
+              color: { srcFactor: "one", dstFactor: "one-minus-src-alpha" },
+              alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha" },
+            },
+          },
+        ],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+  }
+
+  beginFrame(viewport: Viewport, canvasWidth: number): void {
+    this.#viewport = viewport;
+    this.#dpr = devicePixelRatio || 1;
+    this.#isMobile = canvasWidth / this.#dpr < MOBILE_BREAKPOINT;
+  }
+
+  drawCallouts(
+    pass: GPURenderPassEncoder,
+    callouts: readonly CanvasCallout[],
+    entitiesById: ReadonlyMap<string, ShaderCanvasEntity>,
+  ): void {
+    if (!this.#pipeline || !this.#viewport) return;
+
+    const activeIds = new Set<string>();
+    for (const callout of callouts) {
+      activeIds.add(callout.id);
+      const entry = this.#getEntry(callout);
+      const position = this.#resolveWorldPosition(callout, entry, entitiesById);
+      if (!position) continue;
+
+      const data = new Float32Array(UNIFORM_SIZE / 4);
+      data[0] = position.x;
+      data[1] = position.y;
+      data[2] = entry.textureWidth / this.#viewport.zoom;
+      data[3] = entry.textureHeight / this.#viewport.zoom;
+      data[4] = 1;
+      this.#device.queue.writeBuffer(entry.uniformBuffer, 0, data);
+
+      pass.setPipeline(this.#pipeline);
+      pass.setBindGroup(0, entry.bindGroup);
+      pass.draw(6);
+    }
+
+    for (const [id, entry] of this.#cache) {
+      if (activeIds.has(id)) continue;
+      entry.texture.destroy();
+      entry.uniformBuffer.destroy();
+      this.#cache.delete(id);
+    }
+  }
+
+  destroy(): void {
+    for (const entry of this.#cache.values()) {
+      entry.texture.destroy();
+      entry.uniformBuffer.destroy();
+    }
+    this.#cache.clear();
+    this.#pipeline = null;
+  }
+
+  #resolveWorldPosition(
+    callout: CanvasCallout,
+    entry: CalloutCacheEntry,
+    entitiesById: ReadonlyMap<string, ShaderCanvasEntity>,
+  ): { x: number; y: number } | null {
+    const viewport = this.#viewport;
+    if (!viewport) return null;
+
+    const worldWidth = entry.textureWidth / viewport.zoom;
+    const worldHeight = entry.textureHeight / viewport.zoom;
+    const offsetX = ((callout.offset?.x ?? 0) * this.#dpr) / viewport.zoom;
+    const offsetY = ((callout.offset?.y ?? 0) * this.#dpr) / viewport.zoom;
+
+    if (callout.anchor.type === "screen") {
+      const x = viewport.offset.x + (callout.anchor.position.x * this.#dpr) / viewport.zoom;
+      const y = viewport.offset.y + (callout.anchor.position.y * this.#dpr) / viewport.zoom;
+      return {
+        x: x - (callout.anchor.align === "center" ? worldWidth / 2 : 0) + offsetX,
+        y: y + offsetY,
+      };
+    }
+
+    const entity = entitiesById.get(callout.anchor.entityId);
+    if (!entity) return null;
+
+    const x = entity.position.x + entity.size.width / 2 - worldWidth / 2 + offsetX;
+    if (callout.anchor.placement === "top") {
+      return {
+        x,
+        y: entity.position.y - (ENTITY_GAP * this.#dpr) / viewport.zoom - worldHeight + offsetY,
+      };
+    }
+
+    return {
+      x,
+      y:
+        entity.position.y + entity.size.height + (ENTITY_GAP * this.#dpr) / viewport.zoom + offsetY,
+    };
+  }
+
+  #getEntry(callout: CanvasCallout): CalloutCacheEntry {
+    const rasterState = {
+      text: callout.text,
+      dpr: this.#dpr,
+      isMobile: this.#isMobile,
+    };
+    const cached = this.#cache.get(callout.id);
+    if (cached && rasterStatesEqual(cached.rasterState, rasterState)) return cached;
+    return this.#rasterizeCallout(callout.id, rasterState);
+  }
+
+  #rasterizeCallout(id: string, rasterState: CalloutRasterState): CalloutCacheEntry {
+    const { width, height } = this.#rasterize(rasterState);
+    let cached = this.#cache.get(id);
+
+    if (!cached || cached.textureWidth !== width || cached.textureHeight !== height) {
+      cached?.texture.destroy();
+      cached?.uniformBuffer.destroy();
+      cached = this.#createEntry(id, width, height, rasterState);
+      this.#cache.set(id, cached);
+    } else {
+      cached.rasterState = rasterState;
+    }
+
+    this.#device.queue.copyExternalImageToTexture(
+      { source: this.#canvas },
+      { texture: cached.texture },
+      [width, height],
+    );
+
+    return cached;
+  }
+
+  #createEntry(
+    id: string,
+    width: number,
+    height: number,
+    rasterState: CalloutRasterState,
+  ): CalloutCacheEntry {
+    const texture = this.#device.createTexture({
+      label: `Canvas callout ${id}`,
+      size: [width, height],
+      format: "rgba8unorm",
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const uniformBuffer = this.#device.createBuffer({
+      label: `Canvas callout ${id} uniforms`,
+      size: UNIFORM_SIZE,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    const bindGroup = this.#device.createBindGroup({
+      label: `Canvas callout ${id} bind group`,
+      layout: this.#bindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: this.#viewportUniformBuffer } },
+        { binding: 1, resource: { buffer: uniformBuffer } },
+        { binding: 2, resource: texture.createView() },
+        { binding: 3, resource: this.#sampler! },
+      ],
+    });
+
+    return {
+      texture,
+      bindGroup,
+      uniformBuffer,
+      textureWidth: width,
+      textureHeight: height,
+      rasterState,
+    };
+  }
+
+  #rasterize(rasterState: CalloutRasterState): { width: number; height: number } {
+    const { text, dpr, isMobile } = rasterState;
+    const ctx = this.#ctx;
+    const fontSize = (isMobile ? FONT_SIZE_MOBILE : FONT_SIZE_DESKTOP) * dpr;
+    const lineHeight = fontSize * LINE_HEIGHT;
+    const paddingX = PADDING_X * dpr;
+    const paddingY = PADDING_Y * dpr;
+    const maxTextWidth = (isMobile ? MAX_TEXT_WIDTH_MOBILE : MAX_TEXT_WIDTH_DESKTOP) * dpr;
+    const font = `600 ${fontSize}px ${FONT_FAMILY}`;
+
+    ctx.font = font;
+    const lines = wrapText(ctx, text, maxTextWidth);
+    const textWidth = Math.max(...lines.map((line) => ctx.measureText(line).width));
+    const boxWidth = Math.ceil(textWidth + paddingX * 2);
+    const boxHeight = Math.ceil(lines.length * lineHeight + paddingY * 2);
+    const canvasWidth = boxWidth + SHADOW_PAD * dpr * 2;
+    const canvasHeight = boxHeight + SHADOW_PAD * dpr * 2;
+
+    if (this.#canvas.width !== canvasWidth || this.#canvas.height !== canvasHeight) {
+      this.#canvas.width = canvasWidth;
+      this.#canvas.height = canvasHeight;
+    }
+
+    ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+    ctx.font = font;
+    ctx.save();
+    ctx.shadowColor = "rgba(0, 0, 0, 0.28)";
+    ctx.shadowBlur = 5 * dpr;
+    ctx.shadowOffsetY = 2 * dpr;
+    ctx.fillStyle = "rgba(16, 20, 22, 0.92)";
+    ctx.beginPath();
+    ctx.roundRect(SHADOW_PAD * dpr, SHADOW_PAD * dpr, boxWidth, boxHeight, 8 * dpr);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.16)";
+    ctx.lineWidth = dpr;
+    ctx.beginPath();
+    ctx.roundRect(
+      SHADOW_PAD * dpr + 0.5 * dpr,
+      SHADOW_PAD * dpr + 0.5 * dpr,
+      boxWidth - dpr,
+      boxHeight - dpr,
+      8 * dpr,
+    );
+    ctx.stroke();
+
+    ctx.fillStyle = "#ffffff";
+    ctx.textBaseline = "top";
+    lines.forEach((line, index) => {
+      ctx.fillText(
+        line,
+        SHADOW_PAD * dpr + paddingX,
+        SHADOW_PAD * dpr + paddingY + index * lineHeight,
+      );
+    });
+
+    return { width: canvasWidth, height: canvasHeight };
+  }
+}
+
+function rasterStatesEqual(a: CalloutRasterState, b: CalloutRasterState): boolean {
+  return a.text === b.text && a.dpr === b.dpr && a.isMobile === b.isMobile;
+}
+
+function wrapText(
+  ctx: OffscreenCanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string[] {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (ctx.measureText(next).width <= maxWidth || !current) {
+      current = next;
+      continue;
+    }
+    lines.push(current);
+    current = word;
+  }
+
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [text];
+}

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -38,6 +38,7 @@ import { HalftoneShader } from "./shaders/halftone-shader.ts";
 import { MeltShader } from "./shaders/melt-shader.ts";
 import type { ShaderContext } from "./shaders/shader-pass.ts";
 import { ShaderRegistry } from "./shaders/shader-registry.ts";
+import { CanvasCalloutPass } from "./canvas-callout-pass.ts";
 import { EntityLabelPass } from "./entity-label-pass.ts";
 import { TexturePool } from "./texture-pool.ts";
 import { resolveWlurOverlayRuntimeConfig, type WlurOverlayConfig } from "./wlur-overlay.ts";
@@ -177,6 +178,7 @@ export class InfiniteCanvasRenderer {
 
   // Entity label pass (Canvas 2D rasterized → GPU textured quad)
   #entityLabelPass: EntityLabelPass | null = null;
+  #canvasCalloutPass: CanvasCalloutPass | null = null;
 
   // Disintegration overlays — GPU resources for fire-and-forget dust animations
   #disintegrationOverlays: Map<
@@ -439,6 +441,13 @@ export class InfiniteCanvasRenderer {
       this.#viewportUniformBuffer!,
     );
     this.#entityLabelPass.initialize();
+
+    this.#canvasCalloutPass = new CanvasCalloutPass(
+      this.#device,
+      this.#canvasFormat,
+      this.#viewportUniformBuffer!,
+    );
+    this.#canvasCalloutPass.initialize();
 
     // Set up ResizeObserver to cache canvas dimensions (avoids getBoundingClientRect in render loop)
     this.#resizeObserver = new ResizeObserver((entries) => {
@@ -1974,6 +1983,26 @@ export class InfiniteCanvasRenderer {
     this.#writeGpuTimestampMarker(encoder, gpuCapture, "action-layer-sharp", "end");
     markPhaseEnd("action-layer-sharp");
 
+    if (state.canvasCallouts.length > 0 && this.#canvasCalloutPass) {
+      this.#canvasCalloutPass.beginFrame(viewport, width);
+      const calloutPass = encoder.beginRenderPass({
+        label: "Canvas callout pass",
+        colorAttachments: [
+          {
+            view: targetView,
+            loadOp: "load",
+            storeOp: "store",
+          },
+        ],
+      });
+      this.#canvasCalloutPass.drawCallouts(
+        calloutPass,
+        state.canvasCallouts,
+        new Map(entities.map((entity) => [entity.id, entity])),
+      );
+      calloutPass.end();
+    }
+
     // Pass 2b: Render disintegration overlays (on top of entities)
     this.#renderDisintegrationOverlays(encoder, targetView, frameDt);
 
@@ -2403,6 +2432,8 @@ export class InfiniteCanvasRenderer {
     // Destroy entity label pass
     this.#entityLabelPass?.destroy();
     this.#entityLabelPass = null;
+    this.#canvasCalloutPass?.destroy();
+    this.#canvasCalloutPass = null;
 
     // Destroy processing pipeline
     this.#processingPipeline?.destroy();

--- a/styles/app.css
+++ b/styles/app.css
@@ -167,7 +167,7 @@
     min-width: clamp(200px, 500px, 90vw);
     max-height: 90dvh;
     overflow-y: auto;
-    background-color: var(--gray-50);
+    background-color: var(--background);
     border-radius: calc(var(--radius) * 2);
     border: 1px solid var(--border);
     padding: 0.5rem 1rem;

--- a/types/canvas.ts
+++ b/types/canvas.ts
@@ -30,6 +30,27 @@ export interface Viewport {
   zoom: number;
 }
 
+export type CanvasCalloutPlacement = "top" | "bottom" | "screen";
+
+export type CanvasCalloutAnchor =
+  | {
+      type: "entity";
+      entityId: string;
+      placement: Exclude<CanvasCalloutPlacement, "screen">;
+    }
+  | {
+      type: "screen";
+      position: Point;
+      align?: "start" | "center";
+    };
+
+export interface CanvasCallout {
+  id: string;
+  text: string;
+  anchor: CanvasCalloutAnchor;
+  offset?: Point;
+}
+
 export const ShaderType = createEnum({
   halftone: "halftone",
   blobs: "blobs",


### PR DESCRIPTION
* Removes export tab as it only housed one button.
* Adds onboarding to make sure users find the action layer (long press entity).
* Adds default image

<details><summary>Screenshots</summary>
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/0004c1b7-c6dd-4aa7-b9e3-a315be961a4b" />
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/6b2465c4-dbdc-48c5-944e-1cfd9f8b1b1b" />
<img width="590" height="1278" alt="Voidmesh — Shader Effects for Images, Videos   GIFs" src="https://github.com/user-attachments/assets/cf766996-604e-41e9-8930-6b0a9aea1180" />
<img width="590" height="1278" alt="Voidmesh — Shader Effects for Images, Videos   GIFs-2" src="https://github.com/user-attachments/assets/643ff0a9-951f-4612-ae0e-f99927159d15" />
<img width="590" height="1278" alt="Voidmesh — Shader Effects for Images, Videos   GIFs-3" src="https://github.com/user-attachments/assets/4decb8f2-2cfa-4ee4-8712-f81042476adc" />


</details> 