### PR TITLE
[codex] Add Mediabunny timing logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,17 +55,15 @@ bun run test -- __tests__/engine/action-layer-controller.spec.ts
 
 ## Key Patterns
 
-1. **Enum pattern**: Use `createEnum()` from `types/index.ts`, not TypeScript `enum`. Produces both value object and type via `.infer`. Example: `ShaderType.dithering` (value), `ShaderType` (type).
-2. **Store pattern**: Extend `Store<T>` from `lib/store.ts` for reactive state. Use `createSnapshot(versionKey, create)` for `useSyncExternalStore`, `getComputed(key, versionKey, compute)` for derived values with structural sharing.
-3. **Private fields**: Use `#` private class fields, not `private` keyword.
-4. **No barrel exports**: Only `engine/index.ts` and `types/index.ts` have barrels. Import directly from files elsewhere.
-5. **GPU resources**: Always clean up buffers/textures. Use `TexturePool` for intermediates. Track entity textures in Maps keyed by entity ID.
-6. **Undo pattern**: Wrap state mutations in `Command.create({ execute, undo, onEvict })`, push to `undo` singleton from `lib/undo.ts`.
+1. **Store pattern**: Extend `Store<T>` from `lib/store.ts` for reactive state. Use `createSnapshot(versionKey, create)` for `useSyncExternalStore`, `getComputed(key, versionKey, compute)` for derived values with structural sharing.
+2. **Private fields**: Use `#` private class fields, not `private` keyword.
+3. **No barrel exports**: Only `engine/index.ts` and `types/index.ts` have barrels. Import directly from files elsewhere.
+4. **GPU resources**: Always clean up buffers/textures. Use `TexturePool` for intermediates. Track entity textures in Maps keyed by entity ID.
+5. **Undo pattern**: Wrap state mutations in `Command.create({ execute, undo, onEvict })`, push to `undo` singleton from `lib/undo.ts`.
 
 ## Anti-Patterns
 
 - IMPORTANT: Do not add fallback behavior unless it is absolutely necessary and you explain the exact reason why fallback behavior is mandatory!
-- Do not use TypeScript `enum` keyword. Use `createEnum()`.
 - Do not use `typeof import("...").Type` anywhere. Ever. Use a regular type import, a namespace type import, or an explicit local type alias instead.
 - Do not add `"use client"` / `"use server"` — this is a SPA, not Next.js.
 - Do not import from `node_modules` internals. Use opensrc cli for source reading.
@@ -73,7 +71,7 @@ bun run test -- __tests__/engine/action-layer-controller.spec.ts
 
 ## Export Pipeline
 
-Video: WebCodecs H.264 + mediabunny muxer in Web Worker (MP4/MOV only). GIF: gifenc in Web Worker (`lib/gif-encoder-worker.ts`). No WebM. Audio: demuxed via mediabunny, passed as raw AAC packets.
+Video: WebCodecs H.264 + mediabunny muxer in Web Worker (MP4/MOV only). GIF: gifenc in Web Worker (`lib/gif-encoder-worker.ts`). No WebM. Audio: demuxed via mediabunny and passed through as encoded packets when the output container supports the source audio codec.
 
 ## Upscale Pipeline
 

--- a/context/export-queue-context.tsx
+++ b/context/export-queue-context.tsx
@@ -297,7 +297,7 @@ export function ExportQueueProvider({ children }: PropsWithChildren) {
         const { demuxAudio } = await import("#lib/audio-demux.ts");
         audioData = await demuxAudio(entity.mediaSource.blob);
         if (!audioData) {
-          logger.warn("[export] Source video has no audio track, exporting without audio");
+          logger.warn("[export] Source video has no muxable audio track, exporting without audio");
         }
       }
 

--- a/engine/canvas-store.ts
+++ b/engine/canvas-store.ts
@@ -604,7 +604,7 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.version++;
     this.state.viewportDirty = true;
     this.state.debugMode = !this.state.debugMode;
-    this.#logger.setLevel(this.state.debugMode ? LogLevel.DEBUG : LogLevel.ERROR);
+    this.#logger.setLevel(this.state.debugMode ? LogLevel.DEBUG : LogLevel.INFO);
     this.notifySelectionChange();
     this.#logger.debug(`Debug mode toggled: ${this.state.debugMode}`);
   }
