### PR TITLE
[codex] Optimize render pipeline and harness

### DIFF
--- a/bench/render-bench.ts
+++ b/bench/render-bench.ts
@@ -33,6 +33,7 @@ interface BenchScenario {
   frames: number;
   warmupFrames: number;
   samples: number;
+  selectedEntityIndex?: number;
 }
 
 interface BenchResult {
@@ -69,6 +70,15 @@ interface VisualCaptureResult {
   metrics: VisualMetrics;
 }
 
+interface ScenarioVisualCaptureResult {
+  id: string;
+  label: string;
+  sourceSize: Size;
+  shaderType: ShaderType;
+  target: "entity" | "canvas";
+  metrics: VisualMetrics;
+}
+
 interface BenchEntitySet {
   entities: ShaderCanvasEntity[];
   beforeFrame?: (frameIndex: number) => void;
@@ -80,6 +90,12 @@ declare global {
     __voidmeshBenchResults?: BenchResult[];
     __voidmeshBenchVisual?: VisualCaptureResult;
     __captureVoidmeshRenderBenchVisual?: () => Promise<VisualCaptureResult>;
+    __captureVoidmeshRenderBenchScenarioVisual?: (
+      scenarioId: string,
+    ) => Promise<ScenarioVisualCaptureResult>;
+    __captureVoidmeshRenderBenchCanvasVisual?: (
+      scenarioId: string,
+    ) => Promise<ScenarioVisualCaptureResult>;
     __runVoidmeshRenderBenchScenario?: (scenarioId: string) => Promise<BenchResult>;
     __runVoidmeshRenderBench?: () => Promise<BenchResult[]>;
   }
@@ -107,6 +123,24 @@ const scenarios: BenchScenario[] = [
     samples: 5,
   },
   {
+    id: "image-original-4k-selected-label",
+    label: "4K image, cached original + selected label",
+    description: "Static 4K image with selected-entity label rendering each frame.",
+    kind: "image",
+    sourceSize: { width: 3840, height: 2160 },
+    shaderType: ShaderType.dithering,
+    params: {
+      showOriginal: true,
+      postProcess: { enabled: false },
+      adjustments: { brightness: 0.5, contrast: 0.5, saturation: 0.5, blur: 0 },
+    },
+    dirtyMode: "none",
+    frames: 180,
+    warmupFrames: 20,
+    samples: 5,
+    selectedEntityIndex: 0,
+  },
+  {
     id: "image-dither-4k-upload-shader",
     label: "4K image, upload + ordered dithering",
     description: "Forces source upload and shader processing each frame.",
@@ -124,6 +158,26 @@ const scenarios: BenchScenario[] = [
     dirtyMode: "texture",
     frames: 60,
     warmupFrames: 8,
+    samples: 5,
+  },
+  {
+    id: "image-dither-1080p-error-diffusion",
+    label: "1080p image, upload + Floyd-Steinberg dithering",
+    description: "Forces source upload and compute-based error-diffusion dithering each frame.",
+    kind: "image",
+    sourceSize: { width: 1920, height: 1080 },
+    shaderType: ShaderType.dithering,
+    params: {
+      size: 1,
+      scale: 1,
+      preserveColors: false,
+      dithering: { kind: DitheringKind.floydSteinberg },
+      postProcess: { enabled: false },
+      adjustments: { brightness: 0.5, contrast: 0.5, saturation: 0.5, blur: 0 },
+    },
+    dirtyMode: "texture",
+    frames: 30,
+    warmupFrames: 4,
     samples: 5,
   },
   {
@@ -203,6 +257,32 @@ const scenarios: BenchScenario[] = [
     samples: 5,
   },
   {
+    id: "image-postprocess-1440p-no-bloom",
+    label: "1440p image, shader + grain/chromatic",
+    description: "Forces post-processing without bloom to cover the no-bloom binding path.",
+    kind: "image",
+    sourceSize: { width: 2560, height: 1440 },
+    shaderType: ShaderType.halftone,
+    params: {
+      size: 10,
+      intensity: 1,
+      scale: 1,
+      shape: Shape.circle,
+      preserveColors: true,
+      postProcess: {
+        enabled: true,
+        grain: { enabled: true, size: 1, intensity: 0.12 },
+        bloom: { enabled: false, threshold: 0.35, intensity: 0, filterRadius: 21, softness: 0.1 },
+        chromaticAberration: { enabled: true, offset: 3 },
+      },
+      adjustments: { brightness: 0.5, contrast: 0.5, saturation: 0.5, blur: 0 },
+    },
+    dirtyMode: "texture",
+    frames: 60,
+    warmupFrames: 8,
+    samples: 5,
+  },
+  {
     id: "multi-25-cached-composition",
     label: "25 cached 1024px entities, composition",
     description: "Realistic many-entity composition after textures are already cached.",
@@ -258,6 +338,7 @@ const canvas = queryRequired<HTMLCanvasElement>("#bench-canvas");
 const runAllButton = queryRequired<HTMLButtonElement>("#run-all");
 const scenarioList = queryRequired<HTMLDivElement>("#scenario-list");
 const resultsEl = queryRequired<HTMLPreElement>("#results");
+const EMPTY_ENTITY_IDS: ReadonlySet<string> = new Set();
 
 canvas.style.width = `${CANVAS_WIDTH}px`;
 canvas.style.height = `${CANVAS_HEIGHT}px`;
@@ -585,11 +666,15 @@ function getEntityPosition(index: number, count: number): { x: number; y: number
   };
 }
 
-function createRenderState(entities: ShaderCanvasEntity[], dirty: boolean): RenderState {
+function createRenderState(
+  entities: ShaderCanvasEntity[],
+  dirty: boolean,
+  selectedEntityIds: ReadonlySet<string> = EMPTY_ENTITY_IDS,
+): RenderState {
   return {
     viewport: { offset: { x: 0, y: 0 }, zoom: 1 },
     entities,
-    selectedEntityIds: new Set(),
+    selectedEntityIds,
     hoveredEntityId: null,
     debugMode: false,
     dirty,
@@ -597,8 +682,16 @@ function createRenderState(entities: ShaderCanvasEntity[], dirty: boolean): Rend
     dragSelectBounds: null,
     multiSelectBounds: null,
     actionLayerActive: false,
-    actionLayerEntityIds: new Set(),
+    actionLayerEntityIds: EMPTY_ENTITY_IDS,
   };
+}
+
+function getSelectedEntityIds(
+  scenario: BenchScenario,
+  entities: readonly ShaderCanvasEntity[],
+): Set<string> {
+  const selectedEntity = scenario.selectedEntityIndex;
+  return selectedEntity === undefined ? new Set() : new Set([entities[selectedEntity]!.id]);
 }
 
 async function runFrames(params: {
@@ -607,17 +700,20 @@ async function runFrames(params: {
   frameCount: number;
   beforeFrame?: (frameIndex: number) => void;
   startFrameIndex: number;
+  selectedEntityIds?: ReadonlySet<string>;
 }): Promise<{ totalMs: number; cpuEncodeMs: number; queueDrainMs: number }> {
   const device = params.renderer.device;
   if (!device) throw new Error("Renderer device is unavailable");
 
   const start = performance.now();
   let cpuEncodeMs = 0;
+  const renderEntities = [...params.entities];
+  const selectedEntityIds = params.selectedEntityIds ?? EMPTY_ENTITY_IDS;
 
   for (let index = 0; index < params.frameCount; index += 1) {
     params.beforeFrame?.(params.startFrameIndex + index);
     const cpuStart = performance.now();
-    params.renderer.render(createRenderState([...params.entities], true));
+    params.renderer.render(createRenderState(renderEntities, true, selectedEntityIds));
     cpuEncodeMs += performance.now() - cpuStart;
   }
 
@@ -633,34 +729,40 @@ async function runFrames(params: {
 }
 
 async function runScenario(scenario: BenchScenario): Promise<BenchResult> {
+  const activeScenario = applyRuntimeOverrides(scenario);
   const benchRenderer = await getRenderer();
-  const entitySet = await createEntities(scenario);
+  const entitySet = await createEntities(activeScenario);
+  const selectedEntityIds = getSelectedEntityIds(activeScenario, entitySet.entities);
   let frameIndex = 0;
 
   try {
-    writeResults(`Running ${scenario.label}\n\nWarming up...`);
+    writeResults(`Running ${activeScenario.label}\n\nWarming up...`);
     await runFrames({
       renderer: benchRenderer,
       entities: entitySet.entities,
-      frameCount: scenario.warmupFrames,
+      frameCount: activeScenario.warmupFrames,
       beforeFrame: entitySet.beforeFrame,
       startFrameIndex: frameIndex,
+      selectedEntityIds,
     });
-    frameIndex += scenario.warmupFrames;
+    frameIndex += activeScenario.warmupFrames;
 
     const samples: number[] = [];
     const cpuSamples: number[] = [];
     const queueDrainSamples: number[] = [];
-    for (let sample = 0; sample < scenario.samples; sample += 1) {
-      writeResults(`Running ${scenario.label}\n\nSample ${sample + 1} of ${scenario.samples}...`);
+    for (let sample = 0; sample < activeScenario.samples; sample += 1) {
+      writeResults(
+        `Running ${activeScenario.label}\n\nSample ${sample + 1} of ${activeScenario.samples}...`,
+      );
       const result = await runFrames({
         renderer: benchRenderer,
         entities: entitySet.entities,
-        frameCount: scenario.frames,
+        frameCount: activeScenario.frames,
         beforeFrame: entitySet.beforeFrame,
         startFrameIndex: frameIndex,
+        selectedEntityIds,
       });
-      frameIndex += scenario.frames;
+      frameIndex += activeScenario.frames;
       samples.push(result.totalMs);
       cpuSamples.push(result.cpuEncodeMs);
       queueDrainSamples.push(result.queueDrainMs);
@@ -668,23 +770,48 @@ async function runScenario(scenario: BenchScenario): Promise<BenchResult> {
     }
 
     return {
-      id: scenario.id,
-      label: scenario.label,
-      sourceSize: scenario.sourceSize,
+      id: activeScenario.id,
+      label: activeScenario.label,
+      sourceSize: activeScenario.sourceSize,
       entityCount: entitySet.entities.length,
-      frames: scenario.frames,
+      frames: activeScenario.frames,
       samples,
       medianMs: median(samples),
       p95Ms: percentile(samples, 0.95),
-      msPerFrame: median(samples) / scenario.frames,
+      msPerFrame: median(samples) / activeScenario.frames,
       cpuEncodeMedianMs: median(cpuSamples),
       queueDrainMedianMs: median(queueDrainSamples),
-      cpuEncodeMsPerFrame: median(cpuSamples) / scenario.frames,
-      queueDrainMsPerFrame: median(queueDrainSamples) / scenario.frames,
+      cpuEncodeMsPerFrame: median(cpuSamples) / activeScenario.frames,
+      queueDrainMsPerFrame: median(queueDrainSamples) / activeScenario.frames,
     };
   } finally {
     entitySet.cleanup?.();
   }
+}
+
+function parsePositiveIntegerParam(name: string): number | null {
+  const rawValue = new URLSearchParams(window.location.search).get(name);
+  if (!rawValue) return null;
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Expected ${name} to be a positive integer, received ${rawValue}`);
+  }
+  return value;
+}
+
+function applyRuntimeOverrides(scenario: BenchScenario): BenchScenario {
+  const frames = parsePositiveIntegerParam("frames");
+  const samples = parsePositiveIntegerParam("samples");
+  const warmupFrames = parsePositiveIntegerParam("warmupFrames");
+
+  if (!frames && !samples && !warmupFrames) return scenario;
+
+  return {
+    ...scenario,
+    frames: frames ?? scenario.frames,
+    samples: samples ?? scenario.samples,
+    warmupFrames: warmupFrames ?? scenario.warmupFrames,
+  };
 }
 
 function median(values: readonly number[]): number {
@@ -784,6 +911,14 @@ async function captureBlobMetrics(blob: Blob): Promise<VisualMetrics> {
   };
 }
 
+async function canvasToPngBlob(): Promise<Blob> {
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, "image/png");
+  });
+  if (!blob) throw new Error("Could not capture benchmark canvas");
+  return blob;
+}
+
 async function captureFlowingGlassVisual(): Promise<VisualCaptureResult> {
   const benchRenderer = await getRenderer();
   const entitySet = await createEntities(flowingGlassVisualScenario);
@@ -812,6 +947,89 @@ async function captureFlowingGlassVisual(): Promise<VisualCaptureResult> {
     writeResults(JSON.stringify(result, null, 2));
     markVisualComplete(result);
     console.log("[voidmesh-render-visual]", JSON.stringify(result, null, 2));
+    return result;
+  } finally {
+    entitySet.cleanup?.();
+  }
+}
+
+async function captureScenarioVisual(scenarioId: string): Promise<ScenarioVisualCaptureResult> {
+  const scenario = scenarios.find((item) => item.id === scenarioId);
+  if (!scenario) throw new Error(`Unknown render benchmark scenario: ${scenarioId}`);
+  const benchRenderer = await getRenderer();
+  const entitySet = await createEntities(scenario);
+  const device = benchRenderer.device;
+  if (!device) throw new Error("Renderer device is unavailable");
+
+  try {
+    entitySet.beforeFrame?.(0);
+    benchRenderer.render(createRenderState(entitySet.entities, true));
+    await device.queue.onSubmittedWorkDone();
+    const blob = await benchRenderer.renderEntityToBlob(entitySet.entities[0]!, {
+      format: "png",
+      quality: 1,
+    });
+    if (!blob) throw new Error(`Could not export visual reference for ${scenarioId}`);
+
+    const result: ScenarioVisualCaptureResult = {
+      id: scenario.id,
+      label: scenario.label,
+      sourceSize: scenario.sourceSize,
+      shaderType: scenario.shaderType,
+      target: "entity",
+      metrics: await captureBlobMetrics(blob),
+    };
+    writeResults(JSON.stringify(result, null, 2));
+    markVisualComplete({
+      id: result.id,
+      label: result.label,
+      sourceSize: result.sourceSize,
+      time: 0,
+      shaderType: result.shaderType,
+      shaderKind: GlassKind.frostedVoronoi,
+      metrics: result.metrics,
+    });
+    console.log("[voidmesh-render-scenario-visual]", JSON.stringify(result, null, 2));
+    return result;
+  } finally {
+    entitySet.cleanup?.();
+  }
+}
+
+async function captureCanvasVisual(scenarioId: string): Promise<ScenarioVisualCaptureResult> {
+  const scenario = scenarios.find((item) => item.id === scenarioId);
+  if (!scenario) throw new Error(`Unknown render benchmark scenario: ${scenarioId}`);
+  const benchRenderer = await getRenderer();
+  const entitySet = await createEntities(scenario);
+  const device = benchRenderer.device;
+  const selectedEntityIds = getSelectedEntityIds(scenario, entitySet.entities);
+  if (!device) throw new Error("Renderer device is unavailable");
+
+  try {
+    entitySet.beforeFrame?.(0);
+    benchRenderer.render(createRenderState(entitySet.entities, true, selectedEntityIds));
+    await device.queue.onSubmittedWorkDone();
+    const blob = await canvasToPngBlob();
+
+    const result: ScenarioVisualCaptureResult = {
+      id: scenario.id,
+      label: scenario.label,
+      sourceSize: scenario.sourceSize,
+      shaderType: scenario.shaderType,
+      target: "canvas",
+      metrics: await captureBlobMetrics(blob),
+    };
+    writeResults(JSON.stringify(result, null, 2));
+    markVisualComplete({
+      id: result.id,
+      label: result.label,
+      sourceSize: result.sourceSize,
+      time: 0,
+      shaderType: result.shaderType,
+      shaderKind: GlassKind.frostedVoronoi,
+      metrics: result.metrics,
+    });
+    console.log("[voidmesh-render-canvas-visual]", JSON.stringify(result, null, 2));
     return result;
   } finally {
     entitySet.cleanup?.();
@@ -851,11 +1069,19 @@ runAllButton.addEventListener("click", () => {
 window.__runVoidmeshRenderBench = runAll;
 window.__runVoidmeshRenderBenchScenario = runScenarioById;
 window.__captureVoidmeshRenderBenchVisual = captureFlowingGlassVisual;
+window.__captureVoidmeshRenderBenchScenarioVisual = captureScenarioVisual;
+window.__captureVoidmeshRenderBenchCanvasVisual = captureCanvasVisual;
 
 const searchParams = new URLSearchParams(window.location.search);
 const scenarioId = searchParams.get("scenario");
+const visualScenarioId = searchParams.get("visualScenario");
+const canvasVisualScenarioId = searchParams.get("canvasVisualScenario");
 if (searchParams.get("visual") === "flowing-glass") {
   void captureFlowingGlassVisual();
+} else if (canvasVisualScenarioId) {
+  void captureCanvasVisual(canvasVisualScenarioId);
+} else if (visualScenarioId) {
+  void captureScenarioVisual(visualScenarioId);
 } else if (scenarioId) {
   void runScenarioById(scenarioId);
 } else if (searchParams.get("autorun") === "1") {

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -13,7 +13,15 @@ import {
   getViewportMatrix,
   getViewportWorldBounds,
 } from "../lib/canvas-math.ts";
-import { type Bounds, type RGBA, type ShaderCanvasEntity, type Viewport } from "#types/canvas.ts";
+import {
+  DitheringKind,
+  isErrorDiffusion,
+  ShaderType,
+  type Bounds,
+  type RGBA,
+  type ShaderCanvasEntity,
+  type Viewport,
+} from "#types/canvas.ts";
 import compositionShaderSource from "./composition.wgsl?raw";
 import { CopyPass } from "./copy-pass.ts";
 import { DisintegrationParticleSystem } from "./disintegration-particles.ts";
@@ -1218,13 +1226,17 @@ export class InfiniteCanvasRenderer {
       return sourceTexture;
     }
 
+    const needsStorageOutput =
+      entity.shaderType === ShaderType.dithering &&
+      isErrorDiffusion(entity.shaderParams.dithering?.kind ?? DitheringKind.bayer4x4);
+
     // Reuse output texture if dimensions match, otherwise create new
     const outputUsage =
       GPUTextureUsage.TEXTURE_BINDING |
       GPUTextureUsage.RENDER_ATTACHMENT |
       GPUTextureUsage.COPY_DST |
       GPUTextureUsage.COPY_SRC |
-      GPUTextureUsage.STORAGE_BINDING;
+      (needsStorageOutput ? GPUTextureUsage.STORAGE_BINDING : 0);
 
     let outputTexture: GPUTexture;
     if (cachedTexture && cachedTexture.width === width && cachedTexture.height === height) {
@@ -1242,7 +1254,7 @@ export class InfiniteCanvasRenderer {
     }
 
     // Apply shader using unified method (handles both compute and fragment shader paths)
-    this.#applyShaderToTexture(entity, sourceTexture, outputTexture, true);
+    this.#applyShaderToTexture(entity, sourceTexture, outputTexture, needsStorageOutput);
 
     // Cache and return (source texture stays in #entitySourceTextures)
     this.#entityTextures.set(entity.id, outputTexture);

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -36,6 +36,22 @@ interface CompositionDrawItem {
   offsetY: number;
 }
 
+interface EntityCompositionCacheEntry {
+  uniformBuffer: GPUBuffer;
+  texture: GPUTexture;
+  textureView: GPUTextureView;
+  bindGroup: GPUBindGroup;
+  lastHovered: boolean;
+  lastSelected: boolean;
+  lastDebugMode: boolean;
+  lastUniformX: number;
+  lastUniformY: number;
+  lastUniformWidth: number;
+  lastUniformHeight: number;
+  lastUniformRotation: number;
+  lastUniformScale: number;
+}
+
 export class InfiniteCanvasRenderer {
   readonly canvas: HTMLCanvasElement;
 
@@ -86,18 +102,7 @@ export class InfiniteCanvasRenderer {
 
   // Entity composition cache (uniform buffers, bind groups, texture views)
   // These are invalidated when entity texture changes
-  #entityCompositionCache: Map<
-    string,
-    {
-      uniformBuffer: GPUBuffer;
-      texture: GPUTexture;
-      textureView: GPUTextureView;
-      bindGroup: GPUBindGroup;
-      lastHovered: boolean;
-      lastSelected: boolean;
-      lastDebugMode: boolean;
-    }
-  > = new Map();
+  #entityCompositionCache: Map<string, EntityCompositionCacheEntry> = new Map();
 
   #gridConfig: GridConfig = config.rendering.grid.default;
   #actionLayerTintColor: [number, number, number] = config.actionLayer.dimColor.dark;
@@ -300,7 +305,8 @@ export class InfiniteCanvasRenderer {
     this.#exportService = new ExportService(
       this.#device,
       this.#texturePool,
-      (entity, source, output) => this.#applyShaderToTexture(entity, source, output),
+      (entity, source, output, outputTextureHasStorageBinding) =>
+        this.#applyShaderToTexture(entity, source, output, outputTextureHasStorageBinding),
       this.#colorConfig,
     );
 
@@ -849,6 +855,7 @@ export class InfiniteCanvasRenderer {
       width: entity.originalSize.width,
       height: entity.originalSize.height,
       respectShowOriginal: true,
+      outputTextureHasStorageBinding: _outputTextureHasStorageBinding,
     });
 
     this.#device.queue.submit([encoder.finish()]);
@@ -910,6 +917,7 @@ export class InfiniteCanvasRenderer {
     debugMode: boolean,
     positionOffsetX = 0,
     positionOffsetY = 0,
+    dragScale = entityDragVisual.getScale(entity.id),
   ): void {
     this.#entityFloatView[0] = entity.position.x + positionOffsetX;
     this.#entityFloatView[1] = entity.position.y + positionOffsetY;
@@ -919,10 +927,46 @@ export class InfiniteCanvasRenderer {
     this.#entityUintView[5] = isHovered ? 1 : 0; // isHovered flag
     this.#entityUintView[6] = isSelected ? 1 : 0; // isSelected flag
     this.#entityUintView[7] = debugMode ? 1 : 0; // debugMode flag
-    this.#entityFloatView[8] = entityDragVisual.getScale(entity.id); // visual drag scale
+    this.#entityFloatView[8] = dragScale; // visual drag scale
     this.#entityFloatView[9] = 0; // disintProgress (unused for live entities)
     this.#entityFloatView[10] = 0; // disintSeed (unused for live entities)
     this.#entityFloatView[11] = 0;
+  }
+
+  #entityCompositionUniformsChanged(
+    cached: EntityCompositionCacheEntry,
+    uniformX: number,
+    uniformY: number,
+    width: number,
+    height: number,
+    rotation: number,
+    dragScale: number,
+  ): boolean {
+    return (
+      cached.lastUniformX !== uniformX ||
+      cached.lastUniformY !== uniformY ||
+      cached.lastUniformWidth !== width ||
+      cached.lastUniformHeight !== height ||
+      cached.lastUniformRotation !== rotation ||
+      cached.lastUniformScale !== dragScale
+    );
+  }
+
+  #updateEntityCompositionUniformCache(
+    cached: EntityCompositionCacheEntry,
+    uniformX: number,
+    uniformY: number,
+    width: number,
+    height: number,
+    rotation: number,
+    dragScale: number,
+  ): void {
+    cached.lastUniformX = uniformX;
+    cached.lastUniformY = uniformY;
+    cached.lastUniformWidth = width;
+    cached.lastUniformHeight = height;
+    cached.lastUniformRotation = rotation;
+    cached.lastUniformScale = dragScale;
   }
 
   #drawCompositionItems(
@@ -930,13 +974,18 @@ export class InfiniteCanvasRenderer {
     items: readonly CompositionDrawItem[],
     selectedEntityCount: number,
   ): void {
+    if (items.length === 0) return;
+
+    const compositionPipeline = this.#compositionPipeline!;
+    pass.setPipeline(compositionPipeline);
+
     for (const item of items) {
-      pass.setPipeline(this.#compositionPipeline!);
       pass.setBindGroup(0, item.bindGroup);
       pass.draw(6);
 
       if (item.isSelected && selectedEntityCount === 1 && this.#entityLabelPass) {
         this.#entityLabelPass.drawLabel(pass, item.entity, item.offsetX, item.offsetY);
+        pass.setPipeline(compositionPipeline);
       }
     }
   }
@@ -1174,7 +1223,8 @@ export class InfiniteCanvasRenderer {
       GPUTextureUsage.TEXTURE_BINDING |
       GPUTextureUsage.RENDER_ATTACHMENT |
       GPUTextureUsage.COPY_DST |
-      GPUTextureUsage.COPY_SRC;
+      GPUTextureUsage.COPY_SRC |
+      GPUTextureUsage.STORAGE_BINDING;
 
     let outputTexture: GPUTexture;
     if (cachedTexture && cachedTexture.width === width && cachedTexture.height === height) {
@@ -1192,7 +1242,7 @@ export class InfiniteCanvasRenderer {
     }
 
     // Apply shader using unified method (handles both compute and fragment shader paths)
-    this.#applyShaderToTexture(entity, sourceTexture, outputTexture);
+    this.#applyShaderToTexture(entity, sourceTexture, outputTexture, true);
 
     // Cache and return (source texture stays in #entitySourceTextures)
     this.#entityTextures.set(entity.id, outputTexture);
@@ -1306,6 +1356,15 @@ export class InfiniteCanvasRenderer {
       // Determine if this entity is hovered or selected
       const isHovered = entity.id === hoveredEntityId;
       const isSelected = selectedEntityIds.has(entity.id);
+      const applyOffset = actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
+      const positionOffsetX = applyOffset ? actionLayerOffsetX : 0;
+      const positionOffsetY = applyOffset ? actionLayerOffsetY : 0;
+      const uniformX = entity.position.x + positionOffsetX;
+      const uniformY = entity.position.y + positionOffsetY;
+      const uniformWidth = entity.size.width;
+      const uniformHeight = entity.size.height;
+      const uniformRotation = entity.rotation;
+      const dragScale = entityDragVisual.getScale(entity.id);
 
       // Check cache for existing composition resources
       const cached = this.#entityCompositionCache.get(entity.id);
@@ -1330,15 +1389,14 @@ export class InfiniteCanvasRenderer {
           });
 
         // Update and write entity uniforms (apply rubber-band offset for action layer entities)
-        const applyOffset =
-          actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
         this.#updateEntityUniforms(
           entity,
           isHovered,
           isSelected,
           debugMode,
-          applyOffset ? actionLayerOffsetX : 0,
-          applyOffset ? actionLayerOffsetY : 0,
+          positionOffsetX,
+          positionOffsetY,
+          dragScale,
         );
         this.#device.queue.writeBuffer(uniformBuffer, 0, this.#entityUniformData);
 
@@ -1367,21 +1425,45 @@ export class InfiniteCanvasRenderer {
           lastHovered: isHovered,
           lastSelected: isSelected,
           lastDebugMode: debugMode,
+          lastUniformX: uniformX,
+          lastUniformY: uniformY,
+          lastUniformWidth: uniformWidth,
+          lastUniformHeight: uniformHeight,
+          lastUniformRotation: uniformRotation,
+          lastUniformScale: dragScale,
         });
       } else {
-        // Reuse cached bind group, but ALWAYS update uniform buffer with current position
-        // This is critical for drag operations where position changes every frame
-        const applyOffset2 =
-          actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
-        this.#updateEntityUniforms(
-          entity,
-          isHovered,
-          isSelected,
-          debugMode,
-          applyOffset2 ? actionLayerOffsetX : 0,
-          applyOffset2 ? actionLayerOffsetY : 0,
-        );
-        this.#device.queue.writeBuffer(cached.uniformBuffer, 0, this.#entityUniformData);
+        if (
+          this.#entityCompositionUniformsChanged(
+            cached,
+            uniformX,
+            uniformY,
+            uniformWidth,
+            uniformHeight,
+            uniformRotation,
+            dragScale,
+          )
+        ) {
+          this.#updateEntityUniforms(
+            entity,
+            isHovered,
+            isSelected,
+            debugMode,
+            positionOffsetX,
+            positionOffsetY,
+            dragScale,
+          );
+          this.#device.queue.writeBuffer(cached.uniformBuffer, 0, this.#entityUniformData);
+          this.#updateEntityCompositionUniformCache(
+            cached,
+            uniformX,
+            uniformY,
+            uniformWidth,
+            uniformHeight,
+            uniformRotation,
+            dragScale,
+          );
+        }
         bindGroup = cached.bindGroup;
       }
 
@@ -1393,8 +1475,8 @@ export class InfiniteCanvasRenderer {
           bindGroup,
           entity,
           isSelected,
-          offsetX: actionLayerOffsetX,
-          offsetY: actionLayerOffsetY,
+          offsetX: positionOffsetX,
+          offsetY: positionOffsetY,
         });
       } else {
         entityDrawItems.push({

--- a/renderer/copy-pass.ts
+++ b/renderer/copy-pass.ts
@@ -13,6 +13,8 @@ export class CopyPass {
   #pipeline: GPURenderPipeline;
   #bindGroupLayout: GPUBindGroupLayout;
   #sampler: GPUSampler;
+  #textureViewCache = new WeakMap<GPUTexture, GPUTextureView>();
+  #bindGroupCache = new WeakMap<GPUTexture, GPUBindGroup>();
 
   constructor(device: GPUDevice, targetFormat: GPUTextureFormat = "rgba8unorm") {
     this.#device = device;
@@ -67,16 +69,10 @@ export class CopyPass {
     source: GPUTexture,
     destination: GPUTexture | GPUTextureView,
   ): void {
-    const destinationView = "createView" in destination ? destination.createView() : destination;
+    const destinationView =
+      "createView" in destination ? this.#getTextureView(destination) : destination;
 
-    const bindGroup = this.#device.createBindGroup({
-      label: "CopyPass bind group",
-      layout: this.#bindGroupLayout,
-      entries: [
-        { binding: 0, resource: source.createView() },
-        { binding: 1, resource: this.#sampler },
-      ],
-    });
+    const bindGroup = this.#getBindGroup(source);
 
     const pass = encoder.beginRenderPass({
       label: "CopyPass render pass",
@@ -94,6 +90,31 @@ export class CopyPass {
     pass.setBindGroup(0, bindGroup);
     pass.draw(3);
     pass.end();
+  }
+
+  #getTextureView(texture: GPUTexture): GPUTextureView {
+    const cached = this.#textureViewCache.get(texture);
+    if (cached) return cached;
+
+    const view = texture.createView();
+    this.#textureViewCache.set(texture, view);
+    return view;
+  }
+
+  #getBindGroup(source: GPUTexture): GPUBindGroup {
+    const cached = this.#bindGroupCache.get(source);
+    if (cached) return cached;
+
+    const bindGroup = this.#device.createBindGroup({
+      label: "CopyPass bind group",
+      layout: this.#bindGroupLayout,
+      entries: [
+        { binding: 0, resource: this.#getTextureView(source) },
+        { binding: 1, resource: this.#sampler },
+      ],
+    });
+    this.#bindGroupCache.set(source, bindGroup);
+    return bindGroup;
   }
 
   /**

--- a/renderer/dithering.wgsl
+++ b/renderer/dithering.wgsl
@@ -28,7 +28,7 @@ fn bayer2x2(pos: vec2u) -> f32 {
     0.0, 2.0,
     3.0, 1.0
   );
-  let idx = (pos.y % 2u) * 2u + (pos.x % 2u);
+  let idx = (pos.y & 1u) * 2u + (pos.x & 1u);
   return (matrix[idx] + 0.5) / 4.0;
 }
 
@@ -40,7 +40,7 @@ fn bayer4x4(pos: vec2u) -> f32 {
      3.0, 11.0,  1.0,  9.0,
     15.0,  7.0, 13.0,  5.0
   );
-  let idx = (pos.y % 4u) * 4u + (pos.x % 4u);
+  let idx = (pos.y & 3u) * 4u + (pos.x & 3u);
   return (matrix[idx] + 0.5) / 16.0;
 }
 
@@ -56,7 +56,7 @@ fn bayer8x8(pos: vec2u) -> f32 {
     15.0, 47.0,  7.0, 39.0, 13.0, 45.0,  5.0, 37.0,
     63.0, 31.0, 55.0, 23.0, 61.0, 29.0, 53.0, 21.0
   );
-  let idx = (pos.y % 8u) * 8u + (pos.x % 8u);
+  let idx = (pos.y & 7u) * 8u + (pos.x & 7u);
   return (matrix[idx] + 0.5) / 64.0;
 }
 

--- a/renderer/entity-label-pass.ts
+++ b/renderer/entity-label-pass.ts
@@ -60,6 +60,11 @@ interface LabelCacheEntry {
   textureWidth: number;
   textureHeight: number;
   rasterState: LabelRasterState;
+  lastUniformX: number;
+  lastUniformY: number;
+  lastUniformWidth: number;
+  lastUniformHeight: number;
+  lastUniformOpacity: number;
 }
 
 interface LabelRasterState {
@@ -100,6 +105,7 @@ export class EntityLabelPass {
 
   // Per-entity label cache
   #cache = new Map<string, LabelCacheEntry>();
+  #uniformData = new Float32Array(UNIFORM_SIZE / 4);
 
   // Shared animation state (drag icon affects all labels identically)
   #dragIconProgress = 0;
@@ -230,13 +236,27 @@ export class EntityLabelPass {
 
     // ── Write uniforms and draw ────────────────────────────────────────────
 
-    const data = new Float32Array(UNIFORM_SIZE / 4);
-    data[0] = worldX;
-    data[1] = worldY;
-    data[2] = worldWidth;
-    data[3] = worldHeight;
-    data[4] = 1; // opacity
-    this.#device.queue.writeBuffer(cached.uniformBuffer, 0, data);
+    const opacity = 1;
+    if (
+      cached.lastUniformX !== worldX ||
+      cached.lastUniformY !== worldY ||
+      cached.lastUniformWidth !== worldWidth ||
+      cached.lastUniformHeight !== worldHeight ||
+      cached.lastUniformOpacity !== opacity
+    ) {
+      const data = this.#uniformData;
+      data[0] = worldX;
+      data[1] = worldY;
+      data[2] = worldWidth;
+      data[3] = worldHeight;
+      data[4] = opacity;
+      this.#device.queue.writeBuffer(cached.uniformBuffer, 0, data);
+      cached.lastUniformX = worldX;
+      cached.lastUniformY = worldY;
+      cached.lastUniformWidth = worldWidth;
+      cached.lastUniformHeight = worldHeight;
+      cached.lastUniformOpacity = opacity;
+    }
 
     pass.setPipeline(this.#pipeline);
     pass.setBindGroup(0, cached.bindGroup);
@@ -371,6 +391,11 @@ export class EntityLabelPass {
       textureWidth: width,
       textureHeight: height,
       rasterState,
+      lastUniformX: Number.NaN,
+      lastUniformY: Number.NaN,
+      lastUniformWidth: Number.NaN,
+      lastUniformHeight: Number.NaN,
+      lastUniformOpacity: Number.NaN,
     };
   }
 

--- a/renderer/entity-shader-runtime.ts
+++ b/renderer/entity-shader-runtime.ts
@@ -119,6 +119,7 @@ export class EntityShaderRuntime {
     width: number;
     height: number;
     respectShowOriginal: boolean;
+    outputTextureHasStorageBinding?: boolean;
   }): void {
     const { entity, sourceTexture, outputTexture, encoder, width, height } = params;
 
@@ -169,9 +170,11 @@ export class EntityShaderRuntime {
     const postProcessUsage =
       GPUTextureUsage.TEXTURE_BINDING |
       GPUTextureUsage.RENDER_ATTACHMENT |
-      GPUTextureUsage.COPY_DST;
+      GPUTextureUsage.COPY_DST |
+      GPUTextureUsage.STORAGE_BINDING;
     let mainShaderOutputTexture = outputTexture;
     let postProcessIntermediateTexture: GPUTexture | null = null;
+    let mainShaderOutputHasStorageBinding = params.outputTextureHasStorageBinding ?? false;
 
     if (postProcessEnabled) {
       postProcessIntermediateTexture = this.#acquireTexture(
@@ -181,9 +184,16 @@ export class EntityShaderRuntime {
         "Post-process intermediate texture",
       );
       mainShaderOutputTexture = postProcessIntermediateTexture;
+      mainShaderOutputHasStorageBinding = true;
     }
 
-    this.#shaderRegistry.applyShader(entity, shaderSourceTexture, mainShaderOutputTexture, encoder);
+    this.#shaderRegistry.applyShader(
+      entity,
+      shaderSourceTexture,
+      mainShaderOutputTexture,
+      encoder,
+      mainShaderOutputHasStorageBinding,
+    );
 
     if (blurOutputTexture) {
       this.#releaseTexture(blurOutputTexture, width, height, preProcessUsage);

--- a/renderer/export-service.ts
+++ b/renderer/export-service.ts
@@ -14,6 +14,7 @@ export type ApplyShaderFn = (
   entity: ShaderCanvasEntity,
   sourceTexture: GPUTexture,
   outputTexture: GPUTexture,
+  outputTextureHasStorageBinding?: boolean,
 ) => void;
 
 export class ExportService {
@@ -177,7 +178,8 @@ export class ExportService {
       GPUTextureUsage.TEXTURE_BINDING |
       GPUTextureUsage.RENDER_ATTACHMENT |
       GPUTextureUsage.COPY_SRC |
-      GPUTextureUsage.COPY_DST;
+      GPUTextureUsage.COPY_DST |
+      GPUTextureUsage.STORAGE_BINDING;
 
     const sourceTexture = this.#device.createTexture({
       label: "Export source texture",
@@ -205,7 +207,7 @@ export class ExportService {
           usage: outputUsage,
         });
 
-    this.#applyShader(entity, sourceTexture, outputTexture);
+    this.#applyShader(entity, sourceTexture, outputTexture, true);
 
     const bitmap = await this.#convertToImageBitmap(outputTexture, width, height);
 

--- a/renderer/post-process.wgsl
+++ b/renderer/post-process.wgsl
@@ -35,9 +35,14 @@ fn hash(p: vec2f) -> f32 {
 }
 
 // Generate film grain noise
-fn grain(uv: vec2f, time: f32, size: f32, intensity: f32) -> f32 {
+fn grain(pixelPos: vec2f, time: f32, size: f32, intensity: f32) -> f32 {
   // Scale UV by grain size (larger size = larger grain blocks)
-  let scaledUV = floor(uv * uniforms.resolution / max(size, 1.0));
+  var scaledUV: vec2f;
+  if (size <= 1.0) {
+    scaledUV = floor(pixelPos);
+  } else {
+    scaledUV = floor(pixelPos / size);
+  }
 
   // Add time variation for animated grain
   let noise = hash(scaledUV + vec2f(time * 100.0, time * 73.0));
@@ -109,7 +114,7 @@ fn fs_main(@builtin(position) fragCoord: vec4f) -> @location(0) vec4f {
 
   // Apply grain (last, adds noise on top)
   if ((flags & FLAG_GRAIN) != 0u && uniforms.grain_intensity > 0.0) {
-    let grainValue = grain(uv, uniforms.time, uniforms.grain_size, uniforms.grain_intensity);
+    let grainValue = grain(fragCoord.xy, uniforms.time, uniforms.grain_size, uniforms.grain_intensity);
     color += vec3f(grainValue);
   }
 

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -19,6 +19,7 @@ export class ProcessingPipeline {
   #device: GPUDevice;
   #intermediateFormat: GPUTextureFormat;
   #supportsP3: boolean;
+  #textureViewCache = new WeakMap<GPUTexture, GPUTextureView>();
 
   // Adjustments (pre-processing) pipeline
   #adjustmentsPipeline: GPURenderPipeline | null = null;
@@ -27,6 +28,7 @@ export class ProcessingPipeline {
   #adjustmentsSampler: GPUSampler | null = null;
   #adjustmentsUniformData = new ArrayBuffer(config.rendering.adjustmentsUniformSize);
   #adjustmentsFloatView = new Float32Array(this.#adjustmentsUniformData);
+  #adjustmentsBindGroupCache = new WeakMap<GPUTexture, GPUBindGroup>();
 
   // Dual Kawase blur (pre-processing) pipeline
   #blurDownsamplePipeline: GPURenderPipeline | null = null;
@@ -50,6 +52,11 @@ export class ProcessingPipeline {
   #blurMixPipeline: GPURenderPipeline | null = null;
   #blurMixBindGroupLayout: GPUBindGroupLayout | null = null;
   #blurMixUniformBuffer: GPUBuffer | null = null;
+  #blurUniformData = new ArrayBuffer(config.rendering.blurUniformSize);
+  #blurFloatView = new Float32Array(this.#blurUniformData);
+  #blurDownsampleBindGroupCaches: WeakMap<GPUTexture, GPUBindGroup>[] = [];
+  #blurUpsampleBindGroupCaches: WeakMap<GPUTexture, GPUBindGroup>[] = [];
+  #blurMixBindGroupCache = new WeakMap<GPUTexture, WeakMap<GPUTexture, GPUBindGroup>>();
   // Blend textures cached per entity dimensions (keyed by "WxH")
   #blurBlendTextureCache: Map<
     string,
@@ -70,6 +77,8 @@ export class ProcessingPipeline {
   #postProcessFloatView = new Float32Array(this.#postProcessUniformData);
   #postProcessUintView = new Uint32Array(this.#postProcessUniformData);
   #postProcessTime = 0; // Animated time for grain effect
+  #postProcessBindGroupCache = new WeakMap<GPUTexture, WeakMap<GPUTexture, GPUBindGroup>>();
+  #dummyBloomTexture: GPUTexture | null = null;
 
   // Bloom pipeline (multi-pass downsample/upsample)
   #bloomDownsamplePipeline: GPURenderPipeline | null = null;
@@ -80,6 +89,13 @@ export class ProcessingPipeline {
   #bloomDownsampleUniformBuffers: GPUBuffer[] = [];
   #bloomUpsampleUniformBuffers: GPUBuffer[] = [];
   #bloomSampler: GPUSampler | null = null;
+  #bloomDownsampleUniformData = new ArrayBuffer(32);
+  #bloomDownsampleFloatView = new Float32Array(this.#bloomDownsampleUniformData);
+  #bloomDownsampleUintView = new Uint32Array(this.#bloomDownsampleUniformData);
+  #bloomUpsampleUniformData = new ArrayBuffer(16);
+  #bloomUpsampleFloatView = new Float32Array(this.#bloomUpsampleUniformData);
+  #bloomDownsampleBindGroupCaches: WeakMap<GPUTexture, GPUBindGroup>[] = [];
+  #bloomUpsampleBindGroupCaches: WeakMap<GPUTexture, GPUBindGroup>[] = [];
   // Bloom mip chain textures (cached per entity dimensions)
   #bloomMipChainCache: Map<
     string,
@@ -102,6 +118,115 @@ export class ProcessingPipeline {
     this.#createBlurMixPipeline();
     this.#createPostProcessPipeline();
     this.#createBloomPipelines();
+  }
+
+  #getTextureView(texture: GPUTexture): GPUTextureView {
+    const cached = this.#textureViewCache.get(texture);
+    if (cached) return cached;
+
+    const view = texture.createView();
+    this.#textureViewCache.set(texture, view);
+    return view;
+  }
+
+  #getTextureBindGroup(
+    cache: WeakMap<GPUTexture, GPUBindGroup>,
+    texture: GPUTexture,
+    layout: GPUBindGroupLayout,
+    uniformBuffer: GPUBuffer,
+    sampler: GPUSampler,
+    label: string,
+  ): GPUBindGroup {
+    const cached = cache.get(texture);
+    if (cached) return cached;
+
+    const bindGroup = this.#device.createBindGroup({
+      label,
+      layout,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: this.#getTextureView(texture) },
+        { binding: 2, resource: sampler },
+      ],
+    });
+    cache.set(texture, bindGroup);
+    return bindGroup;
+  }
+
+  #getIndexedTextureBindGroup(
+    caches: WeakMap<GPUTexture, GPUBindGroup>[],
+    index: number,
+    texture: GPUTexture,
+    layout: GPUBindGroupLayout,
+    uniformBuffer: GPUBuffer,
+    sampler: GPUSampler,
+    label: string,
+  ): GPUBindGroup {
+    let cache = caches[index];
+    if (!cache) {
+      cache = new WeakMap();
+      caches[index] = cache;
+    }
+    return this.#getTextureBindGroup(cache, texture, layout, uniformBuffer, sampler, label);
+  }
+
+  #getBlurMixBindGroup(textureA: GPUTexture, textureB: GPUTexture): GPUBindGroup {
+    let cache = this.#blurMixBindGroupCache.get(textureA);
+    if (!cache) {
+      cache = new WeakMap();
+      this.#blurMixBindGroupCache.set(textureA, cache);
+    }
+
+    const cached = cache.get(textureB);
+    if (cached) return cached;
+
+    const bindGroup = this.#device.createBindGroup({
+      label: "Blur mix bind group",
+      layout: this.#blurMixBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: this.#blurMixUniformBuffer! } },
+        { binding: 1, resource: this.#getTextureView(textureA) },
+        { binding: 2, resource: this.#getTextureView(textureB) },
+        { binding: 3, resource: this.#blurSampler! },
+      ],
+    });
+    cache.set(textureB, bindGroup);
+    return bindGroup;
+  }
+
+  #getPostProcessBindGroup(inputTexture: GPUTexture, bloomTexture: GPUTexture): GPUBindGroup {
+    let cache = this.#postProcessBindGroupCache.get(inputTexture);
+    if (!cache) {
+      cache = new WeakMap();
+      this.#postProcessBindGroupCache.set(inputTexture, cache);
+    }
+
+    const cached = cache.get(bloomTexture);
+    if (cached) return cached;
+
+    const bindGroup = this.#device.createBindGroup({
+      label: "Post-process bind group",
+      layout: this.#postProcessBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: this.#postProcessUniformBuffer! } },
+        { binding: 1, resource: this.#getTextureView(inputTexture) },
+        { binding: 2, resource: this.#postProcessSampler! },
+        { binding: 3, resource: this.#getTextureView(bloomTexture) },
+      ],
+    });
+    cache.set(bloomTexture, bindGroup);
+    return bindGroup;
+  }
+
+  #getDummyBloomTexture(): GPUTexture {
+    if (this.#dummyBloomTexture) return this.#dummyBloomTexture;
+    this.#dummyBloomTexture = this.#device.createTexture({
+      label: "Dummy bloom texture",
+      size: [1, 1],
+      format: this.#intermediateFormat,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+    });
+    return this.#dummyBloomTexture;
   }
 
   #createAdjustmentsPipeline(): void {
@@ -422,6 +547,7 @@ export class ProcessingPipeline {
         topology: "triangle-list",
       },
     });
+
   }
 
   /**
@@ -654,19 +780,22 @@ export class ProcessingPipeline {
     const softKnee = softness;
 
     for (let i = 0; i < mipChain.length; i++) {
-      const uniformData = new ArrayBuffer(32);
-      const floatView = new Float32Array(uniformData);
-      const uintView = new Uint32Array(uniformData);
-      floatView[0] = srcWidth;
-      floatView[1] = srcHeight;
-      uintView[2] = i;
-      uintView[3] = i === 0 && threshold > 0 ? 1 : 0;
-      floatView[4] = threshold;
-      floatView[5] = softKnee;
-      uintView[6] = this.#supportsP3 ? 1 : 0;
-      floatView[7] = 0;
+      const f = this.#bloomDownsampleFloatView;
+      const u = this.#bloomDownsampleUintView;
+      f[0] = srcWidth;
+      f[1] = srcHeight;
+      u[2] = i;
+      u[3] = i === 0 && threshold > 0 ? 1 : 0;
+      f[4] = threshold;
+      f[5] = softKnee;
+      u[6] = this.#supportsP3 ? 1 : 0;
+      f[7] = 0;
 
-      this.#device.queue.writeBuffer(this.#bloomDownsampleUniformBuffers[i]!, 0, uniformData);
+      this.#device.queue.writeBuffer(
+        this.#bloomDownsampleUniformBuffers[i]!,
+        0,
+        this.#bloomDownsampleUniformData,
+      );
 
       srcWidth = Math.max(1, Math.floor(srcWidth / 2));
       srcHeight = Math.max(1, Math.floor(srcHeight / 2));
@@ -674,19 +803,18 @@ export class ProcessingPipeline {
 
     for (let i = mipChain.length - 1; i > 0; i--) {
       const dstMip = mipChain[i - 1]!;
-      const upsampleUniformData = new ArrayBuffer(16);
-      const upsampleFloatView = new Float32Array(upsampleUniformData);
-      upsampleFloatView[0] = filterRadius;
-      upsampleFloatView[1] = 0;
-      upsampleFloatView[2] = dstMip.width;
-      upsampleFloatView[3] = dstMip.height;
+      const f = this.#bloomUpsampleFloatView;
+      f[0] = filterRadius;
+      f[1] = 0;
+      f[2] = dstMip.width;
+      f[3] = dstMip.height;
 
       // Map pass index: i goes from mipChain.length-1 down to 1, buffer index = mipChain.length-1-i
       const bufIdx = mipChain.length - 1 - i;
       this.#device.queue.writeBuffer(
         this.#bloomUpsampleUniformBuffers[bufIdx]!,
         0,
-        upsampleUniformData,
+        this.#bloomUpsampleUniformData,
       );
     }
 
@@ -697,24 +825,21 @@ export class ProcessingPipeline {
       const dstWidth = dstTexture.width;
       const dstHeight = dstTexture.height;
 
-      const bindGroup = this.#device.createBindGroup({
-        label: `Bloom downsample bind group mip ${i}`,
-        layout: this.#bloomDownsampleBindGroupLayout,
-        entries: [
-          {
-            binding: 0,
-            resource: { buffer: this.#bloomDownsampleUniformBuffers[i]! },
-          },
-          { binding: 1, resource: srcTexture.createView() },
-          { binding: 2, resource: this.#bloomSampler },
-        ],
-      });
+      const bindGroup = this.#getIndexedTextureBindGroup(
+        this.#bloomDownsampleBindGroupCaches,
+        i,
+        srcTexture,
+        this.#bloomDownsampleBindGroupLayout,
+        this.#bloomDownsampleUniformBuffers[i]!,
+        this.#bloomSampler,
+        `Bloom downsample bind group mip ${i}`,
+      );
 
       const pass = encoder.beginRenderPass({
         label: `Bloom downsample pass mip ${i}`,
         colorAttachments: [
           {
-            view: dstTexture.createView(),
+            view: this.#getTextureView(dstTexture),
             loadOp: "clear",
             storeOp: "store",
             clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -739,24 +864,21 @@ export class ProcessingPipeline {
       const dstHeight = dstMip.height;
       const bufIdx = mipChain.length - 1 - i;
 
-      const bindGroup = this.#device.createBindGroup({
-        label: `Bloom upsample bind group mip ${i}`,
-        layout: this.#bloomUpsampleBindGroupLayout,
-        entries: [
-          {
-            binding: 0,
-            resource: { buffer: this.#bloomUpsampleUniformBuffers[bufIdx]! },
-          },
-          { binding: 1, resource: srcMip.createView() },
-          { binding: 2, resource: this.#bloomSampler },
-        ],
-      });
+      const bindGroup = this.#getIndexedTextureBindGroup(
+        this.#bloomUpsampleBindGroupCaches,
+        bufIdx,
+        srcMip,
+        this.#bloomUpsampleBindGroupLayout,
+        this.#bloomUpsampleUniformBuffers[bufIdx]!,
+        this.#bloomSampler,
+        `Bloom upsample bind group mip ${i}`,
+      );
 
       const pass = encoder.beginRenderPass({
         label: `Bloom upsample pass mip ${i}`,
         colorAttachments: [
           {
-            view: dstMip.createView(),
+            view: this.#getTextureView(dstMip),
             loadOp: "load",
             storeOp: "store",
           },
@@ -916,17 +1038,16 @@ export class ProcessingPipeline {
     let srcWidth = width;
     let srcHeight = height;
     for (let i = 0; i < activeLevels; i++) {
-      const uniformData = new ArrayBuffer(config.rendering.blurUniformSize);
-      const floatView = new Float32Array(uniformData);
-      floatView[0] = srcWidth; // src_resolution.x
-      floatView[1] = srcHeight; // src_resolution.y
-      floatView[2] = offset; // per-pass offset
-      floatView[3] = 0; // padding
+      const f = this.#blurFloatView;
+      f[0] = srcWidth; // src_resolution.x
+      f[1] = srcHeight; // src_resolution.y
+      f[2] = offset; // per-pass offset
+      f[3] = 0; // padding
 
       this.#device.queue.writeBuffer(
         this.#blurDownsampleUniformBuffers[bufferOffset + i]!,
         0,
-        uniformData,
+        this.#blurUniformData,
       );
 
       srcWidth = Math.max(1, Math.floor(srcWidth / 2));
@@ -937,34 +1058,32 @@ export class ProcessingPipeline {
     let bufIdx = 0;
     for (let i = activeLevels - 1; i > 0; i--) {
       const dstMip = mipChain[i - 1]!;
-      const uniformData = new ArrayBuffer(config.rendering.blurUniformSize);
-      const floatView = new Float32Array(uniformData);
-      floatView[0] = dstMip.width; // dst_resolution.x
-      floatView[1] = dstMip.height; // dst_resolution.y
-      floatView[2] = offset; // per-pass offset
-      floatView[3] = 0; // padding
+      const f = this.#blurFloatView;
+      f[0] = dstMip.width; // dst_resolution.x
+      f[1] = dstMip.height; // dst_resolution.y
+      f[2] = offset; // per-pass offset
+      f[3] = 0; // padding
 
       this.#device.queue.writeBuffer(
         this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
         0,
-        uniformData,
+        this.#blurUniformData,
       );
       bufIdx++;
     }
 
     // Final upsample uniform: mip[0] -> full resolution
     {
-      const uniformData = new ArrayBuffer(config.rendering.blurUniformSize);
-      const floatView = new Float32Array(uniformData);
-      floatView[0] = width; // dst_resolution.x (full res)
-      floatView[1] = height; // dst_resolution.y (full res)
-      floatView[2] = offset; // per-pass offset
-      floatView[3] = 0; // padding
+      const f = this.#blurFloatView;
+      f[0] = width; // dst_resolution.x (full res)
+      f[1] = height; // dst_resolution.y (full res)
+      f[2] = offset; // per-pass offset
+      f[3] = 0; // padding
 
       this.#device.queue.writeBuffer(
         this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
         0,
-        uniformData,
+        this.#blurUniformData,
       );
     }
 
@@ -973,26 +1092,21 @@ export class ProcessingPipeline {
     for (let i = 0; i < activeLevels; i++) {
       const dstTexture = mipChain[i]!;
 
-      const bindGroup = this.#device.createBindGroup({
-        label: `Blur downsample bind group level ${i}`,
-        layout: this.#blurDownsampleBindGroupLayout!,
-        entries: [
-          {
-            binding: 0,
-            resource: {
-              buffer: this.#blurDownsampleUniformBuffers[bufferOffset + i]!,
-            },
-          },
-          { binding: 1, resource: srcTexture.createView() },
-          { binding: 2, resource: this.#blurSampler! },
-        ],
-      });
+      const bindGroup = this.#getIndexedTextureBindGroup(
+        this.#blurDownsampleBindGroupCaches,
+        bufferOffset + i,
+        srcTexture,
+        this.#blurDownsampleBindGroupLayout!,
+        this.#blurDownsampleUniformBuffers[bufferOffset + i]!,
+        this.#blurSampler!,
+        `Blur downsample bind group level ${i}`,
+      );
 
       const pass = encoder.beginRenderPass({
         label: `Blur downsample pass level ${i}`,
         colorAttachments: [
           {
-            view: dstTexture.createView(),
+            view: this.#getTextureView(dstTexture),
             loadOp: "clear",
             storeOp: "store",
             clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -1015,26 +1129,21 @@ export class ProcessingPipeline {
       const srcMip = mipChain[i]!;
       const dstMip = mipChain[i - 1]!;
 
-      const bindGroup = this.#device.createBindGroup({
-        label: `Blur upsample bind group level ${i}`,
-        layout: this.#blurUpsampleBindGroupLayout!,
-        entries: [
-          {
-            binding: 0,
-            resource: {
-              buffer: this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
-            },
-          },
-          { binding: 1, resource: srcMip.createView() },
-          { binding: 2, resource: this.#blurSampler! },
-        ],
-      });
+      const bindGroup = this.#getIndexedTextureBindGroup(
+        this.#blurUpsampleBindGroupCaches,
+        bufferOffset + bufIdx,
+        srcMip,
+        this.#blurUpsampleBindGroupLayout!,
+        this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
+        this.#blurSampler!,
+        `Blur upsample bind group level ${i}`,
+      );
 
       const pass = encoder.beginRenderPass({
         label: `Blur upsample pass level ${i}`,
         colorAttachments: [
           {
-            view: dstMip.createView(),
+            view: this.#getTextureView(dstMip),
             loadOp: "clear",
             storeOp: "store",
             clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -1055,26 +1164,21 @@ export class ProcessingPipeline {
     {
       const srcMip = mipChain[0]!;
 
-      const bindGroup = this.#device.createBindGroup({
-        label: "Blur final upsample bind group",
-        layout: this.#blurUpsampleBindGroupLayout!,
-        entries: [
-          {
-            binding: 0,
-            resource: {
-              buffer: this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
-            },
-          },
-          { binding: 1, resource: srcMip.createView() },
-          { binding: 2, resource: this.#blurSampler! },
-        ],
-      });
+      const bindGroup = this.#getIndexedTextureBindGroup(
+        this.#blurUpsampleBindGroupCaches,
+        bufferOffset + bufIdx,
+        srcMip,
+        this.#blurUpsampleBindGroupLayout!,
+        this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
+        this.#blurSampler!,
+        "Blur final upsample bind group",
+      );
 
       const pass = encoder.beginRenderPass({
         label: "Blur final upsample pass",
         colorAttachments: [
           {
-            view: finalTarget.createView(),
+            view: this.#getTextureView(finalTarget),
             loadOp: "clear",
             storeOp: "store",
             clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -1102,31 +1206,21 @@ export class ProcessingPipeline {
     width: number,
     height: number,
   ): void {
-    const uniformData = new ArrayBuffer(config.rendering.blurUniformSize);
-    const floatView = new Float32Array(uniformData);
-    floatView[0] = width;
-    floatView[1] = height;
-    floatView[2] = mixFactor;
-    floatView[3] = 0; // padding
+    const f = this.#blurFloatView;
+    f[0] = width;
+    f[1] = height;
+    f[2] = mixFactor;
+    f[3] = 0; // padding
 
-    this.#device.queue.writeBuffer(this.#blurMixUniformBuffer!, 0, uniformData);
+    this.#device.queue.writeBuffer(this.#blurMixUniformBuffer!, 0, this.#blurUniformData);
 
-    const bindGroup = this.#device.createBindGroup({
-      label: "Blur mix bind group",
-      layout: this.#blurMixBindGroupLayout!,
-      entries: [
-        { binding: 0, resource: { buffer: this.#blurMixUniformBuffer! } },
-        { binding: 1, resource: textureA.createView() },
-        { binding: 2, resource: textureB.createView() },
-        { binding: 3, resource: this.#blurSampler! },
-      ],
-    });
+    const bindGroup = this.#getBlurMixBindGroup(textureA, textureB);
 
     const pass = encoder.beginRenderPass({
       label: "Blur mix pass",
       colorAttachments: [
         {
-          view: outputTexture.createView(),
+          view: this.#getTextureView(outputTexture),
           loadOp: "clear",
           storeOp: "store",
           clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -1285,21 +1379,20 @@ export class ProcessingPipeline {
     this.#updateAdjustmentsUniforms(entity);
     this.#device.queue.writeBuffer(this.#adjustmentsUniformBuffer, 0, this.#adjustmentsUniformData);
 
-    const bindGroup = this.#device.createBindGroup({
-      label: "Adjustments bind group",
-      layout: this.#adjustmentsBindGroupLayout,
-      entries: [
-        { binding: 0, resource: { buffer: this.#adjustmentsUniformBuffer } },
-        { binding: 1, resource: inputTexture.createView() },
-        { binding: 2, resource: this.#adjustmentsSampler },
-      ],
-    });
+    const bindGroup = this.#getTextureBindGroup(
+      this.#adjustmentsBindGroupCache,
+      inputTexture,
+      this.#adjustmentsBindGroupLayout,
+      this.#adjustmentsUniformBuffer,
+      this.#adjustmentsSampler,
+      "Adjustments bind group",
+    );
 
     const pass = encoder.beginRenderPass({
       label: "Adjustments render pass",
       colorAttachments: [
         {
-          view: outputTexture.createView(),
+          view: this.#getTextureView(outputTexture),
           loadOp: "clear",
           storeOp: "store",
           clearValue: { r: 0, g: 0, b: 0, a: 0 },
@@ -1392,40 +1485,17 @@ export class ProcessingPipeline {
       );
     }
 
-    // If no bloom texture was generated, create a 1x1 black texture as placeholder
-    // (the shader expects a texture at binding 3)
-    let bloomTextureView: GPUTextureView;
-    if (bloomTexture) {
-      bloomTextureView = bloomTexture.createView();
-    } else {
-      const dummyTexture = this.#device.createTexture({
-        label: "Dummy bloom texture",
-        size: [1, 1],
-        format: this.#intermediateFormat,
-        usage: GPUTextureUsage.TEXTURE_BINDING,
-      });
-      bloomTextureView = dummyTexture.createView();
-    }
-
     this.#updatePostProcessUniforms(entity);
     this.#device.queue.writeBuffer(this.#postProcessUniformBuffer, 0, this.#postProcessUniformData);
 
-    const bindGroup = this.#device.createBindGroup({
-      label: "Post-process bind group",
-      layout: this.#postProcessBindGroupLayout,
-      entries: [
-        { binding: 0, resource: { buffer: this.#postProcessUniformBuffer } },
-        { binding: 1, resource: inputTexture.createView() },
-        { binding: 2, resource: this.#postProcessSampler },
-        { binding: 3, resource: bloomTextureView },
-      ],
-    });
+    const bloomBindingTexture = bloomTexture ?? this.#getDummyBloomTexture();
+    const bindGroup = this.#getPostProcessBindGroup(inputTexture, bloomBindingTexture);
 
     const pass = encoder.beginRenderPass({
       label: "Post-process render pass",
       colorAttachments: [
         {
-          view: outputTexture.createView(),
+          view: this.#getTextureView(outputTexture),
           loadOp: "clear",
           storeOp: "store",
           clearValue: { r: 0, g: 0, b: 0, a: 0 },
@@ -1451,7 +1521,7 @@ export class ProcessingPipeline {
     this.#blurMixUniformBuffer?.destroy();
     for (const buf of this.#bloomDownsampleUniformBuffers) buf.destroy();
     for (const buf of this.#bloomUpsampleUniformBuffers) buf.destroy();
-
+    this.#dummyBloomTexture?.destroy();
     // Destroy blur mip chain textures
     for (const cached of this.#blurMipChainCache.values()) {
       for (const texture of cached.textures) {
@@ -1475,6 +1545,15 @@ export class ProcessingPipeline {
     }
     this.#bloomMipChainCache.clear();
 
+    this.#textureViewCache = new WeakMap();
+    this.#adjustmentsBindGroupCache = new WeakMap();
+    this.#blurDownsampleBindGroupCaches = [];
+    this.#blurUpsampleBindGroupCaches = [];
+    this.#blurMixBindGroupCache = new WeakMap();
+    this.#postProcessBindGroupCache = new WeakMap();
+    this.#bloomDownsampleBindGroupCaches = [];
+    this.#bloomUpsampleBindGroupCaches = [];
+
     // Clear pipeline references
     this.#adjustmentsPipeline = null;
     this.#adjustmentsBindGroupLayout = null;
@@ -1494,6 +1573,7 @@ export class ProcessingPipeline {
     this.#postProcessBindGroupLayout = null;
     this.#postProcessUniformBuffer = null;
     this.#postProcessSampler = null;
+    this.#dummyBloomTexture = null;
     this.#bloomDownsamplePipeline = null;
     this.#bloomUpsamplePipeline = null;
     this.#bloomDownsampleBindGroupLayout = null;

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -547,7 +547,6 @@ export class ProcessingPipeline {
         topology: "triangle-list",
       },
     });
-
   }
 
   /**

--- a/renderer/shaders/dithering-shader.ts
+++ b/renderer/shaders/dithering-shader.ts
@@ -29,6 +29,10 @@ export class DitheringShader extends ShaderPass {
   #computeUniformBuffer: GPUBuffer | null = null;
   // Error buffer cache per entity (keyed by entityId-width-height)
   #errorBufferCache: Map<string, GPUBuffer> = new Map();
+  #computeBindGroupCache = new WeakMap<
+    GPUTexture,
+    WeakMap<GPUTexture, WeakMap<GPUBuffer, GPUBindGroup>>
+  >();
 
   override getShaderSource(): string {
     return ditheringShaderSource;
@@ -138,13 +142,20 @@ export class DitheringShader extends ShaderPass {
     sourceTexture: GPUTexture,
     outputTexture: GPUTexture,
     encoder: GPUCommandEncoder,
+    outputTextureHasStorageBinding = false,
   ): void {
     const ditheringKind = entity.shaderParams.dithering?.kind ?? DitheringKind.bayer4x4;
 
     if (isErrorDiffusion(ditheringKind)) {
-      this.#executeCompute(entity, sourceTexture, outputTexture, encoder);
+      this.#executeCompute(
+        entity,
+        sourceTexture,
+        outputTexture,
+        encoder,
+        outputTextureHasStorageBinding,
+      );
     } else {
-      super.execute(entity, sourceTexture, outputTexture, encoder);
+      super.execute(entity, sourceTexture, outputTexture, encoder, outputTextureHasStorageBinding);
     }
   }
 
@@ -153,6 +164,7 @@ export class DitheringShader extends ShaderPass {
     sourceTexture: GPUTexture,
     outputTexture: GPUTexture,
     encoder: GPUCommandEncoder,
+    outputTextureHasStorageBinding: boolean,
   ): void {
     if (!this.#computePipeline || !this.#computeBindGroupLayout || !this.#computeUniformBuffer) {
       return;
@@ -171,25 +183,18 @@ export class DitheringShader extends ShaderPass {
       GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC;
 
     const pool = this.ctx.texturePool;
-    const computeOutputTexture = pool
-      ? pool.acquire(width, height, computeUsage, `Compute output intermediate`)
-      : device.createTexture({
-          label: `Compute output intermediate texture`,
-          size: [width, height],
-          format: this.ctx.intermediateFormat,
-          usage: computeUsage,
-        });
+    const computeOutputTexture = outputTextureHasStorageBinding
+      ? outputTexture
+      : pool
+        ? pool.acquire(width, height, computeUsage, `Compute output intermediate`)
+        : device.createTexture({
+            label: `Compute output intermediate texture`,
+            size: [width, height],
+            format: this.ctx.intermediateFormat,
+            usage: computeUsage,
+          });
 
-    const bindGroup = device.createBindGroup({
-      label: `Entity ${entity.id} compute bind group`,
-      layout: this.#computeBindGroupLayout,
-      entries: [
-        { binding: 0, resource: { buffer: this.#computeUniformBuffer } },
-        { binding: 1, resource: sourceTexture.createView() },
-        { binding: 2, resource: computeOutputTexture.createView() },
-        { binding: 3, resource: { buffer: errorBuffer } },
-      ],
-    });
+    const bindGroup = this.#getComputeBindGroup(sourceTexture, computeOutputTexture, errorBuffer);
 
     encoder.clearBuffer(errorBuffer);
 
@@ -202,17 +207,53 @@ export class DitheringShader extends ShaderPass {
     computePass.dispatchWorkgroups(Math.ceil(height / 32));
     computePass.end();
 
-    encoder.copyTextureToTexture({ texture: computeOutputTexture }, { texture: outputTexture }, [
-      width,
-      height,
-    ]);
+    if (!outputTextureHasStorageBinding) {
+      encoder.copyTextureToTexture({ texture: computeOutputTexture }, { texture: outputTexture }, [
+        width,
+        height,
+      ]);
 
-    // Release compute output texture back to pool
-    if (pool) {
-      pool.release(computeOutputTexture, width, height, computeUsage);
-    } else {
-      computeOutputTexture.destroy();
+      // Release compute output texture back to pool
+      if (pool) {
+        pool.release(computeOutputTexture, width, height, computeUsage);
+      } else {
+        computeOutputTexture.destroy();
+      }
     }
+  }
+
+  #getComputeBindGroup(
+    sourceTexture: GPUTexture,
+    outputTexture: GPUTexture,
+    errorBuffer: GPUBuffer,
+  ): GPUBindGroup {
+    let outputCache = this.#computeBindGroupCache.get(sourceTexture);
+    if (!outputCache) {
+      outputCache = new WeakMap();
+      this.#computeBindGroupCache.set(sourceTexture, outputCache);
+    }
+
+    let errorCache = outputCache.get(outputTexture);
+    if (!errorCache) {
+      errorCache = new WeakMap();
+      outputCache.set(outputTexture, errorCache);
+    }
+
+    const cached = errorCache.get(errorBuffer);
+    if (cached) return cached;
+
+    const bindGroup = this.ctx.device.createBindGroup({
+      label: `Dithering compute bind group`,
+      layout: this.#computeBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: this.#computeUniformBuffer! } },
+        { binding: 1, resource: this.getTextureView(sourceTexture) },
+        { binding: 2, resource: this.getTextureView(outputTexture) },
+        { binding: 3, resource: { buffer: errorBuffer } },
+      ],
+    });
+    errorCache.set(errorBuffer, bindGroup);
+    return bindGroup;
   }
 
   /** Remove cached error buffers for an entity (call when entity is removed) */
@@ -234,6 +275,7 @@ export class DitheringShader extends ShaderPass {
     this.#computeUniformBuffer = null;
     this.#computePipeline = null;
     this.#computeBindGroupLayout = null;
+    this.#computeBindGroupCache = new WeakMap();
     super.destroy();
   }
 }

--- a/renderer/shaders/shader-pass.ts
+++ b/renderer/shaders/shader-pass.ts
@@ -233,6 +233,7 @@ export abstract class ShaderPass {
     sourceTexture: GPUTexture,
     outputTexture: GPUTexture,
     encoder: GPUCommandEncoder,
+    _outputTextureHasStorageBinding = false,
   ): void {
     if (!this.pipeline) return;
 

--- a/renderer/shaders/shader-registry.ts
+++ b/renderer/shaders/shader-registry.ts
@@ -27,10 +27,11 @@ export class ShaderRegistry {
     sourceTexture: GPUTexture,
     outputTexture: GPUTexture,
     encoder: GPUCommandEncoder,
+    outputTextureHasStorageBinding = false,
   ): void {
     const pass = this.#passes.get(entity.shaderType);
     if (!pass) throw new Error(`Shader pass not registered: ${entity.shaderType}`);
-    pass.execute(entity, sourceTexture, outputTexture, encoder);
+    pass.execute(entity, sourceTexture, outputTexture, encoder, outputTextureHasStorageBinding);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR extends the render benchmark harness and applies a set of scoped renderer performance improvements around WebGPU resource reuse, composition overhead, post-processing, and dithering.

Highlights:

- adds focused render benchmark coverage for selected labels, error-diffusion dithering, and no-bloom post-processing
- adds generic entity/canvas visual hash capture paths for regression checking
- caches texture views and bind groups across copy, shader, post-process, bloom, blur, and composition paths
- reduces steady-state composition uniform uploads when entity transform/selection state is unchanged
- lets error-diffusion dithering write directly to storage-capable outputs, while scoping `STORAGE_BINDING` only to outputs that actually need it
- keeps shader-side wins for ordered dithering bit masks and post-process grain math

## Benchmarks

Lower is better. These are local WebGPU harness runs from the in-app browser on 2026-06-28, alternating `main` (`b0d88c4`) and this branch (`19ce705`) per scenario. Each row is the scenario median reported by the harness. GPU timings are noisy, so treat this as directional rather than a lab-grade benchmark.

### Common scenarios: main vs this branch

| Scenario | main ms/frame | branch ms/frame | Delta |
| --- | ---: | ---: | ---: |
| 4K original composition | 0.2367 | 0.2417 | +2.1% |
| 4K ordered dithering | 1.7650 | 1.5483 | -12.3% |
| 4K flowing glass | 2.5767 | 2.2922 | -11.0% |
| 1080p video glitch | 0.8283 | 0.8083 | -2.4% |
| 1440p bloom stack | 1.7711 | 1.9022 | +7.4% |
| 25 entity composition | 0.6689 | 0.6506 | -2.7% |

### Branch-only added scenarios

| Scenario | branch ms/frame | CPU encode ms/frame | Queue drain ms/frame |
| --- | ---: | ---: | ---: |
| 4K original + selected label | 0.2561 | 0.0150 | 0.2411 |
| 1080p Floyd-Steinberg dithering | 4.9067 | 0.0367 | 4.8800 |
| 1440p no-bloom postprocess | 1.3300 | 0.0333 | 1.2950 |

Notes:

- Bloom total frame time regressed in this local run even though CPU encode improved; this should stay visible in review.
- Earlier experimental passes that failed longer A/B checks were reverted, including no-bloom shader specialization, bloom uniform upload skipping, render-state object reuse, sorted-z guard, and glitch zero-angle trig specialization.

## Validation

- `bun run lint:all`
- render harness on `main` and this branch via `/bench/render.html`
- final branch full harness completed all 9 branch scenarios
