### PR TITLE
Add canvas video audio controls and load error handling

### DIFF
--- a/__tests__/components/media-controls.spec.tsx
+++ b/__tests__/components/media-controls.spec.tsx
@@ -5,7 +5,7 @@
  * and immediate updates when switching between media entities.
  */
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { screen, act } from "@testing-library/react";
+import { screen, act, fireEvent, waitFor } from "@testing-library/react";
 import { MediaControls } from "../../components/infinite-canvas/media-controls.tsx";
 import { renderWithCanvas } from "../helpers/render-with-providers.tsx";
 import { createEntityInput, resetEntityCounter } from "../helpers/test-entity.ts";
@@ -174,6 +174,93 @@ describe("MediaControls", () => {
       expect(button).toBeInTheDocument();
     });
   });
+
+  describe("mute button", () => {
+    test("shows mute button for video with audio, defaulting to muted", () => {
+      const { canvas } = renderWithCanvas(<MediaControls />);
+
+      act(() => {
+        const id = canvas.addEntity(
+          createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: true }),
+        );
+        canvas.selectEntity(id);
+      });
+
+      expect(screen.getByRole("button", { name: /unmute/i, hidden: true })).toBeInTheDocument();
+    });
+
+    test("clicking mute button toggles selected video audio state", async () => {
+      const { canvas } = renderWithCanvas(<MediaControls />);
+
+      let videoId: string;
+      act(() => {
+        videoId = canvas.addEntity(
+          createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: true }),
+        );
+        canvas.selectEntity(videoId);
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: /unmute/i, hidden: true }));
+      });
+
+      const entity = canvasStore.getState().entities.get(videoId!);
+      expect(entity?.playback?.muted).toBe(false);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /^mute$/i, hidden: true })).toBeInTheDocument();
+      });
+    });
+
+    test("does not show mute button for video without audio", () => {
+      const { canvas } = renderWithCanvas(<MediaControls />);
+
+      act(() => {
+        const id = canvas.addEntity(
+          createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: false }),
+        );
+        canvas.selectEntity(id);
+      });
+
+      expect(screen.queryByRole("button", { name: /mute/i, hidden: true })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /unmute/i, hidden: true }),
+      ).not.toBeInTheDocument();
+    });
+
+    test("switching selected videos shows each independent muted state", () => {
+      const { canvas } = renderWithCanvas(<MediaControls />);
+
+      let idA: string;
+      let idB: string;
+      act(() => {
+        idA = canvas.addEntity(
+          createEntityInput({
+            mediaType: "video",
+            videoDuration: 60,
+            videoHasAudio: true,
+            muted: false,
+          }),
+        );
+        idB = canvas.addEntity(
+          createEntityInput({
+            mediaType: "video",
+            videoDuration: 60,
+            videoHasAudio: true,
+            muted: true,
+          }),
+        );
+        canvas.selectEntity(idA);
+      });
+
+      expect(screen.getByRole("button", { name: /^mute$/i, hidden: true })).toBeInTheDocument();
+
+      act(() => {
+        canvas.selectEntity(idB!);
+      });
+
+      expect(screen.getByRole("button", { name: /unmute/i, hidden: true })).toBeInTheDocument();
+    });
+  });
 });
 
 // ============================================================================
@@ -192,6 +279,20 @@ describe("MediaControls - GIF support", () => {
 
       const controls = document.querySelector(".media-controls");
       expect(controls).not.toHaveAttribute("hidden");
+    });
+
+    test("does not show mute button for GIF", () => {
+      const { canvas } = renderWithCanvas(<MediaControls />);
+
+      act(() => {
+        const id = canvas.addEntity(createEntityInput({ mediaType: "gif", gifDuration: 2 }));
+        canvas.selectEntity(id);
+      });
+
+      expect(screen.queryByRole("button", { name: /mute/i, hidden: true })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /unmute/i, hidden: true }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/__tests__/engine/canvas-store.spec.ts
+++ b/__tests__/engine/canvas-store.spec.ts
@@ -92,6 +92,59 @@ describe("canvasStore.seekVideo", () => {
   });
 });
 
+describe("canvasStore video audio controls", () => {
+  test("setVideoMuted updates playback and video element muted state", () => {
+    const entity = createTestEntity({ mediaType: "video", videoHasAudio: true });
+    canvasStore.addEntity(entity);
+
+    canvasStore.setVideoMuted(entity.id, false);
+
+    expect(entity.playback?.muted).toBe(false);
+    expect(entity.mediaSource.type === "video" && entity.mediaSource.videoElement.muted).toBe(
+      false,
+    );
+  });
+
+  test("toggleVideoMuted flips playback and video element muted state", () => {
+    const entity = createTestEntity({
+      mediaType: "video",
+      videoDuration: 100,
+      videoHasAudio: true,
+      muted: true,
+    });
+    canvasStore.addEntity(entity);
+
+    canvasStore.toggleVideoMuted(entity.id);
+
+    expect(entity.playback?.muted).toBe(false);
+    expect(entity.mediaSource.type === "video" && entity.mediaSource.videoElement.muted).toBe(
+      false,
+    );
+  });
+
+  test("does not change timing, playing state, or selected entity when muting", () => {
+    const entity = createTestEntity({
+      mediaType: "video",
+      videoDuration: 100,
+      videoHasAudio: true,
+      muted: true,
+    });
+    canvasStore.addEntity(entity);
+    canvasStore.replaceSelection([entity.id]);
+    canvasStore.seekVideo(entity.id, 12);
+    if (entity.playback) entity.playback.isPlaying = true;
+
+    const selectedBefore = canvasStore.getSelectedEntity()?.id;
+
+    canvasStore.toggleVideoMuted(entity.id);
+
+    expect(entity.playback?.currentTime).toBe(12);
+    expect(getVideoCurrentTime(entity)).toBe(12);
+    expect(entity.playback?.isPlaying).toBe(true);
+    expect(canvasStore.getSelectedEntity()?.id).toBe(selectedBefore);
+  });
+});
+
 describe("canvasStore.updatePlaybackTime", () => {
   test("updates playback.currentTime", () => {
     const entity = createTestEntity({ mediaType: "video", videoDuration: 100 });

--- a/__tests__/helpers/test-entity.ts
+++ b/__tests__/helpers/test-entity.ts
@@ -56,6 +56,12 @@ export interface CreateEntityOptions {
   videoDuration?: number;
   /** Video FPS (for video entities) */
   videoFps?: number;
+  /** Whether the video entity has an audio track */
+  videoHasAudio?: boolean;
+  /** Initial muted state for animated playback */
+  muted?: boolean;
+  /** Initial volume for animated playback */
+  volume?: number;
   /** GIF duration in seconds (for gif entities) */
   gifDuration?: number;
   /** Number of GIF frames (for gif entities) */
@@ -134,14 +140,18 @@ export function createTestEntity(options: CreateEntityOptions = {}): ShaderCanva
       blob: new Blob(["mock-video"], { type: "video/mp4" }),
       duration: options.videoDuration ?? 10,
       fps: options.videoFps ?? 30,
-      hasAudio: false,
+      hasAudio: options.videoHasAudio ?? false,
     };
     const playback: PlaybackState = {
       isPlaying: false,
       currentTime: 0,
       loop: false,
       playbackRate: 1,
+      muted: options.muted ?? true,
+      volume: options.volume ?? 1,
     };
+    videoElement.muted = playback.muted;
+    videoElement.volume = playback.volume;
     return { ...baseProps, mediaSource, playback };
   }
 
@@ -166,6 +176,8 @@ export function createTestEntity(options: CreateEntityOptions = {}): ShaderCanva
       currentTime: 0,
       loop: true,
       playbackRate: 1,
+      muted: options.muted ?? true,
+      volume: options.volume ?? 1,
     };
     return { ...baseProps, mediaSource, playback };
   }

--- a/__tests__/hooks/use-image-input.spec.tsx
+++ b/__tests__/hooks/use-image-input.spec.tsx
@@ -136,6 +136,7 @@ describe("useImageInput", () => {
         select: true,
         fitToView: true,
         bottomInset: 0,
+        onLoadFailure: expect.any(Function),
       },
     );
   });