@@ -613,7 +613,7 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.version++;
     this.state.viewportDirty = true;
     this.state.debugMode = enabled;
-    this.#logger.setLevel(enabled ? LogLevel.DEBUG : LogLevel.ERROR);
+    this.#logger.setLevel(enabled ? LogLevel.DEBUG : LogLevel.INFO);
     this.notifySelectionChange();
     this.#logger.debug(`Debug mode set to: ${this.state.debugMode}`);
   }

--- a/lib/audio-demux.ts
+++ b/lib/audio-demux.ts
@@ -5,8 +5,19 @@
  * sending it to the worker for muxing alongside the processed video track.
  */
 
-import { Input, BlobSource, EncodedPacketSink, ALL_FORMATS } from "mediabunny";
+import {
+  Input,
+  BlobSource,
+  EncodedPacketSink,
+  ALL_FORMATS,
+  AUDIO_CODECS,
+  type AudioCodec,
+} from "mediabunny";
 import { logger } from "./client.logger.ts";
+
+function isAudioCodec(codec: string): codec is AudioCodec {
+  return (AUDIO_CODECS as readonly string[]).includes(codec);
+}
 
 export interface DemuxedAudio {
   /** Encoded audio packets in decode order */
@@ -18,6 +29,8 @@ export interface DemuxedAudio {
   }>;
   /** WebCodecs codec string (e.g. "mp4a.40.2", "opus") */
   codec: string;
+  /** Mediabunny packet codec identifier used when muxing encoded packets */
+  packetCodec: AudioCodec;
   /** Audio sample rate in Hz */
   sampleRate: number;
   /** Number of audio channels */
@@ -31,13 +44,21 @@ export interface DemuxedAudio {
  * Much cheaper than full demuxAudio — only reads container metadata.
  */
 export async function hasAudioTrack(blob: Blob): Promise<boolean> {
+  const startedAt = performance.now();
   const input = new Input({
     source: new BlobSource(blob),
     formats: ALL_FORMATS,
   });
   try {
     const track = await input.getPrimaryAudioTrack();
-    return track !== null;
+    const hasAudio = track !== null;
+    logger.info("[audio-demux] Audio track probe complete", {
+      durationMs: Math.round(performance.now() - startedAt),
+      hasAudio,
+      sizeBytes: blob.size,
+      mimeType: blob.type || "unknown",
+    });
+    return hasAudio;
   } finally {
     input.dispose();
   }
@@ -45,30 +66,62 @@ export async function hasAudioTrack(blob: Blob): Promise<boolean> {
 
 /**
  * Extract audio track from a video blob using mediabunny's demuxer.
- * Returns null if the video has no audio track.
+ * Returns null if the video has no muxable encoded audio track.
  */
 export async function demuxAudio(videoBlob: Blob): Promise<DemuxedAudio | null> {
+  const startedAt = performance.now();
   const input = new Input({
     source: new BlobSource(videoBlob),
     formats: ALL_FORMATS,
   });
 
   try {
+    const trackStartedAt = performance.now();
     const audioTrack = await input.getPrimaryAudioTrack();
+    logger.info("[audio-demux] Primary audio track probe complete", {
+      durationMs: Math.round(performance.now() - trackStartedAt),
+      hasAudio: audioTrack !== null,
+    });
     if (!audioTrack) {
       logger.debug("[audio-demux] No audio track found");
       return null;
     }
 
+    const decoderConfigStartedAt = performance.now();
     const decoderConfig = await audioTrack.getDecoderConfig();
+    logger.info("[audio-demux] Audio decoder config probe complete", {
+      durationMs: Math.round(performance.now() - decoderConfigStartedAt),
+      hasDecoderConfig: decoderConfig !== null,
+    });
     if (!decoderConfig) {
       logger.warn("[audio-demux] Could not get decoder config for audio track");
       return null;
     }
 
+    const codecStartedAt = performance.now();
+    const packetCodec = await audioTrack.getCodec();
+    logger.info("[audio-demux] Audio packet codec probe complete", {
+      durationMs: Math.round(performance.now() - codecStartedAt),
+      packetCodec,
+    });
+    if (!packetCodec || !isAudioCodec(packetCodec)) {
+      logger.warn(
+        `[audio-demux] Unsupported or unknown audio packet codec: ${packetCodec ?? "unknown"}`,
+      );
+      return null;
+    }
+
     const codec = decoderConfig.codec;
-    const sampleRate = audioTrack.sampleRate;
-    const numberOfChannels = audioTrack.numberOfChannels;
+    const formatStartedAt = performance.now();
+    const [sampleRate, numberOfChannels] = await Promise.all([
+      audioTrack.getSampleRate(),
+      audioTrack.getNumberOfChannels(),
+    ]);
+    logger.info("[audio-demux] Audio format metadata probe complete", {
+      durationMs: Math.round(performance.now() - formatStartedAt),
+      sampleRate,
+      numberOfChannels,
+    });
 
     // Extract description bytes if present
     let description: Uint8Array | undefined;
@@ -79,27 +132,37 @@ export async function demuxAudio(videoBlob: Blob): Promise<DemuxedAudio | null> 
         : new Uint8Array(desc);
     }
 
-    // Read all encoded audio packets
     const packetSink = new EncodedPacketSink(audioTrack);
     const packets: DemuxedAudio["packets"] = [];
 
-    let currentPacket = await packetSink.getFirstPacket();
-    while (currentPacket) {
+    const packetsStartedAt = performance.now();
+    for await (const currentPacket of packetSink.packets()) {
       packets.push({
         data: currentPacket.data,
         type: currentPacket.type,
         timestamp: currentPacket.timestamp,
         duration: currentPacket.duration,
       });
-      currentPacket = await packetSink.getNextPacket(currentPacket);
     }
+    const packetsDurationMs = Math.round(performance.now() - packetsStartedAt);
 
-    logger.debug(
-      `[audio-demux] Extracted ${packets.length} audio packets, codec=${codec}, rate=${sampleRate}, ch=${numberOfChannels}`,
+    logger.info(
+      `[audio-demux] Extracted ${packets.length} audio packets, codec=${codec}, packetCodec=${packetCodec}, rate=${sampleRate}, ch=${numberOfChannels}`,
+      {
+        packetsDurationMs,
+        totalDurationMs: Math.round(performance.now() - startedAt),
+        sizeBytes: videoBlob.size,
+        mimeType: videoBlob.type || "unknown",
+      },
     );
 
-    return { packets, codec, sampleRate, numberOfChannels, description };
+    return { packets, codec, packetCodec, sampleRate, numberOfChannels, description };
   } finally {
+    logger.info("[audio-demux] Audio demux complete", {
+      durationMs: Math.round(performance.now() - startedAt),
+      sizeBytes: videoBlob.size,
+      mimeType: videoBlob.type || "unknown",
+    });
     input.dispose();
   }
 }

--- a/lib/media-loader.ts
+++ b/lib/media-loader.ts
@@ -85,101 +85,63 @@ function roundToCommonFrameRate(fps: number): number {
   return Math.round(fps * 100) / 100;
 }
 
-/**
- * Detect video frame rate using requestVideoFrameCallback
- * Observes frames from an already-playing video without controlling playback.
- * @param video - The video element to detect fps from (should already be playing)
- * @param sampleCount - Number of frames to sample (default: 5)
- * @param timeoutMs - Timeout in milliseconds (default: 2000)
- * @returns Detected fps or null if detection fails
- */
-async function detectVideoFps(
-  video: HTMLVideoElement,
-  sampleCount = 5,
-  timeoutMs = 2000,
-): Promise<number | null> {
-  // Check if requestVideoFrameCallback is supported
-  if (!("requestVideoFrameCallback" in video)) {
-    console.warn("[detectVideoFps] requestVideoFrameCallback not supported");
-    return null;
-  }
-
-  return new Promise((resolve) => {
-    const timestamps: number[] = [];
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let resolved = false;
-
-    const cleanup = () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      // Don't pause video - let it continue playing for the user
-    };
-
-    const onFrame = (_now: number, metadata: VideoFrameCallbackMetadata) => {
-      if (resolved) return;
-
-      timestamps.push(metadata.mediaTime);
-
-      if (timestamps.length >= sampleCount + 1) {
-        cleanup();
-        resolved = true;
-
-        // Calculate average frame duration from deltas
-        const deltas: number[] = [];
-        for (let i = 1; i < timestamps.length; i++) {
-          const current = timestamps[i];
-          const previous = timestamps[i - 1];
-          if (current !== undefined && previous !== undefined) {
-            const delta = current - previous;
-            if (delta > 0) {
-              deltas.push(delta);
-            }
-          }
-        }
-
-        if (deltas.length === 0) {
-          resolve(null);
-          return;
-        }
-
-        const avgDelta = deltas.reduce((a, b) => a + b, 0) / deltas.length;
-        const rawFps = 1 / avgDelta;
-
-        // Validate reasonable fps range (1-240)
-        if (rawFps < 1 || rawFps > 240) {
-          resolve(null);
-          return;
-        }
-
-        const fps = roundToCommonFrameRate(rawFps);
-        resolve(fps);
-        return;
-      }
-
-      // Request next frame (only if not resolved)
-      video.requestVideoFrameCallback(onFrame);
-    };
-
-    // Set timeout
-    timeoutId = setTimeout(() => {
-      if (!resolved) {
-        cleanup();
-        resolved = true;
-        resolve(null);
-      }
-    }, timeoutMs);
-
-    // Register callback - video should already be playing
-    video.requestVideoFrameCallback(onFrame);
+async function probeVideoMetadata(blob: Blob): Promise<{ fps: number | null; hasAudio: boolean }> {
+  const startedAt = performance.now();
+  const { ALL_FORMATS, BlobSource, Input } = await import("mediabunny");
+  const input = new Input({
+    source: new BlobSource(blob),
+    formats: ALL_FORMATS,
   });
+
+  try {
+    const tracksStartedAt = performance.now();
+    const [videoTrack, audioTrack] = await Promise.all([
+      input.getPrimaryVideoTrack(),
+      input.getPrimaryAudioTrack(),
+    ]);
+    logger.info("[media-loader] Mediabunny track probe complete", {
+      durationMs: Math.round(performance.now() - tracksStartedAt),
+      hasVideo: videoTrack !== null,
+      hasAudio: audioTrack !== null,
+    });
+    if (!videoTrack) return { fps: null, hasAudio: audioTrack !== null };
+
+    let fps: number | null = null;
+    try {
+      const statsStartedAt = performance.now();
+      const stats = await videoTrack.computePacketStats(100);
+      const statsDurationMs = Math.round(performance.now() - statsStartedAt);
+      const rawFps = stats.averagePacketRate;
+      if (rawFps >= 1 && rawFps <= 240) {
+        fps = roundToCommonFrameRate(rawFps);
+      }
+      logger.info("[media-loader] Mediabunny video packet stats complete", {
+        durationMs: statsDurationMs,
+        packetCount: stats.packetCount,
+        rawFps,
+        fps,
+        averageBitrate: Math.round(stats.averageBitrate),
+      });
+    } catch (error) {
+      logger.debug("[media-loader] Failed to compute video packet stats", error);
+    }
+
+    return { fps, hasAudio: audioTrack !== null };
+  } finally {
+    logger.info("[media-loader] Mediabunny video metadata probe complete", {
+      durationMs: Math.round(performance.now() - startedAt),
+      sizeBytes: blob.size,
+      mimeType: blob.type || "unknown",
+    });
+    input.dispose();
+  }
 }
 
 /**
  * Load a video blob and extract metadata + initial frame
  */
 export async function loadVideo(blob: Blob): Promise<VideoLoadResult> {
+  const loadStartedAt = performance.now();
   const video = document.createElement("video");
   video.muted = true;
   video.defaultMuted = true;
@@ -190,11 +152,20 @@ export async function loadVideo(blob: Blob): Promise<VideoLoadResult> {
 
   // Wait for metadata to load
   try {
+    const metadataStartedAt = performance.now();
     await new Promise<void>((resolve, reject) => {
       video.onloadedmetadata = () => resolve();
       video.onerror = () => {
         void createVideoLoadError(video, blob).then(reject);
       };
+    });
+    logger.info("[media-loader] HTML video metadata loaded", {
+      durationMs: Math.round(performance.now() - metadataStartedAt),
+      mediaDurationSeconds: video.duration,
+      width: video.videoWidth,
+      height: video.videoHeight,
+      sizeBytes: blob.size,
+      mimeType: blob.type || "unknown",
     });
   } catch (error) {
     cleanupVideoElement(video);
@@ -206,27 +177,46 @@ export async function loadVideo(blob: Blob): Promise<VideoLoadResult> {
   const height = video.videoHeight;
 
   // Seek to first frame and wait for it
+  const seekStartedAt = performance.now();
   video.currentTime = 0;
   await new Promise<void>((resolve) => {
     video.onseeked = () => resolve();
   });
+  logger.info("[media-loader] HTML video initial seek complete", {
+    durationMs: Math.round(performance.now() - seekStartedAt),
+  });
 
   // Create initial frame snapshot
+  const captureStartedAt = performance.now();
   const canvas = new OffscreenCanvas(width, height);
   const ctx = canvas.getContext("2d")!;
   ctx.drawImage(video, 0, 0);
   const initialFrame = await createImageBitmap(canvas);
+  logger.info("[media-loader] Initial video frame captured", {
+    durationMs: Math.round(performance.now() - captureStartedAt),
+    width,
+    height,
+  });
 
   // Start playing for autoplay
+  const playStartedAt = performance.now();
   await video.play().catch((e) => {
     logger.error("Failed to autoplay video", e);
   });
+  logger.info("[media-loader] HTML video autoplay request complete", {
+    durationMs: Math.round(performance.now() - playStartedAt),
+    paused: video.paused,
+  });
 
-  // Detect fps and probe for audio track in parallel
-  const [fps, hasAudio] = await Promise.all([
-    detectVideoFps(video),
-    import("#lib/audio-demux.ts").then(({ hasAudioTrack }) => hasAudioTrack(blob)),
-  ]);
+  const { fps, hasAudio } = await probeVideoMetadata(blob);
+  logger.info("[media-loader] Video load complete", {
+    durationMs: Math.round(performance.now() - loadStartedAt),
+    fps,
+    hasAudio,
+    width,
+    height,
+    mediaDurationSeconds: video.duration,
+  });
 
   return {
     videoElement: video,

--- a/lib/video-demux.ts
+++ b/lib/video-demux.ts
@@ -11,6 +11,11 @@
 import { Input, BlobSource, VideoSampleSink, ALL_FORMATS } from "mediabunny";
 import { logger } from "./client.logger.ts";
 
+export const enum VideoFrameStartPolicy {
+  /** Export from composition time 0 and freeze the first decoded frame over any leading media gap. */
+  freezeLeadingGap = "freeze-leading-gap",
+}
+
 export interface VideoDemuxHandle {
   /** Decode frames at the given timestamps (seconds). Caller must close each yielded ImageBitmap. */
   frames(timestamps: Iterable<number>): AsyncGenerator<ImageBitmap>;
@@ -20,6 +25,10 @@ export interface VideoDemuxHandle {
   height: number;
   /** Duration in seconds */
   duration: number;
+  /** Start timestamp of the first video packet in seconds. Can be positive or negative. */
+  firstTimestamp: number;
+  /** Policy used by frame iterators for timestamps before the first decoded frame. */
+  frameStartPolicy: VideoFrameStartPolicy;
   /** Dispose the demuxer and free resources */
   dispose(): void;
 }
@@ -46,32 +55,57 @@ export function createFrameIterator(
  * Caller must call `dispose()` when done to free demuxer resources.
  */
 export async function demuxVideo(videoBlob: Blob): Promise<VideoDemuxHandle> {
+  const openedAt = performance.now();
   const input = new Input({
     source: new BlobSource(videoBlob),
     formats: ALL_FORMATS,
   });
 
+  const trackStartedAt = performance.now();
   const videoTrack = await input.getPrimaryVideoTrack();
+  logger.info("[video-demux] Primary video track probe complete", {
+    durationMs: Math.round(performance.now() - trackStartedAt),
+    hasVideo: videoTrack !== null,
+  });
   if (!videoTrack) {
     input.dispose();
     throw new Error("No video track found in source");
   }
 
+  const canDecodeStartedAt = performance.now();
   const canDecode = await videoTrack.canDecode();
+  logger.info("[video-demux] Video decode support probe complete", {
+    durationMs: Math.round(performance.now() - canDecodeStartedAt),
+    canDecode,
+  });
   if (!canDecode) {
     input.dispose();
     throw new Error("Video track codec is not supported by this browser");
   }
 
-  const width = videoTrack.displayWidth;
-  const height = videoTrack.displayHeight;
-  const duration = await videoTrack.computeDuration();
+  const metadataStartedAt = performance.now();
+  const [width, height, duration, firstTimestamp] = await Promise.all([
+    videoTrack.getDisplayWidth(),
+    videoTrack.getDisplayHeight(),
+    videoTrack.computeDuration(),
+    videoTrack.getFirstTimestamp(),
+  ]);
+  const metadataDurationMs = Math.round(performance.now() - metadataStartedAt);
 
-  logger.debug(`[video-demux] Opened video: ${width}x${height}, duration=${duration.toFixed(2)}s`);
+  logger.info(
+    `[video-demux] Opened video: ${width}x${height}, duration=${duration.toFixed(2)}s, firstTimestamp=${firstTimestamp.toFixed(3)}s`,
+    {
+      metadataDurationMs,
+      openDurationMs: Math.round(performance.now() - openedAt),
+      sizeBytes: videoBlob.size,
+      mimeType: videoBlob.type || "unknown",
+    },
+  );
 
   const sink = new VideoSampleSink(videoTrack);
 
   async function* frames(timestamps: Iterable<number>): AsyncGenerator<ImageBitmap> {
+    const framesStartedAt = performance.now();
     // Hold a display-oriented copy of the last decoded frame for repeats and
     // for videos whose encoded frame dimensions differ from display dimensions.
     const repeatCanvas = new OffscreenCanvas(width, height);
@@ -81,50 +115,63 @@ export async function demuxVideo(videoBlob: Blob): Promise<VideoDemuxHandle> {
     // Count expected outputs to pad if the sink yields fewer samples
     const timestampArray = Array.isArray(timestamps) ? timestamps : [...timestamps];
     let yieldCount = 0;
-    // Buffer leading nulls — timestamps before the first decodable frame
-    // (e.g. video with start_time > 0) will produce nulls that we backfill
-    // once the first real frame arrives.
+    // Explicit start policy: exports are driven from composition time 0. When
+    // the video track starts later, freeze the first decoded frame over that gap.
     let leadingNulls = 0;
 
-    for await (const sample of sink.samplesAtTimestamps(timestampArray)) {
-      if (!sample) {
-        if (!hasFrame) {
-          // Buffer leading nulls — we'll backfill once the first frame arrives
-          leadingNulls++;
+    try {
+      for await (const sample of sink.samplesAtTimestamps(timestampArray)) {
+        if (!sample) {
+          if (!hasFrame) {
+            // Buffer leading nulls — we'll backfill once the first frame arrives
+            leadingNulls++;
+            continue;
+          }
+          yield await createImageBitmap(repeatCanvas);
+          yieldCount++;
           continue;
         }
+        repeatCtx.clearRect(0, 0, width, height);
+        try {
+          sample.draw(repeatCtx, 0, 0, width, height);
+        } finally {
+          sample.close();
+        }
+
+        if (!hasFrame) {
+          hasFrame = true;
+          logger.info("[video-demux] First decoded video frame ready", {
+            durationMs: Math.round(performance.now() - framesStartedAt),
+            leadingNulls,
+            requestedTimestamps: timestampArray.length,
+          });
+          // Backfill leading nulls with the first decoded frame
+          for (let i = 0; i < leadingNulls; i++) {
+            yield await createImageBitmap(repeatCanvas);
+            yieldCount++;
+          }
+        }
+
         yield await createImageBitmap(repeatCanvas);
         yieldCount++;
-        continue;
-      }
-      repeatCtx.clearRect(0, 0, width, height);
-      try {
-        sample.draw(repeatCtx, 0, 0, width, height);
-      } finally {
-        sample.close();
       }
 
       if (!hasFrame) {
-        hasFrame = true;
-        // Backfill leading nulls with the first decoded frame
-        for (let i = 0; i < leadingNulls; i++) {
-          yield await createImageBitmap(repeatCanvas);
-          yieldCount++;
-        }
+        throw new Error("No decodable frames found in video");
       }
 
-      yield await createImageBitmap(repeatCanvas);
-      yieldCount++;
-    }
-
-    if (!hasFrame) {
-      throw new Error("No decodable frames found in video");
-    }
-
-    // Pad remaining frames if sink yielded fewer samples than timestamps
-    while (yieldCount < timestampArray.length) {
-      yield await createImageBitmap(repeatCanvas);
-      yieldCount++;
+      // Pad remaining frames if sink yielded fewer samples than timestamps
+      while (yieldCount < timestampArray.length) {
+        yield await createImageBitmap(repeatCanvas);
+        yieldCount++;
+      }
+    } finally {
+      logger.info("[video-demux] Video frame iteration complete", {
+        durationMs: Math.round(performance.now() - framesStartedAt),
+        requestedTimestamps: timestampArray.length,
+        yieldedFrames: yieldCount,
+        leadingNulls,
+      });
     }
   }
 
@@ -133,6 +180,8 @@ export async function demuxVideo(videoBlob: Blob): Promise<VideoDemuxHandle> {
     width,
     height,
     duration,
+    firstTimestamp,
+    frameStartPolicy: VideoFrameStartPolicy.freezeLeadingGap,
     dispose: () => input.dispose(),
   };
 }

--- a/renderer/frame-encoder.ts
+++ b/renderer/frame-encoder.ts
@@ -225,6 +225,7 @@ async function runEncode(params: RunEncodeParams): Promise<void> {
       type: "audio-track",
       packets: audioData.packets,
       codec: audioData.codec,
+      packetCodec: audioData.packetCodec,
       sampleRate: audioData.sampleRate,
       numberOfChannels: audioData.numberOfChannels,
       description: audioData.description,

--- a/renderer/video-encode-core.ts
+++ b/renderer/video-encode-core.ts
@@ -1,5 +1,6 @@
 import { getH264Codec } from "#config";
 import type { DemuxedAudio } from "#lib/audio-demux.ts";
+import { logger } from "#lib/client.logger.ts";
 import {
   BufferTarget,
   EncodedAudioPacketSource,
@@ -174,6 +175,7 @@ export class VideoEncoderSession {
 }
 
 export async function muxEncodedVideo(options: MuxEncodedVideoOptions): Promise<Blob> {
+  const muxStartedAt = performance.now();
   const { format, fps, chunks, audioData, totalFrames, isCancelled = () => false } = options;
   const isobmffOptions: IsobmffOutputFormatOptions = { fastStart: "in-memory" };
   const outputFormat =
@@ -184,15 +186,33 @@ export async function muxEncodedVideo(options: MuxEncodedVideoOptions): Promise<
   output.addVideoTrack(videoSource, { frameRate: fps });
 
   let audioSource: EncodedAudioPacketSource | null = null;
-  if (audioData) {
-    audioSource = new EncodedAudioPacketSource("aac");
+  const muxedAudioData =
+    audioData && outputFormat.getSupportedCodecs().includes(audioData.packetCodec)
+      ? audioData
+      : null;
+  if (audioData && !muxedAudioData) {
+    logger.warn(
+      `[video-mux] Skipping audio passthrough: ${format} does not support ${audioData.packetCodec}`,
+    );
+  }
+  if (muxedAudioData) {
+    audioSource = new EncodedAudioPacketSource(muxedAudioData.packetCodec);
     output.addAudioTrack(audioSource);
   }
 
   try {
+    const startStartedAt = performance.now();
     await output.start();
+    logger.info("[video-mux] Output start complete", {
+      durationMs: Math.round(performance.now() - startStartedAt),
+      format,
+      videoChunks: chunks.length,
+      audioPackets: muxedAudioData?.packets.length ?? 0,
+    });
 
+    const videoStartedAt = performance.now();
     let firstVideoPacket = true;
+    let videoPacketCount = 0;
     for (const chunk of chunks) {
       if (isCancelled()) throw new Error("Export cancelled");
       const packet = new EncodedPacket(chunk.data, chunk.type, chunk.timestamp, chunk.duration);
@@ -202,15 +222,26 @@ export async function muxEncodedVideo(options: MuxEncodedVideoOptions): Promise<
       } else {
         await videoSource.add(packet);
       }
+      videoPacketCount++;
     }
     videoSource.close();
+    logger.info("[video-mux] Video packet mux complete", {
+      durationMs: Math.round(performance.now() - videoStartedAt),
+      packetCount: videoPacketCount,
+    });
 
-    if (audioData && audioSource) {
+    if (muxedAudioData && audioSource) {
+      const audioStartedAt = performance.now();
       const videoDuration = totalFrames / fps;
       let firstAudioPacket = true;
-      for (const packetData of audioData.packets) {
+      let audioPacketCount = 0;
+      let skippedNegativeAudioPackets = 0;
+      for (const packetData of muxedAudioData.packets) {
         if (isCancelled()) throw new Error("Export cancelled");
-        if (packetData.timestamp < 0) continue;
+        if (packetData.timestamp < 0) {
+          skippedNegativeAudioPackets++;
+          continue;
+        }
         if (packetData.timestamp > videoDuration) break;
 
         const packet = new EncodedPacket(
@@ -222,23 +253,38 @@ export async function muxEncodedVideo(options: MuxEncodedVideoOptions): Promise<
         if (firstAudioPacket) {
           await audioSource.add(packet, {
             decoderConfig: {
-              codec: audioData.codec,
-              sampleRate: audioData.sampleRate,
-              numberOfChannels: audioData.numberOfChannels,
-              description: audioData.description,
+              codec: muxedAudioData.codec,
+              sampleRate: muxedAudioData.sampleRate,
+              numberOfChannels: muxedAudioData.numberOfChannels,
+              description: muxedAudioData.description,
             },
           });
           firstAudioPacket = false;
         } else {
           await audioSource.add(packet);
         }
+        audioPacketCount++;
       }
       audioSource.close();
+      logger.info("[video-mux] Audio packet mux complete", {
+        durationMs: Math.round(performance.now() - audioStartedAt),
+        packetCount: audioPacketCount,
+        skippedNegativePackets: skippedNegativeAudioPackets,
+        packetCodec: muxedAudioData.packetCodec,
+      });
     }
 
+    const finalizeStartedAt = performance.now();
     await output.finalize();
+    const finalizeDurationMs = Math.round(performance.now() - finalizeStartedAt);
     const buffer = target.buffer;
     if (!buffer) throw new Error("Output buffer is null after finalize");
+    logger.info("[video-mux] Output finalize complete", {
+      durationMs: finalizeDurationMs,
+      totalDurationMs: Math.round(performance.now() - muxStartedAt),
+      format,
+      sizeBytes: buffer.byteLength,
+    });
     return new Blob([buffer], { type: output.format.mimeType });
   } catch (error) {
     await output.cancel().catch(() => {});

--- a/renderer/video-export.worker.ts
+++ b/renderer/video-export.worker.ts
@@ -47,6 +47,7 @@ export type ToWorkerMessage =
         duration: number;
       }>;
       codec: string;
+      packetCodec: DemuxedAudio["packetCodec"];
       sampleRate: number;
       numberOfChannels: number;
       description?: Uint8Array;
@@ -147,10 +148,11 @@ function handleFrame(msg: Extract<ToWorkerMessage, { type: "frame" }>): void {
 }
 
 function handleAudioTrack(msg: Extract<ToWorkerMessage, { type: "audio-track" }>): void {
-  // MP4/MOV use AAC natively — no transcoding needed, just store for muxing
+  // No transcoding here; muxing decides whether the output container supports this packet codec.
   pendingAudioData = {
     packets: msg.packets,
     codec: msg.codec,
+    packetCodec: msg.packetCodec,
     sampleRate: msg.sampleRate,
     numberOfChannels: msg.numberOfChannels,
     description: msg.description,


### PR DESCRIPTION
## Summary

Adds Mediabunny-backed media metadata improvements and timing instrumentation across video import, demuxing, audio passthrough, and muxing.

## Changes

- Replaces requestVideoFrameCallback-based import FPS detection with Mediabunny `computePacketStats(100)`.
- Exposes video first timestamp and names the current leading-gap frame policy explicitly.
- Uses Mediabunny's encoded packet iterator for audio demuxing.
- Carries the source audio packet codec through the export worker and muxes audio only when the output format supports it.
- Adds info-level timing logs for HTML video loading phases, Mediabunny track/stat probes, audio/video demuxing, and mux finalization.
- Keeps `logger.info()` visible when debug mode is off while keeping debug logs gated behind debug mode.
- Updates AGENTS.md to remove the old `createEnum()` instruction and clarify audio passthrough behavior.

## Validation

- `bun run lint:all`
- `bun run test`