### PR TITLE
[codex] Optimize canvas hit testing

### DIFF
--- a/__tests__/engine/game-loop.spec.ts
+++ b/__tests__/engine/game-loop.spec.ts
@@ -37,13 +37,14 @@ function addEntity(
   y: number,
   width = 200,
   height = 150,
-  opts: { id?: string; locked?: boolean } = {},
+  opts: { id?: string; locked?: boolean; zIndex?: number } = {},
 ): string {
   const entity = createTestEntity({
     id: opts.id,
     position: { x, y },
     size: { width, height },
     locked: opts.locked,
+    zIndex: opts.zIndex,
   });
   canvasStore.addEntity(entity);
   return entity.id;
@@ -122,6 +123,36 @@ describe("Desktop pointer interactions", () => {
       expect(canvasStore.getSelectedEntityIds().size).toBe(1);
       expect(canvasStore.getSelectedEntityIds().has(id1)).toBe(true);
       expect(canvasStore.getSelectedEntityIds().has(id2)).toBe(false);
+    });
+
+    test("click on overlapping entities selects highest z-index entity", () => {
+      const backId = addEntity(100, 100, 200, 150, { zIndex: 1 });
+      const frontId = addEntity(100, 100, 200, 150, { zIndex: 10 });
+
+      click(gl, { x: 150, y: 150 });
+
+      expect(canvasStore.getSelectedEntityIds().has(frontId)).toBe(true);
+      expect(canvasStore.getSelectedEntityIds().has(backId)).toBe(false);
+    });
+
+    test("click on overlapping entities ignores locked topmost entity", () => {
+      const unlockedId = addEntity(100, 100, 200, 150, { zIndex: 10 });
+      const lockedId = addEntity(100, 100, 200, 150, { locked: true, zIndex: 20 });
+
+      click(gl, { x: 150, y: 150 });
+
+      expect(canvasStore.getSelectedEntityIds().has(unlockedId)).toBe(true);
+      expect(canvasStore.getSelectedEntityIds().has(lockedId)).toBe(false);
+    });
+
+    test("click on overlapping entities with equal z-index keeps insertion order", () => {
+      const firstId = addEntity(100, 100, 200, 150, { zIndex: 5 });
+      const secondId = addEntity(100, 100, 200, 150, { zIndex: 5 });
+
+      click(gl, { x: 150, y: 150 });
+
+      expect(canvasStore.getSelectedEntityIds().has(firstId)).toBe(true);
+      expect(canvasStore.getSelectedEntityIds().has(secondId)).toBe(false);
     });
   });
 

--- a/engine/game-loop.ts
+++ b/engine/game-loop.ts
@@ -732,19 +732,17 @@ export class GameLoop {
   }
 
   private findEntityAtPoint(worldPoint: Point, state: CanvasState): string | null {
-    const sortedEntities = state.entities
-      .values()
-      .toArray()
-      .sort((a, b) => b.zIndex - a.zIndex);
+    let topEntity: { id: string; zIndex: number } | null = null;
 
-    for (const entity of sortedEntities) {
+    for (const entity of state.entities.values()) {
       if (entity.locked) continue;
       const bounds = createBounds(entity.position, entity.size);
-      if (pointInBounds(worldPoint, bounds)) {
-        return entity.id;
+      if (pointInBounds(worldPoint, bounds) && (!topEntity || entity.zIndex > topEntity.zIndex)) {
+        topEntity = entity;
       }
     }
-    return null;
+
+    return topEntity?.id ?? null;
   }
 
   // Input event handlers (called from React component)


### PR DESCRIPTION
## Summary

Optimizes canvas entity hit-testing by replacing the per-hit-test entity array allocation and z-index sort with a single pass that tracks the highest z-index hit. Equal z-index behavior preserves insertion order, matching the previous stable-sort behavior.

## Why

Pointer hover, pointer down, touch, context menu, and double-tap paths all use hit-testing. The previous implementation sorted every entity for each query even though the caller only needs the topmost hit entity.

## Benchmark

Focused inline Bun benchmark against `GameLoop.findEntityAtPoint`:

- 10k sparse hit: `0.13409ms/op` -> `0.03953ms/op`
- 10k miss: `0.16530ms/op` -> `0.03658ms/op`

## Validation

- `bun run test -- __tests__/engine/game-loop.spec.ts`
- `bun run lint:all`
- `bun run test`