@@ -172,6 +173,7 @@ describe("useImageInput", () => {
         select: true,
         fitToView: false,
         bottomInset: 0,
+        onLoadFailure: expect.any(Function),
       },
     );
   });
@@ -235,6 +237,7 @@ describe("useImageInput", () => {
         select: true,
         fitToView: false,
         bottomInset: 0,
+        onLoadFailure: expect.any(Function),
       },
     );
   });

--- a/__tests__/hooks/use-media-controls.spec.tsx
+++ b/__tests__/hooks/use-media-controls.spec.tsx
@@ -14,6 +14,7 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import { act } from "@testing-library/react";
 import React, { type ReactNode } from "react";
 import { canvasStore } from "#engine";
+import { useKeybinds, useRegisterKeybinds } from "#context/keybind-context.ts";
 import { setupCanvasTest } from "../helpers/test-setup.ts";
 import { createTestEntity, createEntityInput, resetEntityCounter } from "../helpers/test-entity.ts";
 import {
@@ -451,6 +452,53 @@ describe("useMediaControlsActions hook callbacks", () => {
 
       updatedEntity = canvasStore.getState().entities.get(gifId!);
       expect(updatedEntity?.playback?.isPlaying).toBe(false);
+    });
+  });
+
+  describe("audio", () => {
+    test("reports and toggles selected video mute state", async () => {
+      const { canvas, getActions } = renderWithMediaHooks();
+
+      let videoId: string;
+      await act(async () => {
+        videoId = canvas.addEntity(
+          createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: true }),
+        );
+        canvas.selectEntity(videoId);
+      });
+
+      expect(getActions().canToggleMuted()).toBe(true);
+      expect(getActions().isMuted()).toBe(true);
+
+      await act(async () => {
+        getActions().toggleMuted();
+      });
+
+      const entity = canvasStore.getState().entities.get(videoId!);
+      expect(entity?.playback?.muted).toBe(false);
+      expect(getActions().isMuted()).toBe(false);
+    });
+
+    test("does not expose mute controls for GIFs or silent videos", async () => {
+      const { canvas, getActions } = renderWithMediaHooks();
+
+      let videoId: string;
+      let gifId: string;
+      await act(async () => {
+        videoId = canvas.addEntity(
+          createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: false }),
+        );
+        gifId = canvas.addEntity(createEntityInput({ mediaType: "gif", gifDuration: 2 }));
+        canvas.selectEntity(videoId);
+      });
+
+      expect(getActions().canToggleMuted()).toBe(false);
+
+      await act(async () => {
+        canvas.selectEntity(gifId!);
+      });
+
+      expect(getActions().canToggleMuted()).toBe(false);
     });
   });
 
@@ -1004,6 +1052,80 @@ describe("useMediaControlsActions hook callbacks", () => {
       const entity = canvasStore.getState().entities.get(gifId!);
       expect(entity?.playback?.isPlaying).toBe(true);
     });
+  });
+});
+
+describe("media mute keybind", () => {
+  function MuteKeybindHarness() {
+    const keybindStore = useKeybinds();
+    const storeSnapshot = React.useSyncExternalStore(
+      canvasStore.subscribe.bind(canvasStore),
+      canvasStore.getSelectionSnapshot.bind(canvasStore),
+    );
+    const selectedEntity =
+      storeSnapshot.selectedEntityIds.size === 1
+        ? storeSnapshot.entities.get([...storeSnapshot.selectedEntityIds][0]!)
+        : undefined;
+    const actions = useMediaControlsActions(selectedEntity);
+
+    React.useEffect(() => {
+      keybindStore.setActiveContext("selection");
+      return () => keybindStore.setActiveContext("global");
+    }, [keybindStore]);
+
+    useRegisterKeybinds("selection", [
+      {
+        id: "test_toggle_media_mute",
+        bind: (bb) => bb.withBind("m").withSensitive(false),
+        group: "video",
+        label: "Mute/Unmute media",
+        action: (e: KeyboardEvent) => {
+          if (!actions.canToggleMuted()) return;
+          e.preventDefault();
+          actions.toggleMuted();
+        },
+      },
+    ]);
+
+    return null;
+  }
+
+  test("pressing m toggles muted state for selected videos with audio", async () => {
+    const { canvas } = renderWithCanvas(<MuteKeybindHarness />);
+
+    let videoId: string;
+    await act(async () => {
+      videoId = canvas.addEntity(
+        createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: true }),
+      );
+      canvas.selectEntity(videoId);
+    });
+
+    expect(canvasStore.getState().entities.get(videoId!)?.playback?.muted).toBe(true);
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "m" }));
+    });
+
+    expect(canvasStore.getState().entities.get(videoId!)?.playback?.muted).toBe(false);
+  });
+
+  test("pressing m is ignored for selected videos without audio", async () => {
+    const { canvas } = renderWithCanvas(<MuteKeybindHarness />);
+
+    let videoId: string;
+    await act(async () => {
+      videoId = canvas.addEntity(
+        createEntityInput({ mediaType: "video", videoDuration: 60, videoHasAudio: false }),
+      );
+      canvas.selectEntity(videoId);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "m" }));
+    });
+
+    expect(canvasStore.getState().entities.get(videoId!)?.playback?.muted).toBe(true);
   });
 });
 

--- a/__tests__/lib/entity-placement.spec.ts
+++ b/__tests__/lib/entity-placement.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { ShaderCanvasEntity } from "#types/canvas.ts";
+import type { MediaLoadFailure } from "#lib/entity-placement.ts";
 import { setupCanvasTest } from "../helpers/test-setup.ts";
 import { createEntityInput } from "../helpers/test-entity.ts";
 
@@ -139,6 +140,39 @@ describe("entity placement", () => {
 
     expect(stopMomentum).toHaveBeenCalled();
     expect(animateTo).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports failed file loads without blocking successful files", async () => {
+    const loadError = new Error("Unsupported codec");
+    vi.spyOn(mediaLoader, "loadMediaFile")
+      .mockRejectedValueOnce(loadError)
+      .mockResolvedValueOnce(makeEntityInput({ width: 100, height: 80 }));
+
+    const { addEntity, added } = createAddEntityRecorder();
+    const onLoadFailure = vi.fn<(failures: MediaLoadFailure[]) => void>();
+
+    const ids = await addFilesToCanvas(
+      [makeFile("bad.mp4", "video/mp4"), makeFile("good.png")],
+      addEntity,
+      makeContainer(),
+      {
+        anchor: { x: 100, y: 100 },
+        select: true,
+        fitToView: false,
+        bottomInset: 0,
+        onLoadFailure,
+      },
+    );
+
+    expect(ids).toEqual(["good.png"]);
+    expect(added).toHaveLength(1);
+    expect(onLoadFailure).toHaveBeenCalledWith([
+      {
+        file: expect.objectContaining({ name: "bad.mp4", type: "video/mp4" }),
+        reason: loadError,
+        mediaKind: "video",
+      },
+    ]);
   });
 
   test("multiple dropped URLs are laid out as a group around the drop point", async () => {

--- a/__tests__/lib/media-duplication.spec.ts
+++ b/__tests__/lib/media-duplication.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import {
+  createDuplicatePlaybackState,
+  resetDuplicatedMediaPlayback,
+} from "#lib/media-duplication.ts";
+import { createTestEntity } from "../helpers/test-entity.ts";
+
+describe("media duplication playback", () => {
+  test("resets duplicated video playback to paused at the beginning", () => {
+    const entity = createTestEntity({
+      mediaType: "video",
+      videoDuration: 120,
+      videoHasAudio: true,
+      muted: false,
+      volume: 0.4,
+    });
+
+    if (entity.mediaSource.type !== "video") throw new Error("Expected video entity");
+    entity.mediaSource.videoElement.currentTime = 42;
+    entity.mediaSource.videoElement.muted = false;
+    entity.mediaSource.videoElement.volume = 0.4;
+    entity.mediaSource.videoElement.loop = false;
+    entity.mediaSource.videoElement.playbackRate = 2;
+    if (entity.playback) {
+      entity.playback.isPlaying = true;
+      entity.playback.currentTime = 42;
+      entity.playback.loop = false;
+      entity.playback.playbackRate = 2;
+      entity.playback.muted = false;
+      entity.playback.volume = 0.4;
+    }
+
+    const playback = createDuplicatePlaybackState(entity);
+    resetDuplicatedMediaPlayback(entity.mediaSource, playback);
+
+    expect(playback).toEqual({
+      isPlaying: false,
+      currentTime: 0,
+      loop: true,
+      playbackRate: 1,
+      muted: true,
+      volume: 1,
+    });
+    expect(entity.mediaSource.videoElement.paused).toBe(true);
+    expect(entity.mediaSource.videoElement.currentTime).toBe(0);
+    expect(entity.mediaSource.videoElement.muted).toBe(true);
+    expect(entity.mediaSource.videoElement.volume).toBe(1);
+    expect(entity.mediaSource.videoElement.loop).toBe(true);
+    expect(entity.mediaSource.videoElement.playbackRate).toBe(1);
+  });
+});

--- a/__tests__/lib/serialization-playback.spec.ts
+++ b/__tests__/lib/serialization-playback.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { canvasStore } from "#engine";
+import { serializePlayback } from "#lib/serialization/serialize.ts";
+import { toPlaybackState } from "#lib/serialization/types.ts";
+import { setupCanvasTest } from "../helpers/test-setup.ts";
+import { createTestEntity, resetEntityCounter } from "../helpers/test-entity.ts";
+
+let cleanup: () => void;
+
+beforeEach(() => {
+  cleanup?.();
+  cleanup = setupCanvasTest();
+  resetEntityCounter();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("serialized playback audio state", () => {
+  test("serializes muted and volume", () => {
+    const playback = toPlaybackState({
+      currentTime: 4,
+      loop: true,
+      playbackRate: 1,
+      muted: false,
+      volume: 0.35,
+      isPlaying: false,
+    });
+
+    expect(serializePlayback(playback)).toEqual({
+      currentTime: 4,
+      loop: true,
+      playbackRate: 1,
+      muted: false,
+      volume: 0.35,
+      isPlaying: false,
+    });
+  });
+
+  test("defaults old playback data to muted at full volume", () => {
+    expect(
+      toPlaybackState({
+        currentTime: 0,
+        loop: true,
+        playbackRate: 1,
+      }),
+    ).toMatchObject({
+      muted: true,
+      volume: 1,
+    });
+  });
+
+  test("restored playback audio state is applied when entity enters the store", () => {
+    const entity = createTestEntity({
+      mediaType: "video",
+      videoHasAudio: true,
+      muted: false,
+      volume: 0.4,
+    });
+
+    canvasStore.addEntity(entity);
+
+    expect(entity.mediaSource.type === "video" && entity.mediaSource.videoElement.muted).toBe(
+      false,
+    );
+    expect(entity.mediaSource.type === "video" && entity.mediaSource.videoElement.volume).toBe(0.4);
+  });
+});

--- a/components/infinite-canvas/infinite-canvas.tsx
+++ b/components/infinite-canvas/infinite-canvas.tsx
@@ -415,6 +415,12 @@ export function InfiniteCanvas() {
     playPauseRef.current = playPauseShortcutHandler;
   });
 
+  const muteMediaShortcutHandler = (e: KeyboardEvent) => {
+    if (!mediaActions.canToggleMuted()) return;
+    e.preventDefault();
+    mediaActions.toggleMuted();
+  };
+
   // Space+drag canvas panning: intercept space before the keybind system (capture phase,
   // registered first due to React's child-before-parent effect ordering).
   useEffect(() => {
@@ -762,6 +768,13 @@ export function InfiniteCanvas() {
       group: "video",
       label: "Play/Pause media",
       action: () => {}, // Handled by space+drag keyup handler to distinguish tap vs hold
+    },
+    {
+      id: "toggle_media_mute",
+      bind: (bb) => bb.withBind("m").withSensitive(false),
+      group: "video",
+      label: "Mute/Unmute media",
+      action: muteMediaShortcutHandler,
     },
     {
       id: "copy_selection",

--- a/components/infinite-canvas/media-controls.css
+++ b/components/infinite-canvas/media-controls.css
@@ -62,7 +62,7 @@
   position: relative;
   height: var(--player-height, 60px);
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
   background: var(--floating-background);
   backdrop-filter: var(--floating-backdrop);
   padding: var(--spacing-2) var(--spacing-2);
@@ -220,4 +220,23 @@
   height: 100%;
   background-color: var(--primary);
   opacity: 1;
+}
+
+.mute-button {
+  color: var(--gray-800);
+  width: 24px;
+  height: 24px;
+  padding: 10px;
+  margin: -8px;
+  margin-left: -4px;
+  padding-top: 8px;
+
+  @media screen and (max-width: 768px) {
+    padding-top: 12px;
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
 }

--- a/components/infinite-canvas/media-controls.tsx
+++ b/components/infinite-canvas/media-controls.tsx
@@ -2,9 +2,10 @@ import { useSelectedEntity } from "#context/use-canvas.ts";
 import {
   useMediaControlsActions,
   useFrozenPlaybackTime,
+  useSelectedVideoAudioState,
   type MediaControlsActionsOnly,
 } from "#hooks/use-media-controls.ts";
-import { PauseSolid, PlaySolid } from "iconoir-react";
+import { PauseSolid, PlaySolid, SoundHigh, SoundOff } from "iconoir-react";
 import { Slider as BaseSlider } from "@base-ui/react/slider";
 import "./media-controls.css";
 
@@ -46,6 +47,24 @@ function PlayPauseButton({ actions }: { actions: MediaControlsActionsOnly }) {
     >
       <PauseSolid className={isPlaying ? "icon-visible" : "icon-hidden"} />
       <PlaySolid className={isPlaying ? "icon-hidden" : "icon-visible"} />
+    </button>
+  );
+}
+
+function MuteButton({ actions }: { actions: MediaControlsActionsOnly }) {
+  const audio = useSelectedVideoAudioState();
+
+  if (!audio.canToggleMuted) return null;
+
+  return (
+    <button
+      type="button"
+      className="mute-button controls-state icon-crossfade"
+      onClick={actions.toggleMuted}
+      aria-label={audio.isMuted ? "Unmute" : "Mute"}
+    >
+      <SoundOff className={audio.isMuted ? "icon-visible" : "icon-hidden"} />
+      <SoundHigh className={audio.isMuted ? "icon-hidden" : "icon-visible"} />
     </button>
   );
 }
@@ -115,6 +134,7 @@ export function MediaControls() {
       <div className="media-controls__container">
         <PlayPauseButton actions={actions} />
         <MediaSlider actions={actions} />
+        <MuteButton actions={actions} />
       </div>
     </div>
   );

--- a/components/media-load-errors.ts
+++ b/components/media-load-errors.ts
@@ -1,0 +1,34 @@
+import { toastManager } from "#components/ui/toast/toast-manager.ts";
+import type { MediaLoadFailure } from "#lib/entity-placement.ts";
+
+const MEDIA_LOAD_ERROR_TOAST_TIMEOUT_MS = 20_000;
+
+export function showMediaLoadFailureToasts(failures: readonly MediaLoadFailure[]): void {
+  const videoFailures = failures.filter((failure) => failure.mediaKind === "video");
+  const otherFailures = failures.filter((failure) => failure.mediaKind !== "video");
+
+  if (videoFailures.length > 0) {
+    const firstFile = videoFailures[0]!.file.name;
+    toastManager.add({
+      title: videoFailures.length === 1 ? "Unsupported video" : "Unsupported videos",
+      description:
+        videoFailures.length === 1
+          ? `${firstFile} isn’t supported by this browser.`
+          : `${videoFailures.length} videos aren’t supported by this browser.`,
+      type: "destructive",
+      timeout: MEDIA_LOAD_ERROR_TOAST_TIMEOUT_MS,
+    });
+  }
+
+  if (otherFailures.length > 0) {
+    toastManager.add({
+      title: "Couldn’t load media",
+      description:
+        otherFailures.length === 1
+          ? `${otherFailures[0]!.file.name} couldn’t be loaded.`
+          : `${otherFailures.length} files couldn’t be loaded.`,
+      type: "destructive",
+      timeout: MEDIA_LOAD_ERROR_TOAST_TIMEOUT_MS,
+    });
+  }
+}

--- a/components/upload-button-controls.tsx
+++ b/components/upload-button-controls.tsx
@@ -2,6 +2,7 @@ import { useCanvasCommands, useHasEntities } from "#context/use-canvas.ts";
 import { useIsMobile } from "#hooks/use-is-mobile.ts";
 import { getViewportCenter } from "#lib/canvas-math.ts";
 import { addFilesToCanvas } from "#lib/entity-placement.ts";
+import { showMediaLoadFailureToasts } from "#components/media-load-errors.ts";
 import { MediaImagePlus } from "iconoir-react";
 import { useRef } from "react";
 import { config } from "../lib/config";
@@ -47,6 +48,7 @@ export function FileUploadComponent() {
       select: true,
       fitToView: true,
       bottomInset,
+      onLoadFailure: showMediaLoadFailureToasts,
     });
   };
 

--- a/context/canvas-context.tsx
+++ b/context/canvas-context.tsx
@@ -50,6 +50,10 @@ import { toastManager } from "#components/ui/toast/toast-manager.ts";
 import { hints } from "#components/ui/hint/hint-manager.ts";
 import { extractOriginalPalette, cloneMediaSource } from "#lib/media-loader.ts";
 import { Command, undo } from "#lib/undo.ts";
+import {
+  createDuplicatePlaybackState,
+  resetDuplicatedMediaPlayback,
+} from "#lib/media-duplication.ts";
 import { config, glassKindResets, glitchKindResets } from "#config";
 import { preferences } from "#lib/storage.ts";
 import { paletteStore } from "#lib/palette-store.ts";
@@ -751,6 +755,8 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
       let n = 1;
       while (entities.values().some((e) => e.name === `${baseName} (${n})`)) n++;
       const name = `${baseName} (${n})`;
+      const playback = createDuplicatePlaybackState(entity);
+      resetDuplicatedMediaPlayback(mediaSource, playback);
 
       const clone: ShaderCanvasEntity = {
         ...entity,
@@ -766,7 +772,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
         originalPalette: entity.originalPalette
           ? structuredClone(entity.originalPalette)
           : undefined,
-        playback: entity.playback ? { ...entity.playback, isPlaying: false } : undefined,
+        playback,
         texture: undefined,
         textureDirty: true,
         selected: false,

--- a/engine/canvas-store.ts
+++ b/engine/canvas-store.ts
@@ -119,6 +119,13 @@ export interface PlaybackSnapshot {
   version: number;
 }
 
+export interface SelectedVideoAudioSnapshot {
+  entityId: string | null;
+  canToggleMuted: boolean;
+  muted: boolean;
+  version: number;
+}
+
 export interface RenderState {
   viewport: Viewport;
   entities: ShaderCanvasEntity[];
@@ -183,6 +190,7 @@ export class CanvasStore extends Store<CanvasState> {
   readonly getContextOpenEntityIdSnapshot: () => string | null;
   readonly getPreferencesSnapshot: () => PreferencesSnapshot;
   readonly getPlaybackSnapshot: () => PlaybackSnapshot;
+  readonly getSelectedVideoAudioSnapshot: () => SelectedVideoAudioSnapshot;
   readonly getDragSnapshot: () => DragSnapshot;
   readonly getActionLayerSnapshot: () => ActionLayerSnapshot;
 
@@ -311,6 +319,25 @@ export class CanvasStore extends Store<CanvasState> {
       };
     });
 
+    this.getSelectedVideoAudioSnapshot = this.createSnapshot("selectionVersion", (s) => {
+      const selectedEntity = this.getSelectedEntity();
+      if (selectedEntity?.mediaSource.type === MediaType.video) {
+        return {
+          entityId: selectedEntity.id,
+          canToggleMuted: selectedEntity.mediaSource.hasAudio,
+          muted: selectedEntity.playback?.muted ?? selectedEntity.mediaSource.videoElement.muted,
+          version: s.selectionVersion,
+        };
+      }
+
+      return {
+        entityId: null,
+        canToggleMuted: false,
+        muted: true,
+        version: s.selectionVersion,
+      };
+    });
+
     this.getDragSnapshot = this.createSnapshot("dragVersion", (s) => ({
       entityDragActive: s.entityDragActive,
       version: s.dragVersion,
@@ -345,6 +372,9 @@ export class CanvasStore extends Store<CanvasState> {
 
   // Entity mutations (only notify selection subscribers)
   addEntity(entity: ShaderCanvasEntity): void {
+    if (entity.mediaSource.type === MediaType.video) {
+      this.#syncVideoElementPlayback(entity);
+    }
     this.state.entities.set(entity.id, entity);
     this.state.entitiesDirty.add(entity.id);
     this.notifySelectionChange();
@@ -671,6 +701,7 @@ export class CanvasStore extends Store<CanvasState> {
     if (!entity || entity.mediaSource.type !== MediaType.video) return;
 
     const video = entity.mediaSource.videoElement;
+    this.#syncVideoElementPlayback(entity);
     await video.play();
 
     if (entity.playback) {
@@ -679,6 +710,30 @@ export class CanvasStore extends Store<CanvasState> {
     }
     this.state.entitiesDirty.add(entityId);
     this.notifySelectionChange();
+  }
+
+  setVideoMuted(entityId: string, muted: boolean): void {
+    const entity = this.state.entities.get(entityId);
+    if (!entity || entity.mediaSource.type !== MediaType.video || !entity.playback) return;
+
+    if (entity.playback.muted === muted && entity.mediaSource.videoElement.muted === muted) {
+      return;
+    }
+
+    entity.playback.muted = muted;
+    entity.mediaSource.videoElement.muted = muted;
+    this.state.entitiesDirty.add(entityId);
+    this.notifySelectionChange();
+  }
+
+  toggleVideoMuted(entityId: string): void {
+    const entity = this.state.entities.get(entityId);
+    if (!entity || entity.mediaSource.type !== MediaType.video) return;
+
+    this.setVideoMuted(
+      entityId,
+      !(entity.playback?.muted ?? entity.mediaSource.videoElement.muted),
+    );
   }
 
   pauseVideo(entityId: string): void {
@@ -845,6 +900,17 @@ export class CanvasStore extends Store<CanvasState> {
     this.#lastPlaybackNotifyTime = performance.now();
     this.state.playbackVersion++;
     this.notify();
+  }
+
+  #syncVideoElementPlayback(entity: ShaderCanvasEntity): void {
+    if (entity.mediaSource.type !== MediaType.video) return;
+
+    const { videoElement } = entity.mediaSource;
+    const playback = entity.playback;
+    videoElement.muted = playback?.muted ?? true;
+    videoElement.volume = Math.max(0, Math.min(playback?.volume ?? 1, 1));
+    videoElement.loop = playback?.loop ?? true;
+    videoElement.playbackRate = playback?.playbackRate ?? 1;
   }
 
   /**

--- a/hooks/use-image-input.ts
+++ b/hooks/use-image-input.ts
@@ -1,4 +1,5 @@
 import { toastManager } from "#components/ui/toast/toast-manager.ts";
+import { showMediaLoadFailureToasts } from "#components/media-load-errors.ts";
 import { config } from "#config";
 import {
   addFilesToCanvas,
@@ -91,6 +92,7 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
         select: true,
         fitToView: shouldFitToView,
         bottomInset,
+        onLoadFailure: showMediaLoadFailureToasts,
       });
     }
 
@@ -181,6 +183,7 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
       select: true,
       fitToView: true,
       bottomInset,
+      onLoadFailure: showMediaLoadFailureToasts,
     });
 
     isLoadingRef.current = false;
@@ -237,6 +240,7 @@ export function useImageInput({ containerRef, multipleFiles = true }: UseImageIn
           select: true,
           fitToView: false,
           bottomInset,
+          onLoadFailure: showMediaLoadFailureToasts,
         });
       }
       // Handle dropped URLs

--- a/hooks/use-media-controls.ts
+++ b/hooks/use-media-controls.ts
@@ -24,12 +24,15 @@ export interface MediaControlsActionsOnly {
   play: () => Promise<void>;
   pause: () => void;
   togglePlayback: () => Promise<void>;
+  toggleMuted: () => void;
   seek: (time: number) => void;
   /** Seek relative to current position. Reads current time directly from entity to avoid stale state. */
   seekRelative: (delta: number) => void;
   seekStart: () => void;
   seekEnd: () => void;
   isIdle: () => boolean;
+  canToggleMuted: () => boolean;
+  isMuted: () => boolean;
 }
 
 export interface PlaybackTimeState {
@@ -41,6 +44,12 @@ export interface PlaybackTimeState {
   timeParts: MediaTimeParts;
   /** Duration parts for custom styling (main + ms) */
   durationParts: MediaTimeParts;
+}
+
+export interface SelectedVideoAudioState {
+  entityId: string | null;
+  canToggleMuted: boolean;
+  isMuted: boolean;
 }
 
 // ============================================================================
@@ -92,6 +101,19 @@ export function useFrozenPlaybackTime(): PlaybackTimeState {
 
   // Return frozen state during idle (for exit animation), live state otherwise
   return liveState.entityId !== null ? liveState : frozen;
+}
+
+export function useSelectedVideoAudioState(): SelectedVideoAudioState {
+  const audioSnapshot = useSyncExternalStore(
+    canvasStore.subscribe.bind(canvasStore),
+    canvasStore.getSelectedVideoAudioSnapshot.bind(canvasStore),
+  );
+
+  return {
+    entityId: audioSnapshot.entityId,
+    canToggleMuted: audioSnapshot.canToggleMuted,
+    isMuted: audioSnapshot.muted,
+  };
 }
 
 // ============================================================================
@@ -157,6 +179,15 @@ export function useMediaControlsActions(
     if (entity?.id) {
       await canvasStore.togglePlayback(entity.id);
     }
+  };
+
+  const toggleMuted = () => {
+    if (!entity?.id || !isVideoEntity(entity) || !entity.mediaSource.hasAudio) return;
+    logger.debug("[MediaControls] toggleMuted() called", {
+      entityId: entity.id,
+      muted: entity.playback?.muted,
+    });
+    canvasStore.toggleVideoMuted(entity.id);
   };
 
   const seek = (time: number) => {
@@ -274,6 +305,15 @@ export function useMediaControlsActions(
     return !entity || !isAnimatedEntity(entity);
   };
 
+  const canToggleMuted = () => {
+    return !!entity && isVideoEntity(entity) && entity.mediaSource.hasAudio;
+  };
+
+  const isMuted = () => {
+    if (!entity || !isVideoEntity(entity)) return true;
+    return entity.playback?.muted ?? entity.mediaSource.videoElement.muted;
+  };
+
   // Handle video edge case events (seeked, ended, play)
   // Note: Regular time updates are handled by the game loop
   useEffect(() => {
@@ -332,10 +372,13 @@ export function useMediaControlsActions(
     play,
     pause,
     togglePlayback,
+    toggleMuted,
     seek,
     seekRelative,
     seekStart,
     seekEnd,
     isIdle,
+    canToggleMuted,
+    isMuted,
   };
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -13,6 +13,21 @@ export interface AnalyticsEventMap {
   "entity.added": { media_type: string };
   "entity.duplicated": { entity_count: number };
   "workspace.cleared": { entity_count: number };
+  "media.video_unsupported": {
+    mimeType: string;
+    sizeBytes: number;
+    errorType: string;
+    errorCode: number | null;
+    canPlayMimeType: string;
+    canPlayVideoCodec: string;
+    videoCodec: string | null;
+    audioCodec: string | null;
+    audioSampleRate: number | null;
+    audioChannels: number | null;
+    demuxError: string | null;
+    webCodecsVideoDecoderSupported: boolean | null;
+    webCodecsVideoDecoderSupportError: string | null;
+  };
   "deserialization.video_seek_timed_out": {
     mediaType: "video";
     container: string;

--- a/lib/entity-placement.ts
+++ b/lib/entity-placement.ts
@@ -23,6 +23,13 @@ export interface ImportPlacementOptions {
   select: boolean;
   fitToView: boolean;
   bottomInset: number;
+  onLoadFailure?: (failures: MediaLoadFailure[]) => void;
+}
+
+export interface MediaLoadFailure {
+  file: File;
+  reason: unknown;
+  mediaKind: "video" | "image" | "unknown";
 }
 
 /**
@@ -204,18 +211,33 @@ function placeLoadedEntities(
   return entityIds;
 }
 
-async function loadFilesForCanvas(files: File[]): Promise<LoadedEntity[]> {
+function getMediaKind(file: File): MediaLoadFailure["mediaKind"] {
+  if (file.type.startsWith("video/")) return "video";
+  if (file.type.startsWith("image/")) return "image";
+  return "unknown";
+}
+
+async function loadFilesForCanvas(
+  files: File[],
+): Promise<{ loaded: LoadedEntity[]; failures: MediaLoadFailure[] }> {
   const results = await Promise.allSettled(files.map((file) => loadMediaFile(file)));
 
   const loaded: LoadedEntity[] = [];
+  const failures: MediaLoadFailure[] = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i]!;
     if (result.status === "fulfilled" && result.value) {
       loaded.push({ data: result.value, filename: files[i]!.name });
+    } else if (result.status === "rejected") {
+      failures.push({
+        file: files[i]!,
+        reason: result.reason,
+        mediaKind: getMediaKind(files[i]!),
+      });
     }
   }
 
-  return loaded;
+  return { loaded, failures };
 }
 
 async function loadUrlForCanvas(url: string): Promise<LoadedEntity | null> {
@@ -254,7 +276,10 @@ export async function addFilesToCanvas(
 ): Promise<string[]> {
   if (files.length === 0) return [];
 
-  const loaded = await loadFilesForCanvas(files);
+  const { loaded, failures } = await loadFilesForCanvas(files);
+  if (failures.length > 0) {
+    options.onLoadFailure?.(failures);
+  }
   return placeLoadedEntities(loaded, addEntity, container, options);
 }
 

--- a/lib/media-duplication.ts
+++ b/lib/media-duplication.ts
@@ -1,0 +1,31 @@
+import {
+  MediaType,
+  type MediaSource,
+  type PlaybackState,
+  type ShaderCanvasEntity,
+} from "#types/canvas.ts";
+import { createPlaybackState } from "./media-playback.ts";
+
+export function createDuplicatePlaybackState(
+  entity: ShaderCanvasEntity,
+): PlaybackState | undefined {
+  if (!entity.playback) return undefined;
+
+  return createPlaybackState();
+}
+
+export function resetDuplicatedMediaPlayback(
+  mediaSource: MediaSource,
+  playback: PlaybackState | undefined,
+): void {
+  if (mediaSource.type !== MediaType.video) return;
+
+  const safePlayback = createPlaybackState(playback);
+  const video = mediaSource.videoElement;
+  video.pause();
+  video.currentTime = safePlayback.currentTime;
+  video.muted = safePlayback.muted;
+  video.volume = safePlayback.volume;
+  video.loop = safePlayback.loop;
+  video.playbackRate = safePlayback.playbackRate;
+}

--- a/lib/media-loader.ts
+++ b/lib/media-loader.ts
@@ -1,9 +1,11 @@
 import type { ShaderCanvasEntity, Point, ColorPalette, MediaSource } from "#types/canvas.ts";
 import type { ColorSpace } from "#types/enums.ts";
+import { analytics } from "./analytics.ts";
 import { logger } from "./client.logger.ts";
 import { config } from "./config/index.ts";
 import { extractPaletteFromImage } from "./palette-extraction/index.ts";
 import { decodeGif, isAnimatedGif, type GifDecodeResult } from "./gif-decoder.ts";
+import { createPlaybackState } from "./media-playback.ts";
 
 /** Check if a file is a video */
 export function isVideoFile(file: File): boolean {
@@ -39,6 +41,23 @@ export interface VideoLoadResult {
   duration: number;
   hasAudio: boolean;
   fps: number | null;
+}
+
+interface VideoLoadFailureDetails {
+  errorCode: number | null;
+  errorType: string;
+  errorMessage: string;
+  mimeType: string;
+  canPlayMimeType: string;
+  canPlayVideoCodec: string;
+  sizeBytes: number;
+  videoCodec: string | null;
+  webCodecsVideoDecoderSupported: boolean | null;
+  webCodecsVideoDecoderSupportError: string | null;
+  audioCodec: string | null;
+  audioSampleRate: number | null;
+  audioChannels: number | null;
+  demuxError: string | null;
 }
 
 /** Common frame rates to round to */
@@ -162,17 +181,26 @@ async function detectVideoFps(
  */
 export async function loadVideo(blob: Blob): Promise<VideoLoadResult> {
   const video = document.createElement("video");
-  video.src = URL.createObjectURL(blob);
   video.muted = true;
+  video.defaultMuted = true;
   video.loop = true;
   video.playsInline = true;
   video.preload = "auto";
+  video.src = URL.createObjectURL(blob);
 
   // Wait for metadata to load
-  await new Promise<void>((resolve, reject) => {
-    video.onloadedmetadata = () => resolve();
-    video.onerror = () => reject(new Error("Failed to load video"));
-  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      video.onloadedmetadata = () => resolve();
+      video.onerror = () => {
+        void createVideoLoadError(video, blob).then(reject);
+      };
+    });
+  } catch (error) {
+    cleanupVideoElement(video);
+    trackUnsupportedVideoLoad(blob, error);
+    throw error;
+  }
 
   const width = video.videoWidth;
   const height = video.videoHeight;
@@ -209,6 +237,165 @@ export async function loadVideo(blob: Blob): Promise<VideoLoadResult> {
     fps,
     hasAudio,
   };
+}
+
+async function createVideoLoadError(video: HTMLVideoElement, blob: Blob): Promise<Error> {
+  const details = await getVideoLoadFailureDetails(video, blob);
+  logger.error("[media-loader] Failed to load video", details);
+
+  const error = new Error(
+    `Failed to load video (${details.errorType}; type=${details.mimeType}; canPlay=${details.canPlayMimeType}; size=${details.sizeBytes}; videoCodec=${details.videoCodec ?? "unknown"}; audioCodec=${details.audioCodec ?? "unknown"})`,
+  );
+  return Object.assign(error, { details });
+}
+
+function getVideoLoadErrorDetails(error: unknown): VideoLoadFailureDetails | null {
+  if (!(error instanceof Error) || !("details" in error)) return null;
+  const details = (error as Error & { details?: unknown }).details;
+  if (!details || typeof details !== "object") return null;
+  return details as VideoLoadFailureDetails;
+}
+
+function trackUnsupportedVideoLoad(blob: Blob, error: unknown): void {
+  const details = getVideoLoadErrorDetails(error);
+  if (!details) return;
+
+  analytics.track("media.video_unsupported", {
+    mimeType: details.mimeType,
+    sizeBytes: blob.size,
+    errorType: details.errorType,
+    errorCode: details.errorCode,
+    canPlayMimeType: details.canPlayMimeType,
+    canPlayVideoCodec: details.canPlayVideoCodec,
+    videoCodec: details.videoCodec,
+    audioCodec: details.audioCodec,
+    audioSampleRate: details.audioSampleRate,
+    audioChannels: details.audioChannels,
+    demuxError: details.demuxError,
+    webCodecsVideoDecoderSupported: details.webCodecsVideoDecoderSupported,
+    webCodecsVideoDecoderSupportError: details.webCodecsVideoDecoderSupportError,
+  });
+}
+
+async function getVideoLoadFailureDetails(
+  video: HTMLVideoElement,
+  blob: Blob,
+): Promise<VideoLoadFailureDetails> {
+  const mediaError = video.error;
+  const code = mediaError?.code;
+  const codeLabel =
+    code === 1
+      ? "aborted"
+      : code === 2
+        ? "network"
+        : code === 3
+          ? "decode"
+          : code === 4
+            ? "source-not-supported"
+            : "unknown";
+  const demux = await probeVideoLoadFailureCodecs(blob);
+  const support = blob.type ? video.canPlayType(blob.type) || "no" : "unknown";
+  const videoCodecSupport =
+    blob.type && demux.videoCodec
+      ? video.canPlayType(`${blob.type}; codecs="${demux.videoCodec}"`) || "no"
+      : "unknown";
+  const videoDecoderSupport = await checkVideoDecoderSupport(demux.videoDecoderConfig);
+
+  return {
+    errorCode: code ?? null,
+    errorType: codeLabel,
+    errorMessage: mediaError?.message ?? "",
+    mimeType: blob.type || "unknown",
+    canPlayMimeType: support,
+    canPlayVideoCodec: videoCodecSupport,
+    sizeBytes: blob.size,
+    videoCodec: demux.videoCodec,
+    webCodecsVideoDecoderSupported: videoDecoderSupport.supported,
+    webCodecsVideoDecoderSupportError: videoDecoderSupport.error,
+    audioCodec: demux.audioCodec,
+    audioSampleRate: demux.audioSampleRate,
+    audioChannels: demux.audioChannels,
+    demuxError: demux.error,
+  };
+}
+
+async function probeVideoLoadFailureCodecs(blob: Blob): Promise<{
+  videoCodec: string | null;
+  videoDecoderConfig: VideoDecoderConfig | null;
+  audioCodec: string | null;
+  audioSampleRate: number | null;
+  audioChannels: number | null;
+  error: string | null;
+}> {
+  try {
+    const { ALL_FORMATS, BlobSource, Input } = await import("mediabunny");
+    const input = new Input({
+      source: new BlobSource(blob),
+      formats: ALL_FORMATS,
+    });
+
+    try {
+      const [videoTrack, audioTrack] = await Promise.all([
+        input.getPrimaryVideoTrack(),
+        input.getPrimaryAudioTrack(),
+      ]);
+      const [videoConfig, audioConfig, audioSampleRate, audioChannels] = await Promise.all([
+        videoTrack?.getDecoderConfig() ?? Promise.resolve(null),
+        audioTrack?.getDecoderConfig() ?? Promise.resolve(null),
+        audioTrack?.getSampleRate() ?? Promise.resolve(null),
+        audioTrack?.getNumberOfChannels() ?? Promise.resolve(null),
+      ]);
+
+      return {
+        videoCodec: videoConfig?.codec ?? null,
+        videoDecoderConfig: videoConfig,
+        audioCodec: audioConfig?.codec ?? null,
+        audioSampleRate,
+        audioChannels,
+        error: null,
+      };
+    } finally {
+      input.dispose();
+    }
+  } catch (error) {
+    return {
+      videoCodec: null,
+      videoDecoderConfig: null,
+      audioCodec: null,
+      audioSampleRate: null,
+      audioChannels: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function checkVideoDecoderSupport(
+  decoderConfig: VideoDecoderConfig | null,
+): Promise<{ supported: boolean | null; error: string | null }> {
+  if (!decoderConfig) return { supported: null, error: null };
+  if (typeof VideoDecoder === "undefined") {
+    return { supported: false, error: "VideoDecoder is unavailable" };
+  }
+
+  try {
+    const support = await VideoDecoder.isConfigSupported(decoderConfig);
+    return { supported: support.supported === true, error: null };
+  } catch (error) {
+    return {
+      supported: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function cleanupVideoElement(video: HTMLVideoElement): void {
+  const { src } = video;
+  video.pause();
+  video.removeAttribute("src");
+  video.load();
+  if (src.startsWith("blob:")) {
+    URL.revokeObjectURL(src);
+  }
 }
 
 /**
@@ -275,12 +462,7 @@ export function createGifEntityData(
     selected: false,
     locked: false,
     edited: false,
-    playback: {
-      isPlaying: true, // Autoplay when added
-      currentTime: 0,
-      loop: true,
-      playbackRate: 1,
-    },
+    playback: createPlaybackState({ isPlaying: true }), // Autoplay when added
   };
 }
 
@@ -412,12 +594,7 @@ export function createVideoEntityData(
     selected: false,
     locked: false,
     edited: false,
-    playback: {
-      isPlaying: true, // Autoplay when added
-      currentTime: 0,
-      loop: true,
-      playbackRate: 1,
-    },
+    playback: createPlaybackState({ isPlaying: true }), // Autoplay when added
   };
 }
 
@@ -429,13 +606,8 @@ export async function loadMediaFile(
   position: Point = { x: 0, y: 0 },
 ): Promise<(Omit<ShaderCanvasEntity, "id" | "zIndex" | "name"> & { name?: string }) | null> {
   if (isVideoFile(file)) {
-    try {
-      const videoResult = await loadVideo(file);
-      return createVideoEntityData(videoResult, file, position, file.name);
-    } catch (err) {
-      console.error("Failed to load video:", err);
-      return null;
-    }
+    const videoResult = await loadVideo(file);
+    return createVideoEntityData(videoResult, file, position, file.name);
   }
 
   if (isImageFile(file)) {
@@ -490,13 +662,8 @@ export async function loadMediaFromBlob(
   filename?: string,
 ): Promise<(Omit<ShaderCanvasEntity, "id" | "zIndex" | "name"> & { name?: string }) | null> {
   if (isVideoMimeType(mimeType)) {
-    try {
-      const videoResult = await loadVideo(blob);
-      return createVideoEntityData(videoResult, blob, position, filename);
-    } catch (err) {
-      console.error("Failed to load video from URL:", err);
-      return null;
-    }
+    const videoResult = await loadVideo(blob);
+    return createVideoEntityData(videoResult, blob, position, filename);
   }
 
   if (isImageMimeType(mimeType)) {

--- a/lib/media-playback.ts
+++ b/lib/media-playback.ts
@@ -1,0 +1,21 @@
+import type { PlaybackState } from "#types/canvas.ts";
+
+export const DEFAULT_PLAYBACK_STATE: PlaybackState = {
+  isPlaying: false,
+  currentTime: 0,
+  loop: true,
+  playbackRate: 1,
+  muted: true,
+  volume: 1,
+};
+
+export function createPlaybackState(overrides: Partial<PlaybackState> = {}): PlaybackState {
+  return {
+    isPlaying: overrides.isPlaying ?? DEFAULT_PLAYBACK_STATE.isPlaying,
+    currentTime: overrides.currentTime ?? DEFAULT_PLAYBACK_STATE.currentTime,
+    loop: overrides.loop ?? DEFAULT_PLAYBACK_STATE.loop,
+    playbackRate: overrides.playbackRate ?? DEFAULT_PLAYBACK_STATE.playbackRate,
+    muted: overrides.muted ?? DEFAULT_PLAYBACK_STATE.muted,
+    volume: overrides.volume ?? DEFAULT_PLAYBACK_STATE.volume,
+  };
+}

--- a/lib/serialization/media.ts
+++ b/lib/serialization/media.ts
@@ -203,11 +203,12 @@ async function seekVideoWithTimeout(
 
 function createArchiveVideoElement(blob: Blob): HTMLVideoElement {
   const video = document.createElement("video");
-  video.src = URL.createObjectURL(blob);
   video.muted = true;
+  video.defaultMuted = true;
   video.loop = true;
   video.playsInline = true;
   video.preload = "auto";
+  video.src = URL.createObjectURL(blob);
   return video;
 }
 

--- a/lib/serialization/migrations.ts
+++ b/lib/serialization/migrations.ts
@@ -35,6 +35,13 @@ const migrations: Record<number, Migration> = {
     doc.version = 4;
     return doc;
   },
+
+  // Version 4 -> 5: Add muted and volume to playback state.
+  // toPlaybackState() supplies defaults for old manifests, so no rewrite needed.
+  4: (doc) => {
+    doc.version = 5;
+    return doc;
+  },
 };
 
 /**

--- a/lib/serialization/serialize.ts
+++ b/lib/serialization/serialize.ts
@@ -1,5 +1,6 @@
 import { canvasStore } from "#engine";
 import { config } from "#config";
+import { createPlaybackState } from "#lib/media-playback.ts";
 import type { ColorPalette, ShaderCanvasEntity } from "#types/canvas.ts";
 import { paletteStore } from "../palette-store.ts";
 import { detectVideoExtension, videoElementToBytes } from "./media.ts";
@@ -202,12 +203,17 @@ async function prepareEntity(entity: ShaderCanvasEntity): Promise<PreparedEntity
   }
 }
 
-function serializePlayback(playback: ShaderCanvasEntity["playback"]): SerializedPlaybackState {
+export function serializePlayback(
+  playback: ShaderCanvasEntity["playback"],
+): SerializedPlaybackState {
+  const safePlayback = createPlaybackState(playback);
   return {
-    currentTime: playback?.currentTime ?? 0,
-    loop: playback?.loop ?? true,
-    playbackRate: playback?.playbackRate ?? 1,
-    isPlaying: playback?.isPlaying ?? false,
+    currentTime: safePlayback.currentTime,
+    loop: safePlayback.loop,
+    playbackRate: safePlayback.playbackRate,
+    muted: safePlayback.muted,
+    volume: safePlayback.volume,
+    isPlaying: safePlayback.isPlaying,
   };
 }
 

--- a/lib/serialization/types.ts
+++ b/lib/serialization/types.ts
@@ -1,4 +1,5 @@
 import type { ColorPalette, PlaybackState, ShaderParams } from "#types/canvas.ts";
+import { createPlaybackState } from "#lib/media-playback.ts";
 
 // ============================================================================
 // Document Envelope
@@ -98,6 +99,8 @@ export interface SerializedPlaybackState {
   currentTime: number;
   loop: boolean;
   playbackRate: number;
+  muted?: boolean;
+  volume?: number;
   isPlaying?: boolean;
 }
 
@@ -178,10 +181,5 @@ export function isSerializedEntity(data: unknown): data is SerializedEntity {
 
 /** Playback state with safe defaults */
 export function toPlaybackState(s: SerializedPlaybackState | undefined): PlaybackState {
-  return {
-    isPlaying: s?.isPlaying ?? false,
-    currentTime: s?.currentTime ?? 0,
-    loop: s?.loop ?? true,
-    playbackRate: s?.playbackRate ?? 1,
-  };
+  return createPlaybackState(s);
 }

--- a/lib/serialization/version.ts
+++ b/lib/serialization/version.ts
@@ -1,2 +1,2 @@
 /** Current schema version for the studio document format */
-export const CURRENT_VERSION = 4;
+export const CURRENT_VERSION = 5;

--- a/types/canvas.ts
+++ b/types/canvas.ts
@@ -433,6 +433,10 @@ export interface PlaybackState {
   currentTime: number;
   loop: boolean;
   playbackRate: number;
+  /** Whether video audio is muted during canvas preview playback */
+  muted: boolean;
+  /** Video audio volume for future volume controls */
+  volume: number;
 }
 
 type ShaderCanvasEntityBase = {


### PR DESCRIPTION
adds audio to videos that have it, and mute/unmute button.

<img width="664" height="199" alt="image" src="https://github.com/user-attachments/assets/f69943d4-41ea-447f-85b5-2bc1bcd33114" />

adds decode failure probing, for example when trying to add a video with av1 codec in safari. Now a error toast will be shown saying this video is unsupported. 