### PR TITLE
[codex] Improve zero-copy video rendering performance

### DIFF
--- a/components/knobs/style-knobs.tsx
+++ b/components/knobs/style-knobs.tsx
@@ -90,48 +90,6 @@ const DITHERING_ITEMS: MobileStyleItem<DitheringKind>[] = [
     shortLabel: "Blue",
     icon: () => <span>B</span>,
   },
-  {
-    value: DitheringKind.floydSteinberg,
-    label: "Floyd-Steinberg",
-    shortLabel: "F-S",
-    icon: () => <span>F</span>,
-  },
-  {
-    value: DitheringKind.atkinson,
-    label: "Atkinson",
-    shortLabel: "Atkin",
-    icon: () => <span>A</span>,
-  },
-  {
-    value: DitheringKind.jarvisJudiceNinke,
-    label: "Jarvis-Judice-Ninke",
-    shortLabel: "J-J-N",
-    icon: () => <span>J</span>,
-  },
-  {
-    value: DitheringKind.stucki,
-    label: "Stucki",
-    shortLabel: "Stucki",
-    icon: () => <span>S</span>,
-  },
-  {
-    value: DitheringKind.burkes,
-    label: "Burkes",
-    shortLabel: "Burkes",
-    icon: () => <span>B</span>,
-  },
-  {
-    value: DitheringKind.sierra,
-    label: "Sierra",
-    shortLabel: "Sierra",
-    icon: () => <span>S</span>,
-  },
-  {
-    value: DitheringKind.sierraLite,
-    label: "Sierra Lite",
-    shortLabel: "Lite",
-    icon: () => <span>S</span>,
-  },
 ];
 
 // ============================================================================

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -14,9 +14,6 @@ import {
   getViewportWorldBounds,
 } from "../lib/canvas-math.ts";
 import {
-  DitheringKind,
-  isErrorDiffusion,
-  ShaderType,
   type Bounds,
   type RGBA,
   type ShaderCanvasEntity,
@@ -28,6 +25,7 @@ import { DisintegrationParticleSystem } from "./disintegration-particles.ts";
 import dotGridShaderSource from "./dot-grid.wgsl?raw";
 import { EntityShaderRuntime, type EntityShaderSource } from "./entity-shader-runtime.ts";
 import { ExportService } from "./export-service.ts";
+import { ExternalTextureCopyPass } from "./external-texture-copy-pass.ts";
 import { detectGpuColorConfig, type GpuColorConfig } from "./gpu-color-space.ts";
 import selectionRectShaderSource from "./selection-rect.wgsl?raw";
 import { CanvasCalloutPass } from "./canvas-callout-pass.ts";
@@ -48,31 +46,6 @@ interface CompositionDrawItem {
 type CompositionSource =
   | { kind: "texture"; texture: GPUTexture }
   | { kind: "external"; texture: GPUExternalTexture };
-
-const externalVideoBlitShaderSource = `
-@group(0) @binding(0) var sourceTexture: texture_external;
-@group(0) @binding(1) var sourceSampler: sampler;
-
-struct VertexOutput {
-  @builtin(position) position: vec4f,
-  @location(0) uv: vec2f,
-}
-
-@vertex
-fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
-  let uv = vec2f(f32((vertexIndex << 1u) & 2u), f32(vertexIndex & 2u));
-  var out: VertexOutput;
-  out.position = vec4f(uv * 2.0 - 1.0, 0.0, 1.0);
-  out.uv = vec2f(uv.x, 1.0 - uv.y);
-  return out;
-}
-
-@fragment
-fn fs_main(in: VertexOutput) -> @location(0) vec4f {
-  let color = textureSampleBaseClampToEdge(sourceTexture, sourceSampler, in.uv);
-  return vec4f(color.rgb, 1.0);
-}
-`;
 
 function createExternalCompositionShaderSource(source: string): string {
   return source
@@ -104,9 +77,7 @@ export class InfiniteCanvasRenderer {
   // Composition pipeline
   #compositionPipeline: GPURenderPipeline | null = null;
   #externalCompositionPipeline: GPURenderPipeline | null = null;
-  #externalVideoBlitPipeline: GPURenderPipeline | null = null;
-  #externalVideoBlitBindGroupLayout: GPUBindGroupLayout | null = null;
-  #externalVideoBlitSampler: GPUSampler | null = null;
+  #externalTextureCopyPass: ExternalTextureCopyPass | null = null;
   #viewportUniformBuffer: GPUBuffer | null = null;
   #entityUniformBuffer: GPUBuffer | null = null;
   #compositionSampler: GPUSampler | null = null;
@@ -133,7 +104,6 @@ export class InfiniteCanvasRenderer {
     string,
     {
       texture: GPUTexture;
-      sourceRef: HTMLVideoElement | ImageBitmap | OffscreenCanvas;
       width: number;
       height: number;
     }
@@ -168,11 +138,6 @@ export class InfiniteCanvasRenderer {
 
   // Texture pool for eliminating per-frame allocation churn
   #texturePool: TexturePool | null = null;
-
-  // Reusable canvas for Firefox-compatible video frame upload
-  #videoUploadCanvas: OffscreenCanvas | null = null;
-  #videoUploadCtx: OffscreenCanvasRenderingContext2D | null = null;
-  #directVideoUploadSupported: boolean | null = null;
 
   // Disintegration particle system (GPU compute + instanced rendering)
   #particleSystem: DisintegrationParticleSystem | null = null;
@@ -335,7 +300,10 @@ export class InfiniteCanvasRenderer {
 
     this.#createGridPipeline();
     this.#createCompositionPipeline();
-    this.#createExternalVideoBlitPipeline();
+    this.#externalTextureCopyPass = new ExternalTextureCopyPass(
+      this.#device,
+      this.#colorConfig.intermediateFormat,
+    );
     this.#entityShaderRuntime = new EntityShaderRuntime({
       device: this.#device,
       colorConfig: this.#colorConfig,
@@ -627,95 +595,6 @@ export class InfiniteCanvasRenderer {
         topology: "triangle-list",
       },
     });
-  }
-
-  #createExternalVideoBlitPipeline(): void {
-    if (!this.#device) return;
-
-    this.#externalVideoBlitBindGroupLayout = this.#device.createBindGroupLayout({
-      label: "External video blit bind group layout",
-      entries: [
-        {
-          binding: 0,
-          visibility: GPUShaderStage.FRAGMENT,
-          externalTexture: {},
-        },
-        {
-          binding: 1,
-          visibility: GPUShaderStage.FRAGMENT,
-          sampler: { type: "filtering" },
-        },
-      ],
-    });
-
-    this.#externalVideoBlitSampler = this.#device.createSampler({
-      label: "External video blit sampler",
-      magFilter: "linear",
-      minFilter: "linear",
-      addressModeU: "clamp-to-edge",
-      addressModeV: "clamp-to-edge",
-    });
-
-    const shaderModule = this.#device.createShaderModule({
-      label: "External video blit shader",
-      code: externalVideoBlitShaderSource,
-    });
-    const pipelineLayout = this.#device.createPipelineLayout({
-      label: "External video blit pipeline layout",
-      bindGroupLayouts: [this.#externalVideoBlitBindGroupLayout],
-    });
-
-    this.#externalVideoBlitPipeline = this.#device.createRenderPipeline({
-      label: "External video blit pipeline",
-      layout: pipelineLayout,
-      vertex: { module: shaderModule, entryPoint: "vs_main" },
-      fragment: {
-        module: shaderModule,
-        entryPoint: "fs_main",
-        targets: [{ format: this.#colorConfig.intermediateFormat }],
-      },
-      primitive: { topology: "triangle-list" },
-    });
-  }
-
-  #blitExternalVideoToTexture(
-    source: GPUExternalTexture,
-    destination: GPUTexture,
-    encoder: GPUCommandEncoder,
-  ): void {
-    if (
-      !this.#device ||
-      !this.#externalVideoBlitPipeline ||
-      !this.#externalVideoBlitBindGroupLayout ||
-      !this.#externalVideoBlitSampler
-    ) {
-      return;
-    }
-
-    const bindGroup = this.#device.createBindGroup({
-      label: "External video blit bind group",
-      layout: this.#externalVideoBlitBindGroupLayout,
-      entries: [
-        { binding: 0, resource: source },
-        { binding: 1, resource: this.#externalVideoBlitSampler },
-      ],
-    });
-
-    const pass = encoder.beginRenderPass({
-      label: "External video blit render pass",
-      colorAttachments: [
-        {
-          view: destination.createView(),
-          loadOp: "clear",
-          storeOp: "store",
-          clearValue: { r: 0, g: 0, b: 0, a: 0 },
-        },
-      ],
-    });
-    pass.setPipeline(this.#externalVideoBlitPipeline);
-    pass.setBindGroup(0, bindGroup);
-    pass.draw(3);
-    pass.end();
   }
 
   #createSelectionRectPipeline(): void {
@@ -1076,26 +955,6 @@ export class InfiniteCanvasRenderer {
     this.#entityShaderRuntime.flushTextureReleases();
   }
 
-  #shouldMaterializeVideoSource(entity: ShaderCanvasEntity): boolean {
-    if (entity.mediaSource.type !== "video" || entity.shaderParams.showOriginal) return false;
-
-    if ((entity.shaderParams.adjustments?.blur ?? 0) > 0) {
-      // TODO(video-external): Add a texture_external variant for the first
-      // blur/downsample pass. Until then, pre-blurred video needs a normal
-      // source texture.
-      return true;
-    }
-
-    const ditheringKind = entity.shaderParams.dithering?.kind ?? DitheringKind.bayer4x4;
-    if (entity.shaderType === ShaderType.dithering && isErrorDiffusion(ditheringKind)) {
-      // TODO(video-external): Add an external-texture compute variant for
-      // error-diffusion dithering, or port that path to fragment passes.
-      return true;
-    }
-
-    return false;
-  }
-
   #destroyEntitySourceTexture(entityId: string): void {
     const cachedSource = this.#entitySourceTextures.get(entityId);
     if (!cachedSource) return;
@@ -1264,64 +1123,12 @@ export class InfiniteCanvasRenderer {
     }
   }
 
-  /**
-   * Get a video frame as an OffscreenCanvas source compatible with all browsers.
-   * Firefox doesn't support HTMLVideoElement in copyExternalImageToTexture,
-   * so we draw to an OffscreenCanvas first.
-   */
-  #getVideoFrameSource(video: HTMLVideoElement, width: number, height: number): OffscreenCanvas {
-    if (
-      !this.#videoUploadCanvas ||
-      this.#videoUploadCanvas.width !== width ||
-      this.#videoUploadCanvas.height !== height
-    ) {
-      this.#videoUploadCanvas = new OffscreenCanvas(width, height);
-      this.#videoUploadCtx = this.#videoUploadCanvas.getContext("2d", {
-        colorSpace: this.#colorConfig.textureColorSpace,
-      });
-    }
-    this.#videoUploadCtx!.drawImage(video, 0, 0, width, height);
-    return this.#videoUploadCanvas;
-  }
-
-  #uploadEntitySourceToTexture(
+  #uploadStaticEntitySourceToTexture(
     entity: ShaderCanvasEntity,
     texture: GPUTexture,
     width: number,
     height: number,
-  ): HTMLVideoElement | ImageBitmap | OffscreenCanvas {
-    if (entity.mediaSource.type === "video") {
-      const video = entity.mediaSource.videoElement;
-
-      if (this.#directVideoUploadSupported !== false) {
-        try {
-          this.#device!.queue.copyExternalImageToTexture(
-            { source: video },
-            { texture, colorSpace: this.#colorConfig.textureColorSpace },
-            [width, height],
-          );
-          this.#directVideoUploadSupported = true;
-          return video;
-        } catch (error) {
-          this.#directVideoUploadSupported = false;
-          logger.debug(
-            "[renderer] Direct video texture upload unavailable; using canvas fallback",
-            {
-              error,
-            },
-          );
-        }
-      }
-
-      const source = this.#getVideoFrameSource(video, width, height);
-      this.#device!.queue.copyExternalImageToTexture(
-        { source },
-        { texture, colorSpace: this.#colorConfig.textureColorSpace },
-        [width, height],
-      );
-      return source;
-    }
-
+  ): void {
     const source =
       entity.mediaSource.type === "image" ? entity.mediaSource.imageBitmap : entity.imageBitmap;
     this.#device!.queue.copyExternalImageToTexture(
@@ -1329,7 +1136,6 @@ export class InfiniteCanvasRenderer {
       { texture, colorSpace: this.#colorConfig.textureColorSpace },
       [width, height],
     );
-    return source;
   }
 
   /**
@@ -1346,8 +1152,7 @@ export class InfiniteCanvasRenderer {
 
     const width = entity.originalSize.width;
     const height = entity.originalSize.height;
-    const useExternalVideoSource =
-      entity.mediaSource.type === "video" && !this.#shouldMaterializeVideoSource(entity);
+    const useExternalVideoSource = entity.mediaSource.type === "video";
 
     // Time-based shaders and zero-copy video sources need the shader pass every frame that the
     // canvas renders. The source frame lives behind the HTMLVideoElement, so reusing an old
@@ -1378,29 +1183,9 @@ export class InfiniteCanvasRenderer {
       });
 
       if (entity.shaderParams.showOriginal) {
-        const outputUsage =
-          GPUTextureUsage.TEXTURE_BINDING |
-          GPUTextureUsage.RENDER_ATTACHMENT |
-          GPUTextureUsage.COPY_DST |
-          GPUTextureUsage.COPY_SRC;
-        let outputTexture: GPUTexture;
-        if (cachedTexture && cachedTexture.width === width && cachedTexture.height === height) {
-          outputTexture = cachedTexture;
-        } else {
-          cachedTexture?.destroy();
-          outputTexture = this.#device.createTexture({
-            label: `Entity ${entity.id} original video texture`,
-            size: [width, height],
-            format: this.#colorConfig.intermediateFormat,
-            usage: outputUsage,
-          });
-        }
-        // Safari corrupts direct external-video composition for showOriginal.
-        // Keep the zero-CPU-copy path, but normalize through a GPU blit into the
-        // same texture format used by processed entities.
-        this.#blitExternalVideoToTexture(externalTexture, outputTexture, encoder);
-        this.#entityTextures.set(entity.id, outputTexture);
-        return { kind: "texture", texture: outputTexture };
+        cachedTexture?.destroy();
+        this.#entityTextures.delete(entity.id);
+        return { kind: "external", texture: externalTexture };
       }
 
       shaderSource = { kind: "external", texture: externalTexture };
@@ -1413,8 +1198,8 @@ export class InfiniteCanvasRenderer {
       GPUTextureUsage.COPY_SRC |
       GPUTextureUsage.RENDER_ATTACHMENT;
 
-    // Check source texture cache: reuse when source dimensions match and no new media frame
-    // was marked dirty. This lets viewport/UI redraws sample the previous video frame.
+    // Check source texture cache for static media: reuse when source dimensions match and
+    // the entity was not marked dirty.
     const cachedSource = this.#entitySourceTextures.get(entity.id);
 
     if (!shaderSource) {
@@ -1449,11 +1234,10 @@ export class InfiniteCanvasRenderer {
           });
         }
 
-        const sourceRef = this.#uploadEntitySourceToTexture(entity, sourceTexture, width, height);
+        this.#uploadStaticEntitySourceToTexture(entity, sourceTexture, width, height);
 
         this.#entitySourceTextures.set(entity.id, {
           texture: sourceTexture,
-          sourceRef,
           width,
           height,
         });
@@ -1495,7 +1279,7 @@ export class InfiniteCanvasRenderer {
       });
     }
 
-    // Apply shader using unified method (handles fragment/external paths and compute fallback paths).
+    // Apply shader using unified method (handles fragment, external, and compute paths).
     this.#entityShaderRuntime.encode({
       entity,
       source: shaderSource,
@@ -1521,8 +1305,7 @@ export class InfiniteCanvasRenderer {
       !this.#context ||
       !this.#gridPipeline ||
       !this.#compositionPipeline ||
-      !this.#externalCompositionPipeline ||
-      !this.#externalVideoBlitPipeline
+      !this.#externalCompositionPipeline
     ) {
       return;
     }
@@ -2169,6 +1952,36 @@ export class InfiniteCanvasRenderer {
    * Called before removeEntityTexture — copies the GPU texture so the entity
    * can be removed immediately while the dust animation plays independently.
    */
+  #copyCurrentVideoFrameToTexture(entity: ShaderCanvasEntity, label: string): GPUTexture | null {
+    if (
+      !this.#device ||
+      !this.#externalTextureCopyPass ||
+      entity.mediaSource.type !== "video"
+    ) {
+      return null;
+    }
+
+    const width = entity.originalSize.width;
+    const height = entity.originalSize.height;
+    const texture = this.#device.createTexture({
+      label,
+      size: [width, height],
+      format: this.#colorConfig.intermediateFormat,
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.COPY_SRC,
+    });
+    const externalTexture = this.#device.importExternalTexture({
+      source: entity.mediaSource.videoElement,
+      colorSpace: this.#colorConfig.textureColorSpace,
+    });
+    const encoder = this.#device.createCommandEncoder({ label: `${label} encoder` });
+    this.#externalTextureCopyPass.encode(encoder, externalTexture, texture);
+    this.#device.queue.submit([encoder.finish()]);
+    return texture;
+  }
+
   #createDisintegrationSnapshot(entity: ShaderCanvasEntity): GPUTexture | null {
     if (!this.#device) return null;
     const entityId = entity.id;
@@ -2191,22 +2004,11 @@ export class InfiniteCanvasRenderer {
     }
 
     let sourceTexture = this.#entitySourceTextures.get(entityId)?.texture ?? null;
-    let temporarySourceTexture: GPUTexture | null = null;
     if (!sourceTexture && entity.mediaSource.type === "video") {
-      const width = entity.originalSize.width;
-      const height = entity.originalSize.height;
-      sourceTexture = this.#device.createTexture({
-        label: `Disintegration video snapshot source ${entityId}`,
-        size: [width, height],
-        format: "rgba8unorm",
-        usage:
-          GPUTextureUsage.TEXTURE_BINDING |
-          GPUTextureUsage.COPY_DST |
-          GPUTextureUsage.COPY_SRC |
-          GPUTextureUsage.RENDER_ATTACHMENT,
-      });
-      this.#uploadEntitySourceToTexture(entity, sourceTexture, width, height);
-      temporarySourceTexture = sourceTexture;
+      return this.#copyCurrentVideoFrameToTexture(
+        entity,
+        `Disintegration video snapshot ${entityId}`,
+      );
     }
     if (!sourceTexture || !this.#entityShaderRuntime) return null;
 
@@ -2219,7 +2021,6 @@ export class InfiniteCanvasRenderer {
     const encoder = this.#device.createCommandEncoder();
     this.#entityShaderRuntime.passthroughCopyPass.encode(encoder, sourceTexture, snapshotTexture);
     this.#device.queue.submit([encoder.finish()]);
-    temporarySourceTexture?.destroy();
     return snapshotTexture;
   }
 
@@ -2344,7 +2145,26 @@ export class InfiniteCanvasRenderer {
     options?: import("./export-formats.ts").ImageExportOptions,
   ): Promise<Blob | null> {
     const displayedTexture = this.#getDisplayedEntityTexture(entity);
-    if (!displayedTexture) return null;
+    if (!displayedTexture) {
+      if (entity.mediaSource.type !== "video" || !entity.shaderParams.showOriginal) return null;
+
+      const capturedTexture = this.#copyCurrentVideoFrameToTexture(
+        entity,
+        `Entity ${entity.id} original video export texture`,
+      );
+      if (!capturedTexture) return null;
+
+      try {
+        return await this.#exportService!.renderTextureToBlob(
+          capturedTexture,
+          entity.originalSize.width,
+          entity.originalSize.height,
+          options,
+        );
+      } finally {
+        capturedTexture.destroy();
+      }
+    }
 
     return this.#exportService!.renderTextureToBlob(
       displayedTexture,
@@ -2486,9 +2306,7 @@ export class InfiniteCanvasRenderer {
     this.#gridPipeline = null;
     this.#compositionPipeline = null;
     this.#externalCompositionPipeline = null;
-    this.#externalVideoBlitPipeline = null;
-    this.#externalVideoBlitBindGroupLayout = null;
-    this.#externalVideoBlitSampler = null;
+    this.#externalTextureCopyPass = null;
     this.#selectionRectPipeline = null;
     this.#gridBindGroup = null;
     this.#selectionRectBindGroup = null;

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -13,12 +13,7 @@ import {
   getViewportMatrix,
   getViewportWorldBounds,
 } from "../lib/canvas-math.ts";
-import {
-  type Bounds,
-  type RGBA,
-  type ShaderCanvasEntity,
-  type Viewport,
-} from "#types/canvas.ts";
+import { type Bounds, type RGBA, type ShaderCanvasEntity, type Viewport } from "#types/canvas.ts";
 import compositionShaderSource from "./composition.wgsl?raw";
 import { CopyPass } from "./copy-pass.ts";
 import { DisintegrationParticleSystem } from "./disintegration-particles.ts";
@@ -1953,11 +1948,7 @@ export class InfiniteCanvasRenderer {
    * can be removed immediately while the dust animation plays independently.
    */
   #copyCurrentVideoFrameToTexture(entity: ShaderCanvasEntity, label: string): GPUTexture | null {
-    if (
-      !this.#device ||
-      !this.#externalTextureCopyPass ||
-      entity.mediaSource.type !== "video"
-    ) {
+    if (!this.#device || !this.#externalTextureCopyPass || entity.mediaSource.type !== "video") {
       return null;
     }
 

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -13,12 +13,20 @@ import {
   getViewportMatrix,
   getViewportWorldBounds,
 } from "../lib/canvas-math.ts";
-import { type Bounds, type RGBA, type ShaderCanvasEntity, type Viewport } from "#types/canvas.ts";
+import {
+  DitheringKind,
+  isErrorDiffusion,
+  ShaderType,
+  type Bounds,
+  type RGBA,
+  type ShaderCanvasEntity,
+  type Viewport,
+} from "#types/canvas.ts";
 import compositionShaderSource from "./composition.wgsl?raw";
 import { CopyPass } from "./copy-pass.ts";
 import { DisintegrationParticleSystem } from "./disintegration-particles.ts";
 import dotGridShaderSource from "./dot-grid.wgsl?raw";
-import { EntityShaderRuntime } from "./entity-shader-runtime.ts";
+import { EntityShaderRuntime, type EntityShaderSource } from "./entity-shader-runtime.ts";
 import { ExportService } from "./export-service.ts";
 import { detectGpuColorConfig, type GpuColorConfig } from "./gpu-color-space.ts";
 import selectionRectShaderSource from "./selection-rect.wgsl?raw";
@@ -30,10 +38,52 @@ import actionLayerBlitShaderSource from "./action-layer-blit.wgsl?raw";
 
 interface CompositionDrawItem {
   bindGroup: GPUBindGroup;
+  pipeline: "texture" | "external";
   entity: ShaderCanvasEntity;
   isSelected: boolean;
   offsetX: number;
   offsetY: number;
+}
+
+type CompositionSource =
+  | { kind: "texture"; texture: GPUTexture }
+  | { kind: "external"; texture: GPUExternalTexture };
+
+const externalVideoBlitShaderSource = `
+@group(0) @binding(0) var sourceTexture: texture_external;
+@group(0) @binding(1) var sourceSampler: sampler;
+
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) uv: vec2f,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+  let uv = vec2f(f32((vertexIndex << 1u) & 2u), f32(vertexIndex & 2u));
+  var out: VertexOutput;
+  out.position = vec4f(uv * 2.0 - 1.0, 0.0, 1.0);
+  out.uv = vec2f(uv.x, 1.0 - uv.y);
+  return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+  let color = textureSampleBaseClampToEdge(sourceTexture, sourceSampler, in.uv);
+  return vec4f(color.rgb, 1.0);
+}
+`;
+
+function createExternalCompositionShaderSource(source: string): string {
+  return source
+    .replace(
+      /@group\(0\)\s+@binding\(2\)\s+var\s+entityTexture:\s+texture_2d<f32>;/,
+      "@group(0) @binding(2) var entityTexture: texture_external;",
+    )
+    .replace(
+      /textureSample\(entityTexture,\s*entitySampler,/g,
+      "textureSampleBaseClampToEdge(entityTexture, entitySampler,",
+    );
 }
 
 export class InfiniteCanvasRenderer {
@@ -53,10 +103,15 @@ export class InfiniteCanvasRenderer {
 
   // Composition pipeline
   #compositionPipeline: GPURenderPipeline | null = null;
+  #externalCompositionPipeline: GPURenderPipeline | null = null;
+  #externalVideoBlitPipeline: GPURenderPipeline | null = null;
+  #externalVideoBlitBindGroupLayout: GPUBindGroupLayout | null = null;
+  #externalVideoBlitSampler: GPUSampler | null = null;
   #viewportUniformBuffer: GPUBuffer | null = null;
   #entityUniformBuffer: GPUBuffer | null = null;
   #compositionSampler: GPUSampler | null = null;
   #compositionBindGroupLayout: GPUBindGroupLayout | null = null;
+  #externalCompositionBindGroupLayout: GPUBindGroupLayout | null = null;
   #viewportUniformData = new ArrayBuffer(config.rendering.viewportUniformSize);
   #viewportFloatView = new Float32Array(this.#viewportUniformData);
   #entityUniformData = new ArrayBuffer(config.rendering.entityUniformSize);
@@ -96,6 +151,13 @@ export class InfiniteCanvasRenderer {
       lastHovered: boolean;
       lastSelected: boolean;
       lastDebugMode: boolean;
+    }
+  > = new Map();
+
+  #entityExternalCompositionCache: Map<
+    string,
+    {
+      uniformBuffer: GPUBuffer;
     }
   > = new Map();
 
@@ -273,6 +335,7 @@ export class InfiniteCanvasRenderer {
 
     this.#createGridPipeline();
     this.#createCompositionPipeline();
+    this.#createExternalVideoBlitPipeline();
     this.#entityShaderRuntime = new EntityShaderRuntime({
       device: this.#device,
       colorConfig: this.#colorConfig,
@@ -438,6 +501,32 @@ export class InfiniteCanvasRenderer {
       ],
     });
 
+    this.#externalCompositionBindGroupLayout = this.#device.createBindGroupLayout({
+      label: "External composition bind group layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        {
+          binding: 3,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+      ],
+    });
+
     this.#viewportUniformBuffer = this.#device.createBuffer({
       label: "Viewport uniforms",
       size: config.rendering.viewportUniformSize,
@@ -495,6 +584,138 @@ export class InfiniteCanvasRenderer {
         topology: "triangle-list",
       },
     });
+
+    const externalShaderModule = this.#device.createShaderModule({
+      label: "External composition shader",
+      code: createExternalCompositionShaderSource(compositionShaderSource),
+    });
+
+    const externalPipelineLayout = this.#device.createPipelineLayout({
+      label: "External composition pipeline layout",
+      bindGroupLayouts: [this.#externalCompositionBindGroupLayout],
+    });
+
+    this.#externalCompositionPipeline = this.#device.createRenderPipeline({
+      label: "External composition pipeline",
+      layout: externalPipelineLayout,
+      vertex: {
+        module: externalShaderModule,
+        entryPoint: "vs_main",
+      },
+      fragment: {
+        module: externalShaderModule,
+        entryPoint: "fs_main",
+        targets: [
+          {
+            format: this.#canvasFormat,
+            blend: {
+              color: {
+                srcFactor: "src-alpha",
+                dstFactor: "one-minus-src-alpha",
+                operation: "add",
+              },
+              alpha: {
+                srcFactor: "one",
+                dstFactor: "one-minus-src-alpha",
+                operation: "add",
+              },
+            },
+          },
+        ],
+      },
+      primitive: {
+        topology: "triangle-list",
+      },
+    });
+  }
+
+  #createExternalVideoBlitPipeline(): void {
+    if (!this.#device) return;
+
+    this.#externalVideoBlitBindGroupLayout = this.#device.createBindGroupLayout({
+      label: "External video blit bind group layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+      ],
+    });
+
+    this.#externalVideoBlitSampler = this.#device.createSampler({
+      label: "External video blit sampler",
+      magFilter: "linear",
+      minFilter: "linear",
+      addressModeU: "clamp-to-edge",
+      addressModeV: "clamp-to-edge",
+    });
+
+    const shaderModule = this.#device.createShaderModule({
+      label: "External video blit shader",
+      code: externalVideoBlitShaderSource,
+    });
+    const pipelineLayout = this.#device.createPipelineLayout({
+      label: "External video blit pipeline layout",
+      bindGroupLayouts: [this.#externalVideoBlitBindGroupLayout],
+    });
+
+    this.#externalVideoBlitPipeline = this.#device.createRenderPipeline({
+      label: "External video blit pipeline",
+      layout: pipelineLayout,
+      vertex: { module: shaderModule, entryPoint: "vs_main" },
+      fragment: {
+        module: shaderModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.#colorConfig.intermediateFormat }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+  }
+
+  #blitExternalVideoToTexture(
+    source: GPUExternalTexture,
+    destination: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    if (
+      !this.#device ||
+      !this.#externalVideoBlitPipeline ||
+      !this.#externalVideoBlitBindGroupLayout ||
+      !this.#externalVideoBlitSampler
+    ) {
+      return;
+    }
+
+    const bindGroup = this.#device.createBindGroup({
+      label: "External video blit bind group",
+      layout: this.#externalVideoBlitBindGroupLayout,
+      entries: [
+        { binding: 0, resource: source },
+        { binding: 1, resource: this.#externalVideoBlitSampler },
+      ],
+    });
+
+    const pass = encoder.beginRenderPass({
+      label: "External video blit render pass",
+      colorAttachments: [
+        {
+          view: destination.createView(),
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+        },
+      ],
+    });
+    pass.setPipeline(this.#externalVideoBlitPipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
   }
 
   #createSelectionRectPipeline(): void {
@@ -843,7 +1064,7 @@ export class InfiniteCanvasRenderer {
     });
     this.#entityShaderRuntime.encode({
       entity,
-      sourceTexture,
+      source: { kind: "texture", texture: sourceTexture },
       outputTexture,
       encoder,
       width: entity.originalSize.width,
@@ -852,6 +1073,35 @@ export class InfiniteCanvasRenderer {
     });
 
     this.#device.queue.submit([encoder.finish()]);
+    this.#entityShaderRuntime.flushTextureReleases();
+  }
+
+  #shouldMaterializeVideoSource(entity: ShaderCanvasEntity): boolean {
+    if (entity.mediaSource.type !== "video" || entity.shaderParams.showOriginal) return false;
+
+    if ((entity.shaderParams.adjustments?.blur ?? 0) > 0) {
+      // TODO(video-external): Add a texture_external variant for the first
+      // blur/downsample pass. Until then, pre-blurred video needs a normal
+      // source texture.
+      return true;
+    }
+
+    const ditheringKind = entity.shaderParams.dithering?.kind ?? DitheringKind.bayer4x4;
+    if (entity.shaderType === ShaderType.dithering && isErrorDiffusion(ditheringKind)) {
+      // TODO(video-external): Add an external-texture compute variant for
+      // error-diffusion dithering, or port that path to fragment passes.
+      return true;
+    }
+
+    return false;
+  }
+
+  #destroyEntitySourceTexture(entityId: string): void {
+    const cachedSource = this.#entitySourceTextures.get(entityId);
+    if (!cachedSource) return;
+
+    cachedSource.texture.destroy();
+    this.#entitySourceTextures.delete(entityId);
   }
 
   #updateGridUniforms(viewport: Viewport): void {
@@ -931,7 +1181,11 @@ export class InfiniteCanvasRenderer {
     selectedEntityCount: number,
   ): void {
     for (const item of items) {
-      pass.setPipeline(this.#compositionPipeline!);
+      pass.setPipeline(
+        item.pipeline === "external"
+          ? this.#externalCompositionPipeline!
+          : this.#compositionPipeline!,
+      );
       pass.setBindGroup(0, item.bindGroup);
       pass.draw(6);
 
@@ -1082,14 +1336,25 @@ export class InfiniteCanvasRenderer {
    * Render an entity's image through its shader to a texture.
    * Returns the texture, caching it for future frames.
    */
-  renderEntityToTexture(entity: ShaderCanvasEntity): GPUTexture | null {
+  renderEntityToTexture(
+    entity: ShaderCanvasEntity,
+    encoder: GPUCommandEncoder,
+  ): CompositionSource | null {
     if (!this.#device || !this.#entityShaderRuntime) {
       return null;
     }
 
-    // Time-based shaders need the shader pass every frame, but animated media only
-    // re-uploads/re-shades when the game loop marks a new decoded frame dirty.
-    const needsContinuousShaderRender = this.#entityShaderRuntime.needsContinuousRender(entity);
+    const width = entity.originalSize.width;
+    const height = entity.originalSize.height;
+    const useExternalVideoSource =
+      entity.mediaSource.type === "video" && !this.#shouldMaterializeVideoSource(entity);
+
+    // Time-based shaders and zero-copy video sources need the shader pass every frame that the
+    // canvas renders. The source frame lives behind the HTMLVideoElement, so reusing an old
+    // processed output can show stale/cross-ticked frames when multiple videos are playing.
+    const needsContinuousShaderRender =
+      this.#entityShaderRuntime.needsContinuousRender(entity) ||
+      (useExternalVideoSource && !entity.shaderParams.showOriginal);
 
     // Check if we have a valid processed texture.
     const cachedTexture = this.#entityTextures.get(entity.id);
@@ -1099,11 +1364,47 @@ export class InfiniteCanvasRenderer {
       cachedTexture &&
       !entity.textureDirty
     ) {
-      return cachedTexture;
+      return { kind: "texture", texture: cachedTexture };
     }
+    let shaderSource: EntityShaderSource | null = null;
+    let sourceTexture: GPUTexture | null = null;
 
-    const width = entity.originalSize.width;
-    const height = entity.originalSize.height;
+    if (useExternalVideoSource && entity.mediaSource.type === "video") {
+      this.#destroyEntitySourceTexture(entity.id);
+      const video = entity.mediaSource.videoElement;
+      const externalTexture = this.#device.importExternalTexture({
+        source: video,
+        colorSpace: this.#colorConfig.textureColorSpace,
+      });
+
+      if (entity.shaderParams.showOriginal) {
+        const outputUsage =
+          GPUTextureUsage.TEXTURE_BINDING |
+          GPUTextureUsage.RENDER_ATTACHMENT |
+          GPUTextureUsage.COPY_DST |
+          GPUTextureUsage.COPY_SRC;
+        let outputTexture: GPUTexture;
+        if (cachedTexture && cachedTexture.width === width && cachedTexture.height === height) {
+          outputTexture = cachedTexture;
+        } else {
+          cachedTexture?.destroy();
+          outputTexture = this.#device.createTexture({
+            label: `Entity ${entity.id} original video texture`,
+            size: [width, height],
+            format: this.#colorConfig.intermediateFormat,
+            usage: outputUsage,
+          });
+        }
+        // Safari corrupts direct external-video composition for showOriginal.
+        // Keep the zero-CPU-copy path, but normalize through a GPU blit into the
+        // same texture format used by processed entities.
+        this.#blitExternalVideoToTexture(externalTexture, outputTexture, encoder);
+        this.#entityTextures.set(entity.id, outputTexture);
+        return { kind: "texture", texture: outputTexture };
+      }
+
+      shaderSource = { kind: "external", texture: externalTexture };
+    }
 
     // Source texture usage flags
     const sourceUsage =
@@ -1115,47 +1416,50 @@ export class InfiniteCanvasRenderer {
     // Check source texture cache: reuse when source dimensions match and no new media frame
     // was marked dirty. This lets viewport/UI redraws sample the previous video frame.
     const cachedSource = this.#entitySourceTextures.get(entity.id);
-    let sourceTexture: GPUTexture;
 
-    if (
-      !entity.textureDirty &&
-      cachedSource &&
-      cachedSource.width === width &&
-      cachedSource.height === height
-    ) {
-      sourceTexture = cachedSource.texture;
-    } else {
-      // Source changed, dimensions changed, or a new animated frame arrived: upload.
-      if (cachedSource && (cachedSource.width !== width || cachedSource.height !== height)) {
-        // Dimensions changed — destroy old, create new
-        cachedSource.texture.destroy();
-        sourceTexture = this.#device.createTexture({
-          label: `Entity ${entity.id} cached source`,
-          size: [width, height],
-          format: "rgba8unorm",
-          usage: sourceUsage,
-        });
-      } else if (cachedSource) {
-        // Same dimensions — reuse existing texture object, just re-upload data
+    if (!shaderSource) {
+      if (
+        !entity.textureDirty &&
+        cachedSource &&
+        cachedSource.width === width &&
+        cachedSource.height === height
+      ) {
         sourceTexture = cachedSource.texture;
       } else {
-        // First render — create new long-lived source texture
-        sourceTexture = this.#device.createTexture({
-          label: `Entity ${entity.id} cached source`,
-          size: [width, height],
-          format: "rgba8unorm",
-          usage: sourceUsage,
+        // Source changed, dimensions changed, or a new animated frame arrived: upload.
+        if (cachedSource && (cachedSource.width !== width || cachedSource.height !== height)) {
+          // Dimensions changed — destroy old, create new
+          cachedSource.texture.destroy();
+          sourceTexture = this.#device.createTexture({
+            label: `Entity ${entity.id} cached source`,
+            size: [width, height],
+            format: "rgba8unorm",
+            usage: sourceUsage,
+          });
+        } else if (cachedSource) {
+          // Same dimensions — reuse existing texture object, just re-upload data
+          sourceTexture = cachedSource.texture;
+        } else {
+          // First render — create new long-lived source texture
+          sourceTexture = this.#device.createTexture({
+            label: `Entity ${entity.id} cached source`,
+            size: [width, height],
+            format: "rgba8unorm",
+            usage: sourceUsage,
+          });
+        }
+
+        const sourceRef = this.#uploadEntitySourceToTexture(entity, sourceTexture, width, height);
+
+        this.#entitySourceTextures.set(entity.id, {
+          texture: sourceTexture,
+          sourceRef,
+          width,
+          height,
         });
       }
 
-      const sourceRef = this.#uploadEntitySourceToTexture(entity, sourceTexture, width, height);
-
-      this.#entitySourceTextures.set(entity.id, {
-        texture: sourceTexture,
-        sourceRef,
-        width,
-        height,
-      });
+      shaderSource = { kind: "texture", texture: sourceTexture! };
     }
 
     // If showOriginal is enabled, compose the source texture directly. The source texture
@@ -1166,7 +1470,7 @@ export class InfiniteCanvasRenderer {
         cachedTexture.destroy();
         this.#entityTextures.delete(entity.id);
       }
-      return sourceTexture;
+      return { kind: "texture", texture: sourceTexture! };
     }
 
     // Reuse output texture if dimensions match, otherwise create new
@@ -1191,12 +1495,20 @@ export class InfiniteCanvasRenderer {
       });
     }
 
-    // Apply shader using unified method (handles both compute and fragment shader paths)
-    this.#applyShaderToTexture(entity, sourceTexture, outputTexture);
+    // Apply shader using unified method (handles fragment/external paths and compute fallback paths).
+    this.#entityShaderRuntime.encode({
+      entity,
+      source: shaderSource,
+      outputTexture,
+      encoder,
+      width,
+      height,
+      respectShowOriginal: true,
+    });
 
     // Cache and return (source texture stays in #entitySourceTextures)
     this.#entityTextures.set(entity.id, outputTexture);
-    return outputTexture;
+    return { kind: "texture", texture: outputTexture };
   }
 
   /**
@@ -1204,7 +1516,14 @@ export class InfiniteCanvasRenderer {
    * Optimized to batch all render passes into a single GPU submission.
    */
   render(state: RenderState): void {
-    if (!this.#device || !this.#context || !this.#gridPipeline || !this.#compositionPipeline) {
+    if (
+      !this.#device ||
+      !this.#context ||
+      !this.#gridPipeline ||
+      !this.#compositionPipeline ||
+      !this.#externalCompositionPipeline ||
+      !this.#externalVideoBlitPipeline
+    ) {
       return;
     }
 
@@ -1265,6 +1584,13 @@ export class InfiniteCanvasRenderer {
     // Sort entities in-place by z-index (avoid array copying)
     entities.sort((a, b) => a.zIndex - b.zIndex);
 
+    // Entity preprocessing can encode shader passes into this same command buffer.
+    // External video textures must be imported, bound, encoded, finished, and submitted
+    // inside the current render task.
+    const encoder = this.#device.createCommandEncoder({
+      label: "Canvas render encoder",
+    });
+
     // Pre-process entities: render to textures and prepare bind groups
     // Uses caching to avoid per-frame allocations
     const entityDrawItems: CompositionDrawItem[] = [];
@@ -1296,9 +1622,8 @@ export class InfiniteCanvasRenderer {
         hasAnimatingContent = true;
       }
 
-      // Render entity to texture if needed (this has its own submission for dirty textures)
-      const entityTexture = this.renderEntityToTexture(entity);
-      if (!entityTexture) continue;
+      const compositionSource = this.renderEntityToTexture(entity, encoder);
+      if (!compositionSource) continue;
 
       // Clear dirty flag
       entity.textureDirty = false;
@@ -1307,29 +1632,97 @@ export class InfiniteCanvasRenderer {
       const isHovered = entity.id === hoveredEntityId;
       const isSelected = selectedEntityIds.has(entity.id);
 
-      // Check cache for existing composition resources
-      const cached = this.#entityCompositionCache.get(entity.id);
-      const textureChanged = cached?.texture !== entityTexture;
-      const needsNewBindGroup =
-        !cached ||
-        textureChanged ||
-        cached.lastHovered !== isHovered ||
-        cached.lastSelected !== isSelected ||
-        cached.lastDebugMode !== debugMode;
-
       let bindGroup: GPUBindGroup;
+      let pipeline: "texture" | "external";
 
-      if (needsNewBindGroup) {
-        // Create or reuse uniform buffer
+      if (compositionSource.kind === "texture") {
+        pipeline = "texture";
+
+        // Check cache for existing composition resources
+        const cached = this.#entityCompositionCache.get(entity.id);
+        const textureChanged = cached?.texture !== compositionSource.texture;
+        const needsNewBindGroup =
+          !cached ||
+          textureChanged ||
+          cached.lastHovered !== isHovered ||
+          cached.lastSelected !== isSelected ||
+          cached.lastDebugMode !== debugMode;
+
+        if (needsNewBindGroup) {
+          // Create or reuse uniform buffer
+          const uniformBuffer =
+            cached?.uniformBuffer ??
+            this.#device.createBuffer({
+              label: `Entity ${entity.id} composition uniform`,
+              size: config.rendering.entityUniformSize,
+              usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+            });
+
+          // Update and write entity uniforms (apply rubber-band offset for action layer entities)
+          const applyOffset =
+            actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
+          this.#updateEntityUniforms(
+            entity,
+            isHovered,
+            isSelected,
+            debugMode,
+            applyOffset ? actionLayerOffsetX : 0,
+            applyOffset ? actionLayerOffsetY : 0,
+          );
+          this.#device.queue.writeBuffer(uniformBuffer, 0, this.#entityUniformData);
+
+          // Create texture view (reuse if texture didn't change)
+          const textureView =
+            cached && !textureChanged ? cached.textureView : compositionSource.texture.createView();
+
+          // Create bind group with dedicated uniform buffer
+          bindGroup = this.#device.createBindGroup({
+            label: `Entity ${entity.id} composition bind group`,
+            layout: this.#compositionBindGroupLayout!,
+            entries: [
+              { binding: 0, resource: { buffer: this.#viewportUniformBuffer! } },
+              { binding: 1, resource: { buffer: uniformBuffer } },
+              { binding: 2, resource: textureView },
+              { binding: 3, resource: this.#compositionSampler! },
+            ],
+          });
+
+          // Update cache
+          this.#entityCompositionCache.set(entity.id, {
+            uniformBuffer,
+            texture: compositionSource.texture,
+            textureView,
+            bindGroup,
+            lastHovered: isHovered,
+            lastSelected: isSelected,
+            lastDebugMode: debugMode,
+          });
+        } else {
+          // Reuse cached bind group, but ALWAYS update uniform buffer with current position
+          // This is critical for drag operations where position changes every frame
+          const applyOffset2 =
+            actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
+          this.#updateEntityUniforms(
+            entity,
+            isHovered,
+            isSelected,
+            debugMode,
+            applyOffset2 ? actionLayerOffsetX : 0,
+            applyOffset2 ? actionLayerOffsetY : 0,
+          );
+          this.#device.queue.writeBuffer(cached.uniformBuffer, 0, this.#entityUniformData);
+          bindGroup = cached.bindGroup;
+        }
+      } else {
+        pipeline = "external";
+        const cached = this.#entityExternalCompositionCache.get(entity.id);
         const uniformBuffer =
           cached?.uniformBuffer ??
           this.#device.createBuffer({
-            label: `Entity ${entity.id} composition uniform`,
+            label: `Entity ${entity.id} external composition uniform`,
             size: config.rendering.entityUniformSize,
             usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
           });
-
-        // Update and write entity uniforms (apply rubber-band offset for action layer entities)
         const applyOffset =
           actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
         this.#updateEntityUniforms(
@@ -1341,48 +1734,19 @@ export class InfiniteCanvasRenderer {
           applyOffset ? actionLayerOffsetY : 0,
         );
         this.#device.queue.writeBuffer(uniformBuffer, 0, this.#entityUniformData);
-
-        // Create texture view (reuse if texture didn't change)
-        const textureView =
-          cached && !textureChanged ? cached.textureView : entityTexture.createView();
-
-        // Create bind group with dedicated uniform buffer
         bindGroup = this.#device.createBindGroup({
-          label: `Entity ${entity.id} composition bind group`,
-          layout: this.#compositionBindGroupLayout!,
+          label: `Entity ${entity.id} external composition bind group`,
+          layout: this.#externalCompositionBindGroupLayout!,
           entries: [
             { binding: 0, resource: { buffer: this.#viewportUniformBuffer! } },
             { binding: 1, resource: { buffer: uniformBuffer } },
-            { binding: 2, resource: textureView },
+            { binding: 2, resource: compositionSource.texture },
             { binding: 3, resource: this.#compositionSampler! },
           ],
         });
-
-        // Update cache
-        this.#entityCompositionCache.set(entity.id, {
-          uniformBuffer,
-          texture: entityTexture,
-          textureView,
-          bindGroup,
-          lastHovered: isHovered,
-          lastSelected: isSelected,
-          lastDebugMode: debugMode,
-        });
-      } else {
-        // Reuse cached bind group, but ALWAYS update uniform buffer with current position
-        // This is critical for drag operations where position changes every frame
-        const applyOffset2 =
-          actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
-        this.#updateEntityUniforms(
-          entity,
-          isHovered,
-          isSelected,
-          debugMode,
-          applyOffset2 ? actionLayerOffsetX : 0,
-          applyOffset2 ? actionLayerOffsetY : 0,
-        );
-        this.#device.queue.writeBuffer(cached.uniformBuffer, 0, this.#entityUniformData);
-        bindGroup = cached.bindGroup;
+        if (!cached) {
+          this.#entityExternalCompositionCache.set(entity.id, { uniformBuffer });
+        }
       }
 
       // Action layer entities are drawn AFTER blur (not in main pass) to avoid halo
@@ -1391,6 +1755,7 @@ export class InfiniteCanvasRenderer {
       if (isActionLayerEntity) {
         actionLayerDrawItems.push({
           bindGroup,
+          pipeline,
           entity,
           isSelected,
           offsetX: actionLayerOffsetX,
@@ -1399,6 +1764,7 @@ export class InfiniteCanvasRenderer {
       } else {
         entityDrawItems.push({
           bindGroup,
+          pipeline,
           entity,
           isSelected,
           offsetX: 0,
@@ -1408,14 +1774,10 @@ export class InfiniteCanvasRenderer {
     }
     markPhaseEnd("entity-prep");
 
-    // Create single command encoder for grid + all entities
-    const encoder = this.#device.createCommandEncoder({
-      label: "Canvas render encoder",
-    });
-
     const texture = this.#context.getCurrentTexture();
     // Skip render if swapchain texture is invalid
     if (texture.width === 0 || texture.height === 0) {
+      this.#entityShaderRuntime?.flushTextureReleases();
       return;
     }
     const targetView = texture.createView();
@@ -1724,6 +2086,7 @@ export class InfiniteCanvasRenderer {
     // Single submission for all passes
     markPhaseStart("queue-submit");
     this.#device.queue.submit([encoder.finish()]);
+    this.#entityShaderRuntime?.flushTextureReleases();
     markPhaseEnd("queue-submit");
 
     // Record frame stats for performance overlay
@@ -1789,6 +2152,12 @@ export class InfiniteCanvasRenderer {
       this.#entityCompositionCache.delete(entityId);
     }
 
+    const externalCached = this.#entityExternalCompositionCache.get(entityId);
+    if (externalCached) {
+      externalCached.uniformBuffer.destroy();
+      this.#entityExternalCompositionCache.delete(entityId);
+    }
+
     this.#entityShaderRuntime?.removeEntity(entityId);
 
     // Clear any errors for this entity
@@ -1800,8 +2169,9 @@ export class InfiniteCanvasRenderer {
    * Called before removeEntityTexture — copies the GPU texture so the entity
    * can be removed immediately while the dust animation plays independently.
    */
-  #createDisintegrationSnapshot(entityId: string): GPUTexture | null {
+  #createDisintegrationSnapshot(entity: ShaderCanvasEntity): GPUTexture | null {
     if (!this.#device) return null;
+    const entityId = entity.id;
 
     const renderedTexture = this.#entityTextures.get(entityId);
     if (renderedTexture) {
@@ -1820,7 +2190,24 @@ export class InfiniteCanvasRenderer {
       return snapshotTexture;
     }
 
-    const sourceTexture = this.#entitySourceTextures.get(entityId)?.texture;
+    let sourceTexture = this.#entitySourceTextures.get(entityId)?.texture ?? null;
+    let temporarySourceTexture: GPUTexture | null = null;
+    if (!sourceTexture && entity.mediaSource.type === "video") {
+      const width = entity.originalSize.width;
+      const height = entity.originalSize.height;
+      sourceTexture = this.#device.createTexture({
+        label: `Disintegration video snapshot source ${entityId}`,
+        size: [width, height],
+        format: "rgba8unorm",
+        usage:
+          GPUTextureUsage.TEXTURE_BINDING |
+          GPUTextureUsage.COPY_DST |
+          GPUTextureUsage.COPY_SRC |
+          GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+      this.#uploadEntitySourceToTexture(entity, sourceTexture, width, height);
+      temporarySourceTexture = sourceTexture;
+    }
     if (!sourceTexture || !this.#entityShaderRuntime) return null;
 
     const snapshotTexture = this.#device.createTexture({
@@ -1832,18 +2219,14 @@ export class InfiniteCanvasRenderer {
     const encoder = this.#device.createCommandEncoder();
     this.#entityShaderRuntime.passthroughCopyPass.encode(encoder, sourceTexture, snapshotTexture);
     this.#device.queue.submit([encoder.finish()]);
+    temporarySourceTexture?.destroy();
     return snapshotTexture;
   }
 
-  startDisintegration(entity: {
-    id: string;
-    position: { x: number; y: number };
-    size: { width: number; height: number };
-    rotation: number;
-  }): void {
+  startDisintegration(entity: ShaderCanvasEntity): void {
     if (!this.#device || !this.#compositionBindGroupLayout) return;
 
-    const snapshotTexture = this.#createDisintegrationSnapshot(entity.id);
+    const snapshotTexture = this.#createDisintegrationSnapshot(entity);
     if (!snapshotTexture) return;
 
     const textureView = snapshotTexture.createView();
@@ -1973,7 +2356,11 @@ export class InfiniteCanvasRenderer {
 
   #getDisplayedEntityTexture(entity: ShaderCanvasEntity): GPUTexture | null {
     if (entity.shaderParams.showOriginal) {
-      return this.#entitySourceTextures.get(entity.id)?.texture ?? null;
+      return (
+        this.#entitySourceTextures.get(entity.id)?.texture ??
+        this.#entityTextures.get(entity.id) ??
+        null
+      );
     }
 
     return this.#entityTextures.get(entity.id) ?? null;
@@ -2028,6 +2415,11 @@ export class InfiniteCanvasRenderer {
       cached.uniformBuffer.destroy();
     }
     this.#entityCompositionCache.clear();
+
+    for (const cached of this.#entityExternalCompositionCache.values()) {
+      cached.uniformBuffer.destroy();
+    }
+    this.#entityExternalCompositionCache.clear();
 
     // Destroy disintegration overlays + particle system
     for (const overlay of this.#disintegrationOverlays.values()) {
@@ -2093,10 +2485,15 @@ export class InfiniteCanvasRenderer {
     // Clear references
     this.#gridPipeline = null;
     this.#compositionPipeline = null;
+    this.#externalCompositionPipeline = null;
+    this.#externalVideoBlitPipeline = null;
+    this.#externalVideoBlitBindGroupLayout = null;
+    this.#externalVideoBlitSampler = null;
     this.#selectionRectPipeline = null;
     this.#gridBindGroup = null;
     this.#selectionRectBindGroup = null;
     this.#compositionBindGroupLayout = null;
+    this.#externalCompositionBindGroupLayout = null;
     this.#context = null;
     this.#device = null;
   }

--- a/renderer/entity-shader-runtime.ts
+++ b/renderer/entity-shader-runtime.ts
@@ -149,19 +149,17 @@ export class EntityShaderRuntime {
     let adjustmentsOutputTexture: GPUTexture | null = null;
 
     if (needsBlur) {
-      if (source.kind === "external") {
-        // TODO(video-external): Add an external-texture variant for the first
-        // Kawase blur/downsample pass so videos with pre-blur do not need a
-        // materialized source texture.
-        return;
-      }
       blurOutputTexture = this.#acquireTexture(
         width,
         height,
         preProcessUsage,
         "Blur output texture",
       );
-      this.#processingPipeline.applyBlur(entity, source.texture, blurOutputTexture, encoder);
+      if (source.kind === "external") {
+        this.#processingPipeline.applyBlurExternal(entity, source, blurOutputTexture, encoder);
+      } else {
+        this.#processingPipeline.applyBlur(entity, source.texture, blurOutputTexture, encoder);
+      }
       shaderSource = { kind: "texture", texture: blurOutputTexture };
     }
 

--- a/renderer/entity-shader-runtime.ts
+++ b/renderer/entity-shader-runtime.ts
@@ -13,6 +13,7 @@ import { GlitchShader } from "./shaders/glitch-shader.ts";
 import { HalftoneShader } from "./shaders/halftone-shader.ts";
 import { MeltShader } from "./shaders/melt-shader.ts";
 import type { ShaderContext } from "./shaders/shader-pass.ts";
+import type { ExternalTextureSource } from "./shaders/shader-pass.ts";
 import { ShaderRegistry } from "./shaders/shader-registry.ts";
 import type { TexturePool } from "./texture-pool.ts";
 
@@ -23,6 +24,10 @@ export interface EntityShaderRuntimeOptions {
   onEntityError?: (entityId: string, error: string) => void;
 }
 
+export type EntityShaderSource =
+  | { kind: "texture"; texture: GPUTexture }
+  | ({ kind: "external" } & ExternalTextureSource);
+
 export class EntityShaderRuntime {
   #device: GPUDevice;
   #colorConfig: GpuColorConfig;
@@ -30,13 +35,18 @@ export class EntityShaderRuntime {
   #shaderRegistry = new ShaderRegistry();
   #processingPipeline: ProcessingPipeline;
   #passthroughCopyPass: CopyPass;
-  #uniformBuffer: GPUBuffer;
   #sampler: GPUSampler;
   #uniformData = new ArrayBuffer(config.rendering.ditheringUniformSize);
   #floatView = new Float32Array(this.#uniformData);
   #uintView = new Uint32Array(this.#uniformData);
   #sortedPaletteCache: { original: readonly RGBA[]; reversed: boolean; sorted: RGBA[] } | null =
     null;
+  #pendingTextureReleases: Array<{
+    texture: GPUTexture;
+    width: number;
+    height: number;
+    usage: GPUTextureUsageFlags;
+  }> = [];
   #shaderContext: ShaderContext;
   #initialized = false;
   #onEntityError?: (entityId: string, error: string) => void;
@@ -46,11 +56,6 @@ export class EntityShaderRuntime {
     this.#colorConfig = options.colorConfig;
     this.#texturePool = options.texturePool;
     this.#onEntityError = options.onEntityError;
-    this.#uniformBuffer = this.#device.createBuffer({
-      label: "Entity shader uniforms",
-      size: config.rendering.ditheringUniformSize,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
     this.#sampler = this.#device.createSampler({
       label: "Entity shader sampler",
       magFilter: "linear",
@@ -60,13 +65,15 @@ export class EntityShaderRuntime {
     });
     this.#shaderContext = {
       device: this.#device,
-      uniformBuffer: this.#uniformBuffer,
       uniformData: this.#uniformData,
       floatView: this.#floatView,
       uintView: this.#uintView,
       sampler: this.#sampler,
       sortedPaletteCache: this.#sortedPaletteCache,
       texturePool: this.#texturePool,
+      releaseTexture: (texture, width, height, usage) => {
+        this.#releaseTexture(texture, width, height, usage);
+      },
       intermediateFormat: this.#colorConfig.intermediateFormat,
       supportsP3: this.#colorConfig.supportsP3,
     };
@@ -113,16 +120,18 @@ export class EntityShaderRuntime {
 
   encode(params: {
     entity: EffectRenderEntity;
-    sourceTexture: GPUTexture;
+    source: EntityShaderSource;
     outputTexture: GPUTexture;
     encoder: GPUCommandEncoder;
     width: number;
     height: number;
     respectShowOriginal: boolean;
   }): void {
-    const { entity, sourceTexture, outputTexture, encoder, width, height } = params;
+    const { entity, source, outputTexture, encoder, width, height } = params;
 
     if (params.respectShowOriginal && entity.shaderParams.showOriginal) {
+      if (source.kind === "external") return;
+      const sourceTexture = source.texture;
       this.#passthroughCopyPass.encode(encoder, sourceTexture, outputTexture);
       return;
     }
@@ -135,19 +144,25 @@ export class EntityShaderRuntime {
       GPUTextureUsage.RENDER_ATTACHMENT |
       GPUTextureUsage.COPY_SRC;
 
-    let shaderSourceTexture = sourceTexture;
+    let shaderSource = source;
     let blurOutputTexture: GPUTexture | null = null;
     let adjustmentsOutputTexture: GPUTexture | null = null;
 
     if (needsBlur) {
+      if (source.kind === "external") {
+        // TODO(video-external): Add an external-texture variant for the first
+        // Kawase blur/downsample pass so videos with pre-blur do not need a
+        // materialized source texture.
+        return;
+      }
       blurOutputTexture = this.#acquireTexture(
         width,
         height,
         preProcessUsage,
         "Blur output texture",
       );
-      this.#processingPipeline.applyBlur(entity, sourceTexture, blurOutputTexture, encoder);
-      shaderSourceTexture = blurOutputTexture;
+      this.#processingPipeline.applyBlur(entity, source.texture, blurOutputTexture, encoder);
+      shaderSource = { kind: "texture", texture: blurOutputTexture };
     }
 
     if (needsAdjustments) {
@@ -157,13 +172,22 @@ export class EntityShaderRuntime {
         preProcessUsage,
         "Adjustments output texture",
       );
-      this.#processingPipeline.applyAdjustments(
-        entity,
-        shaderSourceTexture,
-        adjustmentsOutputTexture,
-        encoder,
-      );
-      shaderSourceTexture = adjustmentsOutputTexture;
+      if (shaderSource.kind === "external") {
+        this.#processingPipeline.applyAdjustmentsExternal(
+          entity,
+          shaderSource,
+          adjustmentsOutputTexture,
+          encoder,
+        );
+      } else {
+        this.#processingPipeline.applyAdjustments(
+          entity,
+          shaderSource.texture,
+          adjustmentsOutputTexture,
+          encoder,
+        );
+      }
+      shaderSource = { kind: "texture", texture: adjustmentsOutputTexture };
     }
 
     const postProcessUsage =
@@ -183,7 +207,21 @@ export class EntityShaderRuntime {
       mainShaderOutputTexture = postProcessIntermediateTexture;
     }
 
-    this.#shaderRegistry.applyShader(entity, shaderSourceTexture, mainShaderOutputTexture, encoder);
+    if (shaderSource.kind === "external") {
+      this.#shaderRegistry.applyShaderExternal(
+        entity,
+        shaderSource,
+        mainShaderOutputTexture,
+        encoder,
+      );
+    } else {
+      this.#shaderRegistry.applyShader(
+        entity,
+        shaderSource.texture,
+        mainShaderOutputTexture,
+        encoder,
+      );
+    }
 
     if (blurOutputTexture) {
       this.#releaseTexture(blurOutputTexture, width, height, preProcessUsage);
@@ -224,11 +262,18 @@ export class EntityShaderRuntime {
     height: number,
     usage: GPUTextureUsageFlags,
   ): void {
-    if (this.#texturePool) {
-      this.#texturePool.release(texture, width, height, usage);
-    } else {
-      texture.destroy();
+    this.#pendingTextureReleases.push({ texture, width, height, usage });
+  }
+
+  flushTextureReleases(): void {
+    for (const release of this.#pendingTextureReleases) {
+      if (this.#texturePool) {
+        this.#texturePool.release(release.texture, release.width, release.height, release.usage);
+      } else {
+        release.texture.destroy();
+      }
     }
+    this.#pendingTextureReleases = [];
   }
 
   needsContinuousRender(entity: EffectRenderEntity): boolean {
@@ -240,6 +285,7 @@ export class EntityShaderRuntime {
       | DitheringShader
       | undefined;
     ditheringShader?.removeEntity(entityId);
+    this.#processingPipeline.removeEntity(entityId);
     this.removeGlassEntity(entityId);
   }
 
@@ -249,8 +295,8 @@ export class EntityShaderRuntime {
   }
 
   destroy(): void {
+    this.flushTextureReleases();
     this.#shaderRegistry.destroy();
     this.#processingPipeline.destroy();
-    this.#uniformBuffer.destroy();
   }
 }

--- a/renderer/external-texture-copy-pass.ts
+++ b/renderer/external-texture-copy-pass.ts
@@ -1,0 +1,118 @@
+const externalTextureCopyShaderSource = `
+@group(0) @binding(0) var sourceTexture: texture_external;
+@group(0) @binding(1) var sourceSampler: sampler;
+
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) uv: vec2f,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+  let uv = vec2f(f32((vertexIndex << 1u) & 2u), f32(vertexIndex & 2u));
+  var out: VertexOutput;
+  out.position = vec4f(uv * 2.0 - 1.0, 0.0, 1.0);
+  out.uv = vec2f(uv.x, 1.0 - uv.y);
+  return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+  let color = textureSampleBaseClampToEdge(sourceTexture, sourceSampler, in.uv);
+  return vec4f(color.rgb, 1.0);
+}
+`;
+
+export class ExternalTextureCopyPass {
+  #device: GPUDevice;
+  #pipeline: GPURenderPipeline;
+  #bindGroupLayout: GPUBindGroupLayout;
+  #sampler: GPUSampler;
+  #textureViewCache = new WeakMap<GPUTexture, GPUTextureView>();
+
+  constructor(device: GPUDevice, format: GPUTextureFormat) {
+    this.#device = device;
+    this.#bindGroupLayout = device.createBindGroupLayout({
+      label: "External texture copy bind group layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+      ],
+    });
+    this.#sampler = device.createSampler({
+      label: "External texture copy sampler",
+      magFilter: "linear",
+      minFilter: "linear",
+      addressModeU: "clamp-to-edge",
+      addressModeV: "clamp-to-edge",
+    });
+
+    const shaderModule = device.createShaderModule({
+      label: "External texture copy shader",
+      code: externalTextureCopyShaderSource,
+    });
+    const pipelineLayout = device.createPipelineLayout({
+      label: "External texture copy pipeline layout",
+      bindGroupLayouts: [this.#bindGroupLayout],
+    });
+    this.#pipeline = device.createRenderPipeline({
+      label: "External texture copy pipeline",
+      layout: pipelineLayout,
+      vertex: { module: shaderModule, entryPoint: "vs_main" },
+      fragment: {
+        module: shaderModule,
+        entryPoint: "fs_main",
+        targets: [{ format }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+  }
+
+  encode(
+    encoder: GPUCommandEncoder,
+    source: GPUExternalTexture,
+    destination: GPUTexture,
+  ): void {
+    const bindGroup = this.#device.createBindGroup({
+      label: "External texture copy bind group",
+      layout: this.#bindGroupLayout,
+      entries: [
+        { binding: 0, resource: source },
+        { binding: 1, resource: this.#sampler },
+      ],
+    });
+
+    const pass = encoder.beginRenderPass({
+      label: "External texture copy pass",
+      colorAttachments: [
+        {
+          view: this.#getTextureView(destination),
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+        },
+      ],
+    });
+    pass.setPipeline(this.#pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+  }
+
+  #getTextureView(texture: GPUTexture): GPUTextureView {
+    const cached = this.#textureViewCache.get(texture);
+    if (cached) return cached;
+
+    const view = texture.createView();
+    this.#textureViewCache.set(texture, view);
+    return view;
+  }
+}

--- a/renderer/external-texture-copy-pass.ts
+++ b/renderer/external-texture-copy-pass.ts
@@ -76,11 +76,7 @@ export class ExternalTextureCopyPass {
     });
   }
 
-  encode(
-    encoder: GPUCommandEncoder,
-    source: GPUExternalTexture,
-    destination: GPUTexture,
-  ): void {
+  encode(encoder: GPUCommandEncoder, source: GPUExternalTexture, destination: GPUTexture): void {
     const bindGroup = this.#device.createBindGroup({
       label: "External texture copy bind group",
       layout: this.#bindGroupLayout,

--- a/renderer/headless-export-renderer.ts
+++ b/renderer/headless-export-renderer.ts
@@ -177,6 +177,7 @@ export class HeadlessExportRenderer {
     try {
       return await consume(encoder, outputTexture);
     } finally {
+      this.#entityShaderRuntime.flushTextureReleases();
       sourceTexture.destroy();
       this.#texturePool.release(outputTexture, width, height, outputUsage);
       this.#texturePool.nextFrame();
@@ -230,7 +231,7 @@ export class HeadlessExportRenderer {
 
     this.#entityShaderRuntime.encode({
       entity,
-      sourceTexture,
+      source: { kind: "texture", texture: sourceTexture },
       outputTexture,
       encoder,
       width,

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -15,6 +15,33 @@ import textureMixShaderSource from "./texture-mix.wgsl?raw";
 /** Number of mip levels in the bloom chain (determines blur spread) */
 const BLOOM_MIP_LEVELS = 5;
 
+interface ExternalTextureSource {
+  texture: GPUExternalTexture;
+}
+
+interface BlurUniformSet {
+  downsample: GPUBuffer[];
+  upsample: GPUBuffer[];
+  mix: GPUBuffer;
+}
+
+interface BloomUniformSet {
+  downsample: GPUBuffer[];
+  upsample: GPUBuffer[];
+}
+
+function createExternalTextureShaderSource(source: string): string {
+  return source
+    .replace(
+      /@group\(0\)\s+@binding\(1\)\s+var\s+sourceTexture:\s+texture_2d<f32>;/,
+      "@group(0) @binding(1) var sourceTexture: texture_external;",
+    )
+    .replace(
+      /textureSample\(sourceTexture,\s*sourceSampler,/g,
+      "textureSampleBaseClampToEdge(sourceTexture, sourceSampler,",
+    );
+}
+
 export class ProcessingPipeline {
   #device: GPUDevice;
   #intermediateFormat: GPUTextureFormat;
@@ -22,8 +49,10 @@ export class ProcessingPipeline {
 
   // Adjustments (pre-processing) pipeline
   #adjustmentsPipeline: GPURenderPipeline | null = null;
+  #adjustmentsExternalPipeline: GPURenderPipeline | null = null;
   #adjustmentsBindGroupLayout: GPUBindGroupLayout | null = null;
-  #adjustmentsUniformBuffer: GPUBuffer | null = null;
+  #adjustmentsExternalBindGroupLayout: GPUBindGroupLayout | null = null;
+  #adjustmentsUniformBuffers = new Map<string, GPUBuffer>();
   #adjustmentsSampler: GPUSampler | null = null;
   #adjustmentsUniformData = new ArrayBuffer(config.rendering.adjustmentsUniformSize);
   #adjustmentsFloatView = new Float32Array(this.#adjustmentsUniformData);
@@ -64,7 +93,7 @@ export class ProcessingPipeline {
   // Post-processing pipeline
   #postProcessPipeline: GPURenderPipeline | null = null;
   #postProcessBindGroupLayout: GPUBindGroupLayout | null = null;
-  #postProcessUniformBuffer: GPUBuffer | null = null;
+  #postProcessUniformBuffers = new Map<string, GPUBuffer>();
   #postProcessSampler: GPUSampler | null = null;
   #postProcessUniformData = new ArrayBuffer(config.rendering.postProcessUniformSize);
   #postProcessFloatView = new Float32Array(this.#postProcessUniformData);
@@ -89,11 +118,99 @@ export class ProcessingPipeline {
       height: number;
     }
   > = new Map();
+  #entityBlurUniforms = new Map<string, BlurUniformSet>();
+  #entityBloomUniforms = new Map<string, BloomUniformSet>();
 
   constructor(device: GPUDevice, intermediateFormat: GPUTextureFormat, supportsP3: boolean) {
     this.#device = device;
     this.#intermediateFormat = intermediateFormat;
     this.#supportsP3 = supportsP3;
+  }
+
+  #getOrCreateUniformBuffer(
+    cache: Map<string, GPUBuffer>,
+    entityId: string,
+    label: string,
+    size: number,
+  ): GPUBuffer {
+    const cached = cache.get(entityId);
+    if (cached) return cached;
+
+    const buffer = this.#device.createBuffer({
+      label: `${label} ${entityId}`,
+      size,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    cache.set(entityId, buffer);
+    return buffer;
+  }
+
+  #getOrCreateBlurUniformSet(entityId: string): BlurUniformSet {
+    const cached = this.#entityBlurUniforms.get(entityId);
+    if (cached) return cached;
+
+    const downsample: GPUBuffer[] = [];
+    for (let i = 0; i < MAX_BLUR_MIP_LEVELS * 2; i++) {
+      downsample.push(
+        this.#device.createBuffer({
+          label: `Blur downsample uniforms ${entityId} level ${i}`,
+          size: config.rendering.blurUniformSize,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        }),
+      );
+    }
+
+    const upsample: GPUBuffer[] = [];
+    for (let i = 0; i < MAX_BLUR_MIP_LEVELS * 2; i++) {
+      upsample.push(
+        this.#device.createBuffer({
+          label: `Blur upsample uniforms ${entityId} level ${i}`,
+          size: config.rendering.blurUniformSize,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        }),
+      );
+    }
+
+    const mix = this.#device.createBuffer({
+      label: `Blur mix uniforms ${entityId}`,
+      size: config.rendering.blurUniformSize,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    const uniformSet = { downsample, upsample, mix };
+    this.#entityBlurUniforms.set(entityId, uniformSet);
+    return uniformSet;
+  }
+
+  #getOrCreateBloomUniformSet(entityId: string): BloomUniformSet {
+    const cached = this.#entityBloomUniforms.get(entityId);
+    if (cached) return cached;
+
+    const downsample: GPUBuffer[] = [];
+    for (let i = 0; i < BLOOM_MIP_LEVELS; i++) {
+      downsample.push(
+        this.#device.createBuffer({
+          label: `Bloom downsample uniforms ${entityId} mip ${i}`,
+          size: 32,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        }),
+      );
+    }
+
+    const upsample: GPUBuffer[] = [];
+    for (let i = 0; i < BLOOM_MIP_LEVELS - 1; i++) {
+      upsample.push(
+        this.#device.createBuffer({
+          label: `Bloom upsample uniforms ${entityId} mip ${i}`,
+          size: 16,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        }),
+      );
+    }
+
+    const uniformSet = { downsample, upsample };
+    this.#entityBloomUniforms.set(entityId, uniformSet);
+    return uniformSet;
   }
 
   initialize(): void {
@@ -131,10 +248,25 @@ export class ProcessingPipeline {
       ],
     });
 
-    this.#adjustmentsUniformBuffer = this.#device.createBuffer({
-      label: "Adjustments uniforms",
-      size: config.rendering.adjustmentsUniformSize,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    this.#adjustmentsExternalBindGroupLayout = this.#device.createBindGroupLayout({
+      label: "Adjustments external bind group layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+      ],
     });
 
     this.#adjustmentsSampler = this.#device.createSampler({
@@ -159,6 +291,33 @@ export class ProcessingPipeline {
       },
       fragment: {
         module: shaderModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.#intermediateFormat }],
+      },
+      primitive: {
+        topology: "triangle-list",
+      },
+    });
+
+    const externalShaderModule = this.#device.createShaderModule({
+      label: "Adjustments external shader",
+      code: createExternalTextureShaderSource(adjustmentsShaderSource),
+    });
+
+    const externalPipelineLayout = this.#device.createPipelineLayout({
+      label: "Adjustments external pipeline layout",
+      bindGroupLayouts: [this.#adjustmentsExternalBindGroupLayout],
+    });
+
+    this.#adjustmentsExternalPipeline = this.#device.createRenderPipeline({
+      label: "Adjustments external pipeline",
+      layout: externalPipelineLayout,
+      vertex: {
+        module: externalShaderModule,
+        entryPoint: "vs_main",
+      },
+      fragment: {
+        module: externalShaderModule,
         entryPoint: "fs_main",
         targets: [{ format: this.#intermediateFormat }],
       },
@@ -385,12 +544,6 @@ export class ProcessingPipeline {
           texture: { sampleType: "float" },
         },
       ],
-    });
-
-    this.#postProcessUniformBuffer = this.#device.createBuffer({
-      label: "Post-process uniforms",
-      size: config.rendering.postProcessUniformSize,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     this.#postProcessSampler = this.#device.createSampler({
@@ -625,6 +778,7 @@ export class ProcessingPipeline {
    * Returns the final bloom texture (first mip level) to be composited.
    */
   #renderBloom(
+    entityId: string,
     sourceTexture: GPUTexture,
     width: number,
     height: number,
@@ -638,13 +792,12 @@ export class ProcessingPipeline {
       !this.#bloomUpsamplePipeline ||
       !this.#bloomDownsampleBindGroupLayout ||
       !this.#bloomUpsampleBindGroupLayout ||
-      this.#bloomDownsampleUniformBuffers.length < BLOOM_MIP_LEVELS ||
-      this.#bloomUpsampleUniformBuffers.length < BLOOM_MIP_LEVELS - 1 ||
       !this.#bloomSampler
     ) {
       return null;
     }
 
+    const uniformSet = this.#getOrCreateBloomUniformSet(entityId);
     const mipChain = this.#getOrCreateBloomMipChain(width, height);
     if (mipChain.length === 0) return null;
 
@@ -666,7 +819,7 @@ export class ProcessingPipeline {
       uintView[6] = this.#supportsP3 ? 1 : 0;
       floatView[7] = 0;
 
-      this.#device.queue.writeBuffer(this.#bloomDownsampleUniformBuffers[i]!, 0, uniformData);
+      this.#device.queue.writeBuffer(uniformSet.downsample[i]!, 0, uniformData);
 
       srcWidth = Math.max(1, Math.floor(srcWidth / 2));
       srcHeight = Math.max(1, Math.floor(srcHeight / 2));
@@ -683,11 +836,7 @@ export class ProcessingPipeline {
 
       // Map pass index: i goes from mipChain.length-1 down to 1, buffer index = mipChain.length-1-i
       const bufIdx = mipChain.length - 1 - i;
-      this.#device.queue.writeBuffer(
-        this.#bloomUpsampleUniformBuffers[bufIdx]!,
-        0,
-        upsampleUniformData,
-      );
+      this.#device.queue.writeBuffer(uniformSet.upsample[bufIdx]!, 0, upsampleUniformData);
     }
 
     // === Downsample passes ===
@@ -703,7 +852,7 @@ export class ProcessingPipeline {
         entries: [
           {
             binding: 0,
-            resource: { buffer: this.#bloomDownsampleUniformBuffers[i]! },
+            resource: { buffer: uniformSet.downsample[i]! },
           },
           { binding: 1, resource: srcTexture.createView() },
           { binding: 2, resource: this.#bloomSampler },
@@ -745,7 +894,7 @@ export class ProcessingPipeline {
         entries: [
           {
             binding: 0,
-            resource: { buffer: this.#bloomUpsampleUniformBuffers[bufIdx]! },
+            resource: { buffer: uniformSet.upsample[bufIdx]! },
           },
           { binding: 1, resource: srcMip.createView() },
           { binding: 2, resource: this.#bloomSampler },
@@ -903,6 +1052,7 @@ export class ProcessingPipeline {
     inputTexture: GPUTexture,
     finalTarget: GPUTexture,
     mipChain: GPUTexture[],
+    uniformSet: BlurUniformSet,
     levels: number,
     offset: number,
     width: number,
@@ -923,11 +1073,7 @@ export class ProcessingPipeline {
       floatView[2] = offset; // per-pass offset
       floatView[3] = 0; // padding
 
-      this.#device.queue.writeBuffer(
-        this.#blurDownsampleUniformBuffers[bufferOffset + i]!,
-        0,
-        uniformData,
-      );
+      this.#device.queue.writeBuffer(uniformSet.downsample[bufferOffset + i]!, 0, uniformData);
 
       srcWidth = Math.max(1, Math.floor(srcWidth / 2));
       srcHeight = Math.max(1, Math.floor(srcHeight / 2));
@@ -944,11 +1090,7 @@ export class ProcessingPipeline {
       floatView[2] = offset; // per-pass offset
       floatView[3] = 0; // padding
 
-      this.#device.queue.writeBuffer(
-        this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
-        0,
-        uniformData,
-      );
+      this.#device.queue.writeBuffer(uniformSet.upsample[bufferOffset + bufIdx]!, 0, uniformData);
       bufIdx++;
     }
 
@@ -961,11 +1103,7 @@ export class ProcessingPipeline {
       floatView[2] = offset; // per-pass offset
       floatView[3] = 0; // padding
 
-      this.#device.queue.writeBuffer(
-        this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
-        0,
-        uniformData,
-      );
+      this.#device.queue.writeBuffer(uniformSet.upsample[bufferOffset + bufIdx]!, 0, uniformData);
     }
 
     // === Downsample passes ===
@@ -980,7 +1118,7 @@ export class ProcessingPipeline {
           {
             binding: 0,
             resource: {
-              buffer: this.#blurDownsampleUniformBuffers[bufferOffset + i]!,
+              buffer: uniformSet.downsample[bufferOffset + i]!,
             },
           },
           { binding: 1, resource: srcTexture.createView() },
@@ -1022,7 +1160,7 @@ export class ProcessingPipeline {
           {
             binding: 0,
             resource: {
-              buffer: this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
+              buffer: uniformSet.upsample[bufferOffset + bufIdx]!,
             },
           },
           { binding: 1, resource: srcMip.createView() },
@@ -1062,7 +1200,7 @@ export class ProcessingPipeline {
           {
             binding: 0,
             resource: {
-              buffer: this.#blurUpsampleUniformBuffers[bufferOffset + bufIdx]!,
+              buffer: uniformSet.upsample[bufferOffset + bufIdx]!,
             },
           },
           { binding: 1, resource: srcMip.createView() },
@@ -1098,6 +1236,7 @@ export class ProcessingPipeline {
     textureA: GPUTexture,
     textureB: GPUTexture,
     outputTexture: GPUTexture,
+    uniformBuffer: GPUBuffer,
     mixFactor: number,
     width: number,
     height: number,
@@ -1109,13 +1248,13 @@ export class ProcessingPipeline {
     floatView[2] = mixFactor;
     floatView[3] = 0; // padding
 
-    this.#device.queue.writeBuffer(this.#blurMixUniformBuffer!, 0, uniformData);
+    this.#device.queue.writeBuffer(uniformBuffer, 0, uniformData);
 
     const bindGroup = this.#device.createBindGroup({
       label: "Blur mix bind group",
       layout: this.#blurMixBindGroupLayout!,
       entries: [
-        { binding: 0, resource: { buffer: this.#blurMixUniformBuffer! } },
+        { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: textureA.createView() },
         { binding: 2, resource: textureB.createView() },
         { binding: 3, resource: this.#blurSampler! },
@@ -1157,6 +1296,9 @@ export class ProcessingPipeline {
       !this.#blurUpsamplePipeline ||
       !this.#blurDownsampleBindGroupLayout ||
       !this.#blurUpsampleBindGroupLayout ||
+      !this.#blurMixPipeline ||
+      !this.#blurMixBindGroupLayout ||
+      !this.#blurMixUniformBuffer ||
       !this.#blurSampler
     ) {
       return;
@@ -1176,6 +1318,7 @@ export class ProcessingPipeline {
 
     const mipChain = this.#getOrCreateBlurMipChain(width, height);
     if (mipChain.length === 0) return;
+    const uniformSet = this.#getOrCreateBlurUniformSet(entity.id);
 
     if (!needsBlend) {
       this.#encodeBlurPasses(
@@ -1183,6 +1326,7 @@ export class ProcessingPipeline {
         inputTexture,
         outputTexture,
         mipChain,
+        uniformSet,
         levels,
         offset,
         width,
@@ -1200,6 +1344,7 @@ export class ProcessingPipeline {
       inputTexture,
       textureA,
       mipChain,
+      uniformSet,
       levelsLow,
       offsetLow,
       width,
@@ -1211,13 +1356,23 @@ export class ProcessingPipeline {
       inputTexture,
       textureB,
       mipChain,
+      uniformSet,
       levelsHigh,
       offsetHigh,
       width,
       height,
       MAX_BLUR_MIP_LEVELS,
     );
-    this.#encodeMixPass(encoder, textureA, textureB, outputTexture, blendFactor, width, height);
+    this.#encodeMixPass(
+      encoder,
+      textureA,
+      textureB,
+      outputTexture,
+      uniformSet.mix,
+      blendFactor,
+      width,
+      height,
+    );
   }
 
   /**
@@ -1237,6 +1392,7 @@ export class ProcessingPipeline {
       !this.#blurUpsamplePipeline ||
       !this.#blurDownsampleBindGroupLayout ||
       !this.#blurUpsampleBindGroupLayout ||
+      !this.#blurMixUniformBuffer ||
       !this.#blurSampler
     ) {
       return;
@@ -1248,12 +1404,18 @@ export class ProcessingPipeline {
 
     const mipChain = this.#getOrCreateBlurMipChain(width, height);
     if (mipChain.length === 0) return;
+    const uniformSet = {
+      downsample: this.#blurDownsampleUniformBuffers,
+      upsample: this.#blurUpsampleUniformBuffers,
+      mix: this.#blurMixUniformBuffer,
+    };
 
     this.#encodeBlurPasses(
       encoder,
       inputTexture,
       outputTexture,
       mipChain,
+      uniformSet,
       levels,
       offset,
       width,
@@ -1276,20 +1438,25 @@ export class ProcessingPipeline {
     if (
       !this.#adjustmentsPipeline ||
       !this.#adjustmentsBindGroupLayout ||
-      !this.#adjustmentsUniformBuffer ||
       !this.#adjustmentsSampler
     ) {
       return;
     }
 
     this.#updateAdjustmentsUniforms(entity);
-    this.#device.queue.writeBuffer(this.#adjustmentsUniformBuffer, 0, this.#adjustmentsUniformData);
+    const uniformBuffer = this.#getOrCreateUniformBuffer(
+      this.#adjustmentsUniformBuffers,
+      entity.id,
+      "Adjustments uniforms",
+      config.rendering.adjustmentsUniformSize,
+    );
+    this.#device.queue.writeBuffer(uniformBuffer, 0, this.#adjustmentsUniformData);
 
     const bindGroup = this.#device.createBindGroup({
       label: "Adjustments bind group",
       layout: this.#adjustmentsBindGroupLayout,
       entries: [
-        { binding: 0, resource: { buffer: this.#adjustmentsUniformBuffer } },
+        { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: inputTexture.createView() },
         { binding: 2, resource: this.#adjustmentsSampler },
       ],
@@ -1308,6 +1475,57 @@ export class ProcessingPipeline {
     });
 
     pass.setPipeline(this.#adjustmentsPipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+  }
+
+  applyAdjustmentsExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    if (
+      !this.#adjustmentsExternalPipeline ||
+      !this.#adjustmentsExternalBindGroupLayout ||
+      !this.#adjustmentsSampler
+    ) {
+      return;
+    }
+
+    this.#updateAdjustmentsUniforms(entity);
+    const uniformBuffer = this.#getOrCreateUniformBuffer(
+      this.#adjustmentsUniformBuffers,
+      entity.id,
+      "Adjustments uniforms",
+      config.rendering.adjustmentsUniformSize,
+    );
+    this.#device.queue.writeBuffer(uniformBuffer, 0, this.#adjustmentsUniformData);
+
+    const bindGroup = this.#device.createBindGroup({
+      label: "Adjustments external bind group",
+      layout: this.#adjustmentsExternalBindGroupLayout,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: source.texture },
+        { binding: 2, resource: this.#adjustmentsSampler },
+      ],
+    });
+
+    const pass = encoder.beginRenderPass({
+      label: "Adjustments external render pass",
+      colorAttachments: [
+        {
+          view: outputTexture.createView(),
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+        },
+      ],
+    });
+
+    pass.setPipeline(this.#adjustmentsExternalPipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(3);
     pass.end();
@@ -1365,7 +1583,6 @@ export class ProcessingPipeline {
     if (
       !this.#postProcessPipeline ||
       !this.#postProcessBindGroupLayout ||
-      !this.#postProcessUniformBuffer ||
       !this.#postProcessSampler
     ) {
       return;
@@ -1382,6 +1599,7 @@ export class ProcessingPipeline {
     if (postProcess?.bloom?.enabled && bloom.intensity > 0) {
       const softness = bloom.softness ?? 0.1;
       bloomTexture = this.#renderBloom(
+        entity.id,
         inputTexture,
         width,
         height,
@@ -1408,13 +1626,19 @@ export class ProcessingPipeline {
     }
 
     this.#updatePostProcessUniforms(entity);
-    this.#device.queue.writeBuffer(this.#postProcessUniformBuffer, 0, this.#postProcessUniformData);
+    const uniformBuffer = this.#getOrCreateUniformBuffer(
+      this.#postProcessUniformBuffers,
+      entity.id,
+      "Post-process uniforms",
+      config.rendering.postProcessUniformSize,
+    );
+    this.#device.queue.writeBuffer(uniformBuffer, 0, this.#postProcessUniformData);
 
     const bindGroup = this.#device.createBindGroup({
       label: "Post-process bind group",
       layout: this.#postProcessBindGroupLayout,
       entries: [
-        { binding: 0, resource: { buffer: this.#postProcessUniformBuffer } },
+        { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: inputTexture.createView() },
         { binding: 2, resource: this.#postProcessSampler },
         { binding: 3, resource: bloomTextureView },
@@ -1442,10 +1666,46 @@ export class ProcessingPipeline {
     this.#postProcessTime += 0.016; // ~60fps increment
   }
 
+  removeEntity(entityId: string): void {
+    this.#adjustmentsUniformBuffers.get(entityId)?.destroy();
+    this.#adjustmentsUniformBuffers.delete(entityId);
+
+    this.#postProcessUniformBuffers.get(entityId)?.destroy();
+    this.#postProcessUniformBuffers.delete(entityId);
+
+    const blurUniforms = this.#entityBlurUniforms.get(entityId);
+    if (blurUniforms) {
+      for (const buffer of blurUniforms.downsample) buffer.destroy();
+      for (const buffer of blurUniforms.upsample) buffer.destroy();
+      blurUniforms.mix.destroy();
+      this.#entityBlurUniforms.delete(entityId);
+    }
+
+    const bloomUniforms = this.#entityBloomUniforms.get(entityId);
+    if (bloomUniforms) {
+      for (const buffer of bloomUniforms.downsample) buffer.destroy();
+      for (const buffer of bloomUniforms.upsample) buffer.destroy();
+      this.#entityBloomUniforms.delete(entityId);
+    }
+  }
+
   destroy(): void {
     // Destroy uniform buffers
-    this.#adjustmentsUniformBuffer?.destroy();
-    this.#postProcessUniformBuffer?.destroy();
+    for (const buffer of this.#adjustmentsUniformBuffers.values()) buffer.destroy();
+    this.#adjustmentsUniformBuffers.clear();
+    for (const buffer of this.#postProcessUniformBuffers.values()) buffer.destroy();
+    this.#postProcessUniformBuffers.clear();
+    for (const uniforms of this.#entityBlurUniforms.values()) {
+      for (const buffer of uniforms.downsample) buffer.destroy();
+      for (const buffer of uniforms.upsample) buffer.destroy();
+      uniforms.mix.destroy();
+    }
+    this.#entityBlurUniforms.clear();
+    for (const uniforms of this.#entityBloomUniforms.values()) {
+      for (const buffer of uniforms.downsample) buffer.destroy();
+      for (const buffer of uniforms.upsample) buffer.destroy();
+    }
+    this.#entityBloomUniforms.clear();
     for (const buf of this.#blurDownsampleUniformBuffers) buf.destroy();
     for (const buf of this.#blurUpsampleUniformBuffers) buf.destroy();
     this.#blurMixUniformBuffer?.destroy();
@@ -1477,8 +1737,9 @@ export class ProcessingPipeline {
 
     // Clear pipeline references
     this.#adjustmentsPipeline = null;
+    this.#adjustmentsExternalPipeline = null;
     this.#adjustmentsBindGroupLayout = null;
-    this.#adjustmentsUniformBuffer = null;
+    this.#adjustmentsExternalBindGroupLayout = null;
     this.#adjustmentsSampler = null;
     this.#blurDownsamplePipeline = null;
     this.#blurUpsamplePipeline = null;
@@ -1492,7 +1753,6 @@ export class ProcessingPipeline {
     this.#blurMixUniformBuffer = null;
     this.#postProcessPipeline = null;
     this.#postProcessBindGroupLayout = null;
-    this.#postProcessUniformBuffer = null;
     this.#postProcessSampler = null;
     this.#bloomDownsamplePipeline = null;
     this.#bloomUpsamplePipeline = null;

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -30,16 +30,26 @@ interface BloomUniformSet {
   upsample: GPUBuffer[];
 }
 
-function createExternalTextureShaderSource(source: string): string {
+type BlurInputSource =
+  | { kind: "texture"; texture: GPUTexture }
+  | { kind: "external"; texture: GPUExternalTexture };
+
+function createExternalTextureShaderSource(
+  source: string,
+  textureName = "sourceTexture",
+  samplerName = "sourceSampler",
+): string {
+  const textureDeclaration = new RegExp(
+    `@group\\(0\\)\\s+@binding\\(1\\)\\s+var\\s+${textureName}:\\s+texture_2d<f32>;`,
+  );
+  const textureSample = new RegExp(`textureSample\\(${textureName},\\s*${samplerName},`, "g");
+
   return source
     .replace(
-      /@group\(0\)\s+@binding\(1\)\s+var\s+sourceTexture:\s+texture_2d<f32>;/,
-      "@group(0) @binding(1) var sourceTexture: texture_external;",
+      textureDeclaration,
+      `@group(0) @binding(1) var ${textureName}: texture_external;`,
     )
-    .replace(
-      /textureSample\(sourceTexture,\s*sourceSampler,/g,
-      "textureSampleBaseClampToEdge(sourceTexture, sourceSampler,",
-    );
+    .replace(textureSample, `textureSampleBaseClampToEdge(${textureName}, ${samplerName},`);
 }
 
 export class ProcessingPipeline {
@@ -59,8 +69,10 @@ export class ProcessingPipeline {
 
   // Dual Kawase blur (pre-processing) pipeline
   #blurDownsamplePipeline: GPURenderPipeline | null = null;
+  #blurExternalDownsamplePipeline: GPURenderPipeline | null = null;
   #blurUpsamplePipeline: GPURenderPipeline | null = null;
   #blurDownsampleBindGroupLayout: GPUBindGroupLayout | null = null;
+  #blurExternalDownsampleBindGroupLayout: GPUBindGroupLayout | null = null;
   #blurUpsampleBindGroupLayout: GPUBindGroupLayout | null = null;
   // Per-level uniform buffers (enables single command encoder submission)
   #blurDownsampleUniformBuffers: GPUBuffer[] = [];
@@ -396,6 +408,48 @@ export class ProcessingPipeline {
       },
       fragment: {
         module: downsampleModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.#intermediateFormat }],
+      },
+      primitive: {
+        topology: "triangle-list",
+      },
+    });
+
+    this.#blurExternalDownsampleBindGroupLayout = this.#device.createBindGroupLayout({
+      label: "Blur external downsample bind group layout",
+      entries: [
+        bindGroupLayoutEntries[0]!,
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        bindGroupLayoutEntries[2]!,
+      ],
+    });
+
+    const externalDownsampleModule = this.#device.createShaderModule({
+      label: "Kawase external downsample shader",
+      code: createExternalTextureShaderSource(
+        kawaseDownsampleShaderSource,
+        "src_texture",
+        "src_sampler",
+      ),
+    });
+    const externalDownsamplePipelineLayout = this.#device.createPipelineLayout({
+      label: "Blur external downsample pipeline layout",
+      bindGroupLayouts: [this.#blurExternalDownsampleBindGroupLayout],
+    });
+    this.#blurExternalDownsamplePipeline = this.#device.createRenderPipeline({
+      label: "Blur external downsample pipeline",
+      layout: externalDownsamplePipelineLayout,
+      vertex: {
+        module: externalDownsampleModule,
+        entryPoint: "vs_main",
+      },
+      fragment: {
+        module: externalDownsampleModule,
         entryPoint: "fs_main",
         targets: [{ format: this.#intermediateFormat }],
       },
@@ -1049,7 +1103,7 @@ export class ProcessingPipeline {
    */
   #encodeBlurPasses(
     encoder: GPUCommandEncoder,
-    inputTexture: GPUTexture,
+    inputSource: BlurInputSource,
     finalTarget: GPUTexture,
     mipChain: GPUTexture[],
     uniformSet: BlurUniformSet,
@@ -1107,27 +1161,55 @@ export class ProcessingPipeline {
     }
 
     // === Downsample passes ===
-    let srcTexture = inputTexture;
+    let srcTexture: GPUTexture | null = inputSource.kind === "texture" ? inputSource.texture : null;
     for (let i = 0; i < activeLevels; i++) {
       const dstTexture = mipChain[i]!;
 
-      const bindGroup = this.#device.createBindGroup({
-        label: `Blur downsample bind group level ${i}`,
-        layout: this.#blurDownsampleBindGroupLayout!,
-        entries: [
-          {
-            binding: 0,
-            resource: {
-              buffer: uniformSet.downsample[bufferOffset + i]!,
+      const readsExternalSource = i === 0 && inputSource.kind === "external";
+      if (
+        readsExternalSource &&
+        (!this.#blurExternalDownsampleBindGroupLayout || !this.#blurExternalDownsamplePipeline)
+      ) {
+        return;
+      }
+      if (!readsExternalSource && !srcTexture) return;
+
+      const bindGroup = this.#device.createBindGroup(
+        readsExternalSource
+          ? {
+              label: `Blur external downsample bind group level ${i}`,
+              layout: this.#blurExternalDownsampleBindGroupLayout!,
+              entries: [
+                {
+                  binding: 0,
+                  resource: {
+                    buffer: uniformSet.downsample[bufferOffset + i]!,
+                  },
+                },
+                { binding: 1, resource: inputSource.texture },
+                { binding: 2, resource: this.#blurSampler! },
+              ],
+            }
+          : {
+              label: `Blur downsample bind group level ${i}`,
+              layout: this.#blurDownsampleBindGroupLayout!,
+              entries: [
+                {
+                  binding: 0,
+                  resource: {
+                    buffer: uniformSet.downsample[bufferOffset + i]!,
+                  },
+                },
+                { binding: 1, resource: srcTexture!.createView() },
+                { binding: 2, resource: this.#blurSampler! },
+              ],
             },
-          },
-          { binding: 1, resource: srcTexture.createView() },
-          { binding: 2, resource: this.#blurSampler! },
-        ],
-      });
+      );
 
       const pass = encoder.beginRenderPass({
-        label: `Blur downsample pass level ${i}`,
+        label: readsExternalSource
+          ? `Blur external downsample pass level ${i}`
+          : `Blur downsample pass level ${i}`,
         colorAttachments: [
           {
             view: dstTexture.createView(),
@@ -1138,7 +1220,9 @@ export class ProcessingPipeline {
         ],
       });
 
-      pass.setPipeline(this.#blurDownsamplePipeline!);
+      pass.setPipeline(
+        readsExternalSource ? this.#blurExternalDownsamplePipeline! : this.#blurDownsamplePipeline!,
+      );
       pass.setBindGroup(0, bindGroup);
       pass.setViewport(0, 0, dstTexture.width, dstTexture.height, 0, 1);
       pass.draw(3);
@@ -1323,7 +1407,7 @@ export class ProcessingPipeline {
     if (!needsBlend) {
       this.#encodeBlurPasses(
         encoder,
-        inputTexture,
+        { kind: "texture", texture: inputTexture },
         outputTexture,
         mipChain,
         uniformSet,
@@ -1341,7 +1425,7 @@ export class ProcessingPipeline {
 
     this.#encodeBlurPasses(
       encoder,
-      inputTexture,
+      { kind: "texture", texture: inputTexture },
       textureA,
       mipChain,
       uniformSet,
@@ -1353,7 +1437,99 @@ export class ProcessingPipeline {
     );
     this.#encodeBlurPasses(
       encoder,
-      inputTexture,
+      { kind: "texture", texture: inputTexture },
+      textureB,
+      mipChain,
+      uniformSet,
+      levelsHigh,
+      offsetHigh,
+      width,
+      height,
+      MAX_BLUR_MIP_LEVELS,
+    );
+    this.#encodeMixPass(
+      encoder,
+      textureA,
+      textureB,
+      outputTexture,
+      uniformSet.mix,
+      blendFactor,
+      width,
+      height,
+    );
+  }
+
+  applyBlurExternal(
+    entity: EffectRenderEntity,
+    inputSource: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    if (
+      !this.#blurDownsamplePipeline ||
+      !this.#blurExternalDownsamplePipeline ||
+      !this.#blurUpsamplePipeline ||
+      !this.#blurDownsampleBindGroupLayout ||
+      !this.#blurExternalDownsampleBindGroupLayout ||
+      !this.#blurUpsampleBindGroupLayout ||
+      !this.#blurMixPipeline ||
+      !this.#blurMixBindGroupLayout ||
+      !this.#blurMixUniformBuffer ||
+      !this.#blurSampler
+    ) {
+      return;
+    }
+
+    const width = entity.originalSize.width;
+    const height = entity.originalSize.height;
+    const blur = entity.shaderParams.adjustments?.blur ?? 0;
+    const { levelsLow, levelsHigh, offsetLow, offsetHigh, blendFactor } =
+      blurParamToKawaseParams(blur);
+
+    const needsBlend = blendFactor > 0.001 && blendFactor < 0.999;
+    const levels = needsBlend ? levelsLow : blendFactor >= 0.999 ? levelsHigh : levelsLow;
+    const offset = needsBlend ? offsetLow : blendFactor >= 0.999 ? offsetHigh : offsetLow;
+
+    if (levels <= 0 && (!needsBlend || levelsHigh <= 0)) return;
+
+    const mipChain = this.#getOrCreateBlurMipChain(width, height);
+    if (mipChain.length === 0) return;
+    const uniformSet = this.#getOrCreateBlurUniformSet(entity.id);
+    const blurSource: BlurInputSource = { kind: "external", texture: inputSource.texture };
+
+    if (!needsBlend) {
+      this.#encodeBlurPasses(
+        encoder,
+        blurSource,
+        outputTexture,
+        mipChain,
+        uniformSet,
+        levels,
+        offset,
+        width,
+        height,
+        0,
+      );
+      return;
+    }
+
+    const { textureA, textureB } = this.#getOrCreateBlurBlendTextures(width, height);
+
+    this.#encodeBlurPasses(
+      encoder,
+      blurSource,
+      textureA,
+      mipChain,
+      uniformSet,
+      levelsLow,
+      offsetLow,
+      width,
+      height,
+      0,
+    );
+    this.#encodeBlurPasses(
+      encoder,
+      blurSource,
       textureB,
       mipChain,
       uniformSet,
@@ -1412,7 +1588,7 @@ export class ProcessingPipeline {
 
     this.#encodeBlurPasses(
       encoder,
-      inputTexture,
+      { kind: "texture", texture: inputTexture },
       outputTexture,
       mipChain,
       uniformSet,
@@ -1742,8 +1918,10 @@ export class ProcessingPipeline {
     this.#adjustmentsExternalBindGroupLayout = null;
     this.#adjustmentsSampler = null;
     this.#blurDownsamplePipeline = null;
+    this.#blurExternalDownsamplePipeline = null;
     this.#blurUpsamplePipeline = null;
     this.#blurDownsampleBindGroupLayout = null;
+    this.#blurExternalDownsampleBindGroupLayout = null;
     this.#blurUpsampleBindGroupLayout = null;
     this.#blurDownsampleUniformBuffers = [];
     this.#blurUpsampleUniformBuffers = [];

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -45,10 +45,7 @@ function createExternalTextureShaderSource(
   const textureSample = new RegExp(`textureSample\\(${textureName},\\s*${samplerName},`, "g");
 
   return source
-    .replace(
-      textureDeclaration,
-      `@group(0) @binding(1) var ${textureName}: texture_external;`,
-    )
+    .replace(textureDeclaration, `@group(0) @binding(1) var ${textureName}: texture_external;`)
     .replace(textureSample, `textureSampleBaseClampToEdge(${textureName}, ${samplerName},`);
 }
 

--- a/renderer/shaders/ascii-shader.ts
+++ b/renderer/shaders/ascii-shader.ts
@@ -1,7 +1,7 @@
 import { AsciiKind } from "#types/canvas.ts";
 import type { EffectRenderEntity } from "../effect-render-entity.ts";
 import asciiShaderSource from "../ascii.wgsl?raw";
-import { ShaderPass } from "./shader-pass.ts";
+import { type ExternalTextureSource, ShaderPass } from "./shader-pass.ts";
 
 // Map AsciiKind to uniform index
 // Matches asciiKind values in ascii.wgsl: 0=standard, 1=extended, 2=binary, 3=minimal
@@ -30,6 +30,8 @@ export class AsciiShader extends ShaderPass {
     await this.#loadAtlas();
     this.bindGroupLayout = this.createBindGroupLayout();
     this.pipeline = this.createPipeline();
+    this.externalBindGroupLayout = this.createExternalBindGroupLayout();
+    this.externalPipeline = this.createExternalPipeline();
   }
 
   async #loadAtlas(): Promise<void> {
@@ -111,14 +113,67 @@ export class AsciiShader extends ShaderPass {
     });
   }
 
+  protected override createExternalBindGroupLayout(): GPUBindGroupLayout {
+    return this.ctx.device.createBindGroupLayout({
+      label: "ASCII shader external bind group layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+        {
+          binding: 3,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: { sampleType: "float" },
+        },
+        {
+          binding: 4,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+      ],
+    });
+  }
+
   /** Override: includes atlas texture and sampler at bindings 3, 4 */
-  override createBindGroup(sourceTextureView: GPUTextureView): GPUBindGroup {
+  override createBindGroup(
+    sourceTextureView: GPUTextureView,
+    uniformBuffer: GPUBuffer,
+  ): GPUBindGroup {
     return this.ctx.device.createBindGroup({
       label: "ASCII shader bind group",
       layout: this.bindGroupLayout!,
       entries: [
-        { binding: 0, resource: { buffer: this.ctx.uniformBuffer } },
+        { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: sourceTextureView },
+        { binding: 2, resource: this.ctx.sampler },
+        { binding: 3, resource: this.#atlasTexture!.createView() },
+        { binding: 4, resource: this.#atlasSampler! },
+      ],
+    });
+  }
+
+  override createExternalBindGroup(
+    source: ExternalTextureSource,
+    uniformBuffer: GPUBuffer,
+  ): GPUBindGroup {
+    return this.ctx.device.createBindGroup({
+      label: "ASCII shader external bind group",
+      layout: this.externalBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: source.texture },
         { binding: 2, resource: this.ctx.sampler },
         { binding: 3, resource: this.#atlasTexture!.createView() },
         { binding: 4, resource: this.#atlasSampler! },
@@ -141,6 +196,23 @@ export class AsciiShader extends ShaderPass {
       return;
     }
     super.execute(entity, sourceTexture, outputTexture, encoder);
+  }
+
+  override executeExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    if (!this.#atlasTexture || !this.#atlasSampler) {
+      const errorMsg = "ASCII atlas not loaded";
+      if (!this.#reportedErrors.has(entity.id)) {
+        this.#reportedErrors.add(entity.id);
+        this.onEntityError?.(entity.id, errorMsg);
+      }
+      return;
+    }
+    super.executeExternal(entity, source, outputTexture, encoder);
   }
 
   /** Clear error state for an entity (e.g., when entity is removed) */

--- a/renderer/shaders/dithering-shader.ts
+++ b/renderer/shaders/dithering-shader.ts
@@ -21,10 +21,24 @@ const DITHERING_KIND_INDEX: Record<DitheringKind, number> = {
   [DitheringKind.sierraLite]: 11,
 };
 
+function createExternalComputeShaderSource(source: string): string {
+  return source
+    .replace(
+      /@group\(0\)\s+@binding\(1\)\s+var\s+inputTexture:\s+texture_2d<f32>;/,
+      "@group(0) @binding(1) var inputTexture: texture_external;",
+    )
+    .replace(
+      /textureLoad\(inputTexture,\s*samplePos,\s*0\)/g,
+      "textureLoad(inputTexture, samplePos)",
+    );
+}
+
 export class DitheringShader extends ShaderPass {
   // Compute pipeline for error diffusion
   #computePipeline: GPUComputePipeline | null = null;
+  #externalComputePipeline: GPUComputePipeline | null = null;
   #computeBindGroupLayout: GPUBindGroupLayout | null = null;
+  #externalComputeBindGroupLayout: GPUBindGroupLayout | null = null;
   // Error buffer cache per entity (keyed by entityId-width-height)
   #errorBufferCache: Map<string, GPUBuffer> = new Map();
 
@@ -77,9 +91,39 @@ export class DitheringShader extends ShaderPass {
       ],
     });
 
+    this.#externalComputeBindGroupLayout = device.createBindGroupLayout({
+      label: "Dithering external compute bind group layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.COMPUTE,
+          externalTexture: {},
+        },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.COMPUTE,
+          storageTexture: { access: "write-only", format: this.ctx.intermediateFormat },
+        },
+        {
+          binding: 3,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: "storage" },
+        },
+      ],
+    });
+
     const shaderModule = device.createShaderModule({
       label: "Dithering compute shader",
       code: ditheringComputeShaderSource,
+    });
+    const externalShaderModule = device.createShaderModule({
+      label: "Dithering external compute shader",
+      code: createExternalComputeShaderSource(ditheringComputeShaderSource),
     });
 
     const compilationInfo = await shaderModule.getCompilationInfo();
@@ -88,10 +132,22 @@ export class DitheringShader extends ShaderPass {
       const errorMessages = errors.map((e) => `Line ${e.lineNum}: ${e.message}`).join("\n");
       throw new Error(`Dithering compute shader compilation failed:\n${errorMessages}`);
     }
+    const externalCompilationInfo = await externalShaderModule.getCompilationInfo();
+    const externalErrors = externalCompilationInfo.messages.filter((m) => m.type === "error");
+    if (externalErrors.length > 0) {
+      const errorMessages = externalErrors
+        .map((e) => `Line ${e.lineNum}: ${e.message}`)
+        .join("\n");
+      throw new Error(`Dithering external compute shader compilation failed:\n${errorMessages}`);
+    }
 
     const pipelineLayout = device.createPipelineLayout({
       label: "Dithering compute pipeline layout",
       bindGroupLayouts: [this.#computeBindGroupLayout],
+    });
+    const externalPipelineLayout = device.createPipelineLayout({
+      label: "Dithering external compute pipeline layout",
+      bindGroupLayouts: [this.#externalComputeBindGroupLayout],
     });
 
     try {
@@ -100,6 +156,14 @@ export class DitheringShader extends ShaderPass {
         layout: pipelineLayout,
         compute: {
           module: shaderModule,
+          entryPoint: "main",
+        },
+      });
+      this.#externalComputePipeline = await device.createComputePipelineAsync({
+        label: "Dithering external compute pipeline",
+        layout: externalPipelineLayout,
+        compute: {
+          module: externalShaderModule,
           entryPoint: "main",
         },
       });
@@ -151,9 +215,7 @@ export class DitheringShader extends ShaderPass {
     const ditheringKind = entity.shaderParams.dithering?.kind ?? DitheringKind.bayer4x4;
 
     if (isErrorDiffusion(ditheringKind)) {
-      // TODO(video-external): Add a texture_external compute variant or a fragment-path
-      // implementation for error-diffusion dithering. For now callers must materialize
-      // video frames to a GPUTexture before reaching this method.
+      this.#executeComputeExternal(entity, source, outputTexture, encoder);
       return;
     }
 
@@ -221,6 +283,66 @@ export class DitheringShader extends ShaderPass {
     this.ctx.releaseTexture(computeOutputTexture, width, height, computeUsage);
   }
 
+  #executeComputeExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    if (!this.#externalComputePipeline || !this.#externalComputeBindGroupLayout) {
+      return;
+    }
+
+    const device = this.ctx.device;
+    const width = entity.originalSize.width;
+    const height = entity.originalSize.height;
+
+    const errorBuffer = this.#getOrCreateErrorBuffer(entity.id, width, height);
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
+
+    const computeUsage =
+      GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC;
+
+    const pool = this.ctx.texturePool;
+    const computeOutputTexture = pool
+      ? pool.acquire(width, height, computeUsage, `Compute external output intermediate`)
+      : device.createTexture({
+          label: `Compute external output intermediate texture`,
+          size: [width, height],
+          format: this.ctx.intermediateFormat,
+          usage: computeUsage,
+        });
+
+    const bindGroup = device.createBindGroup({
+      label: `Entity ${entity.id} external compute bind group`,
+      layout: this.#externalComputeBindGroupLayout,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: source.texture },
+        { binding: 2, resource: computeOutputTexture.createView() },
+        { binding: 3, resource: { buffer: errorBuffer } },
+      ],
+    });
+
+    encoder.clearBuffer(errorBuffer);
+
+    const computePass = encoder.beginComputePass({
+      label: `Entity ${entity.id} external compute pass`,
+    });
+
+    computePass.setPipeline(this.#externalComputePipeline);
+    computePass.setBindGroup(0, bindGroup);
+    computePass.dispatchWorkgroups(Math.ceil(height / 32));
+    computePass.end();
+
+    encoder.copyTextureToTexture({ texture: computeOutputTexture }, { texture: outputTexture }, [
+      width,
+      height,
+    ]);
+
+    this.ctx.releaseTexture(computeOutputTexture, width, height, computeUsage);
+  }
+
   /** Remove cached error buffers for an entity (call when entity is removed) */
   removeEntity(entityId: string): void {
     for (const [key, buffer] of this.#errorBufferCache.entries()) {
@@ -237,7 +359,9 @@ export class DitheringShader extends ShaderPass {
     }
     this.#errorBufferCache.clear();
     this.#computePipeline = null;
+    this.#externalComputePipeline = null;
     this.#computeBindGroupLayout = null;
+    this.#externalComputeBindGroupLayout = null;
     super.destroy();
   }
 }

--- a/renderer/shaders/dithering-shader.ts
+++ b/renderer/shaders/dithering-shader.ts
@@ -1,9 +1,8 @@
-import { config } from "#config";
 import { DitheringKind, isErrorDiffusion } from "#types/canvas.ts";
 import type { EffectRenderEntity } from "../effect-render-entity.ts";
 import ditheringComputeShaderSource from "../dithering-compute.wgsl?raw";
 import ditheringShaderSource from "../dithering.wgsl?raw";
-import { ShaderPass } from "./shader-pass.ts";
+import { type ExternalTextureSource, ShaderPass } from "./shader-pass.ts";
 
 // Map DitheringKind to uniform index
 const DITHERING_KIND_INDEX: Record<DitheringKind, number> = {
@@ -26,7 +25,6 @@ export class DitheringShader extends ShaderPass {
   // Compute pipeline for error diffusion
   #computePipeline: GPUComputePipeline | null = null;
   #computeBindGroupLayout: GPUBindGroupLayout | null = null;
-  #computeUniformBuffer: GPUBuffer | null = null;
   // Error buffer cache per entity (keyed by entityId-width-height)
   #errorBufferCache: Map<string, GPUBuffer> = new Map();
 
@@ -43,6 +41,8 @@ export class DitheringShader extends ShaderPass {
     // Fragment pipeline (ordered dithering) - from base class
     this.bindGroupLayout = this.createBindGroupLayout();
     this.pipeline = this.createPipeline();
+    this.externalBindGroupLayout = this.createExternalBindGroupLayout();
+    this.externalPipeline = this.createExternalPipeline();
 
     // Compute pipeline (error diffusion dithering)
     await this.#createComputePipeline();
@@ -75,12 +75,6 @@ export class DitheringShader extends ShaderPass {
           buffer: { type: "storage" },
         },
       ],
-    });
-
-    this.#computeUniformBuffer = device.createBuffer({
-      label: "Dithering compute uniforms",
-      size: config.rendering.ditheringUniformSize,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
     const shaderModule = device.createShaderModule({
@@ -148,13 +142,31 @@ export class DitheringShader extends ShaderPass {
     }
   }
 
+  override executeExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    const ditheringKind = entity.shaderParams.dithering?.kind ?? DitheringKind.bayer4x4;
+
+    if (isErrorDiffusion(ditheringKind)) {
+      // TODO(video-external): Add a texture_external compute variant or a fragment-path
+      // implementation for error-diffusion dithering. For now callers must materialize
+      // video frames to a GPUTexture before reaching this method.
+      return;
+    }
+
+    super.executeExternal(entity, source, outputTexture, encoder);
+  }
+
   #executeCompute(
     entity: EffectRenderEntity,
     sourceTexture: GPUTexture,
     outputTexture: GPUTexture,
     encoder: GPUCommandEncoder,
   ): void {
-    if (!this.#computePipeline || !this.#computeBindGroupLayout || !this.#computeUniformBuffer) {
+    if (!this.#computePipeline || !this.#computeBindGroupLayout) {
       return;
     }
 
@@ -164,8 +176,7 @@ export class DitheringShader extends ShaderPass {
 
     const errorBuffer = this.#getOrCreateErrorBuffer(entity.id, width, height);
 
-    this.writeUniforms(entity);
-    device.queue.writeBuffer(this.#computeUniformBuffer, 0, this.ctx.uniformData);
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
 
     const computeUsage =
       GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC;
@@ -184,7 +195,7 @@ export class DitheringShader extends ShaderPass {
       label: `Entity ${entity.id} compute bind group`,
       layout: this.#computeBindGroupLayout,
       entries: [
-        { binding: 0, resource: { buffer: this.#computeUniformBuffer } },
+        { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: sourceTexture.createView() },
         { binding: 2, resource: computeOutputTexture.createView() },
         { binding: 3, resource: { buffer: errorBuffer } },
@@ -207,12 +218,7 @@ export class DitheringShader extends ShaderPass {
       height,
     ]);
 
-    // Release compute output texture back to pool
-    if (pool) {
-      pool.release(computeOutputTexture, width, height, computeUsage);
-    } else {
-      computeOutputTexture.destroy();
-    }
+    this.ctx.releaseTexture(computeOutputTexture, width, height, computeUsage);
   }
 
   /** Remove cached error buffers for an entity (call when entity is removed) */
@@ -230,8 +236,6 @@ export class DitheringShader extends ShaderPass {
       buffer.destroy();
     }
     this.#errorBufferCache.clear();
-    this.#computeUniformBuffer?.destroy();
-    this.#computeUniformBuffer = null;
     this.#computePipeline = null;
     this.#computeBindGroupLayout = null;
     super.destroy();

--- a/renderer/shaders/dithering-shader.ts
+++ b/renderer/shaders/dithering-shader.ts
@@ -135,9 +135,7 @@ export class DitheringShader extends ShaderPass {
     const externalCompilationInfo = await externalShaderModule.getCompilationInfo();
     const externalErrors = externalCompilationInfo.messages.filter((m) => m.type === "error");
     if (externalErrors.length > 0) {
-      const errorMessages = externalErrors
-        .map((e) => `Line ${e.lineNum}: ${e.message}`)
-        .join("\n");
+      const errorMessages = externalErrors.map((e) => `Line ${e.lineNum}: ${e.message}`).join("\n");
       throw new Error(`Dithering external compute shader compilation failed:\n${errorMessages}`);
     }
 

--- a/renderer/shaders/glass-shader.ts
+++ b/renderer/shaders/glass-shader.ts
@@ -3,11 +3,17 @@ import type { EffectRenderEntity } from "../effect-render-entity.ts";
 import glassFlowingSource from "../glass-flowing.wgsl?raw";
 import glassFlutedSource from "../glass-fluted.wgsl?raw";
 import glassFrostedSource from "../glass-frosted.wgsl?raw";
-import { ShaderPass } from "./shader-pass.ts";
+import {
+  createExternalTextureShaderSource,
+  type ExternalTextureSource,
+  ShaderPass,
+} from "./shader-pass.ts";
 
 export class GlassShader extends ShaderPass {
   #flutedPipeline: GPURenderPipeline | null = null;
   #flowingPipeline: GPURenderPipeline | null = null;
+  #externalFlutedPipeline: GPURenderPipeline | null = null;
+  #externalFlowingPipeline: GPURenderPipeline | null = null;
 
   /** Per-entity last frame timestamps for delta-time calculation */
   #lastFrameTimes = new Map<string, number>();
@@ -28,6 +34,8 @@ export class GlassShader extends ShaderPass {
     // Frosted pipeline (default, stored in this.pipeline via base class)
     this.bindGroupLayout = this.createBindGroupLayout();
     this.pipeline = this.createPipeline();
+    this.externalBindGroupLayout = this.createExternalBindGroupLayout();
+    this.externalPipeline = this.createExternalPipeline();
 
     // Fluted pipeline (separate render pipeline, same bind group layout)
     const flutedModule = this.ctx.device.createShaderModule({
@@ -49,6 +57,25 @@ export class GlassShader extends ShaderPass {
       },
       primitive: { topology: "triangle-list" },
     });
+    const externalFlutedModule = this.ctx.device.createShaderModule({
+      label: "GlassShader external fluted shader",
+      code: createExternalTextureShaderSource(glassFlutedSource),
+    });
+    const externalFlutedPipelineLayout = this.ctx.device.createPipelineLayout({
+      label: "GlassShader external fluted pipeline layout",
+      bindGroupLayouts: [this.externalBindGroupLayout!],
+    });
+    this.#externalFlutedPipeline = this.ctx.device.createRenderPipeline({
+      label: "GlassShader external fluted pipeline",
+      layout: externalFlutedPipelineLayout,
+      vertex: { module: externalFlutedModule, entryPoint: "vs_main" },
+      fragment: {
+        module: externalFlutedModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.ctx.intermediateFormat }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
 
     // Flowing pipeline (separate render pipeline, same bind group layout)
     const flowingModule = this.ctx.device.createShaderModule({
@@ -65,6 +92,25 @@ export class GlassShader extends ShaderPass {
       vertex: { module: flowingModule, entryPoint: "vs_main" },
       fragment: {
         module: flowingModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.ctx.intermediateFormat }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+    const externalFlowingModule = this.ctx.device.createShaderModule({
+      label: "GlassShader external flowing shader",
+      code: createExternalTextureShaderSource(glassFlowingSource),
+    });
+    const externalFlowingPipelineLayout = this.ctx.device.createPipelineLayout({
+      label: "GlassShader external flowing pipeline layout",
+      bindGroupLayouts: [this.externalBindGroupLayout!],
+    });
+    this.#externalFlowingPipeline = this.ctx.device.createRenderPipeline({
+      label: "GlassShader external flowing pipeline",
+      layout: externalFlowingPipelineLayout,
+      vertex: { module: externalFlowingModule, entryPoint: "vs_main" },
+      fragment: {
+        module: externalFlowingModule,
         entryPoint: "fs_main",
         targets: [{ format: this.ctx.intermediateFormat }],
       },
@@ -110,6 +156,69 @@ export class GlassShader extends ShaderPass {
     }
   }
 
+  override executeExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    const glassKind = entity.shaderParams.glass?.kind ?? GlassKind.frostedVoronoi;
+
+    if (glassKind === GlassKind.fluted) {
+      this.#executeExternalVariant(
+        entity,
+        source,
+        outputTexture,
+        encoder,
+        this.#externalFlutedPipeline,
+        "GlassShader external fluted render pass",
+      );
+    } else if (glassKind === GlassKind.flowing) {
+      this.#executeExternalVariant(
+        entity,
+        source,
+        outputTexture,
+        encoder,
+        this.#externalFlowingPipeline,
+        "GlassShader external flowing render pass",
+      );
+      this.#advanceFlowingTime(entity);
+    } else {
+      super.executeExternal(entity, source, outputTexture, encoder);
+    }
+  }
+
+  #executeExternalVariant(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+    pipeline: GPURenderPipeline | null,
+    label: string,
+  ): void {
+    if (!pipeline) return;
+
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
+    const bindGroup = this.createExternalBindGroup(source, uniformBuffer);
+
+    const pass = encoder.beginRenderPass({
+      label,
+      colorAttachments: [
+        {
+          view: this.getTextureView(outputTexture),
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+        },
+      ],
+    });
+
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+  }
+
   #executeFluted(
     entity: EffectRenderEntity,
     sourceTexture: GPUTexture,
@@ -118,10 +227,8 @@ export class GlassShader extends ShaderPass {
   ): void {
     if (!this.#flutedPipeline) return;
 
-    this.writeUniforms(entity);
-    this.ctx.device.queue.writeBuffer(this.ctx.uniformBuffer, 0, this.ctx.uniformData);
-
-    const bindGroup = this.getBindGroup(sourceTexture);
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
+    const bindGroup = this.getBindGroup(sourceTexture, uniformBuffer);
 
     const pass = encoder.beginRenderPass({
       label: "GlassShader fluted render pass",
@@ -149,10 +256,8 @@ export class GlassShader extends ShaderPass {
   ): void {
     if (!this.#flowingPipeline) return;
 
-    this.writeUniforms(entity);
-    this.ctx.device.queue.writeBuffer(this.ctx.uniformBuffer, 0, this.ctx.uniformData);
-
-    const bindGroup = this.getBindGroup(sourceTexture);
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
+    const bindGroup = this.getBindGroup(sourceTexture, uniformBuffer);
 
     const pass = encoder.beginRenderPass({
       label: "GlassShader flowing render pass",
@@ -171,6 +276,10 @@ export class GlassShader extends ShaderPass {
     pass.draw(3);
     pass.end();
 
+    this.#advanceFlowingTime(entity);
+  }
+
+  #advanceFlowingTime(entity: EffectRenderEntity): void {
     // Auto-increment time per-entity (mutate in-place, no React/undo involvement)
     if (entity.shaderParams.timeAutoPlay !== false) {
       const now = performance.now();
@@ -193,6 +302,8 @@ export class GlassShader extends ShaderPass {
   override destroy(): void {
     this.#flutedPipeline = null;
     this.#flowingPipeline = null;
+    this.#externalFlutedPipeline = null;
+    this.#externalFlowingPipeline = null;
     this.#lastFrameTimes.clear();
     super.destroy();
   }

--- a/renderer/shaders/shader-pass.ts
+++ b/renderer/shaders/shader-pass.ts
@@ -6,8 +6,6 @@ import type { EffectRenderEntity } from "../effect-render-entity.ts";
 
 export interface ShaderContext {
   device: GPUDevice;
-  /** Shared 336-byte uniform buffer for entity shaders */
-  uniformBuffer: GPUBuffer;
   /** Pre-allocated ArrayBuffer for the 336-byte uniform layout */
   uniformData: ArrayBuffer;
   floatView: Float32Array;
@@ -18,17 +16,50 @@ export interface ShaderContext {
   sortedPaletteCache: { original: readonly RGBA[]; reversed: boolean; sorted: RGBA[] } | null;
   /** Texture pool for intermediate textures (used by compute shaders) */
   texturePool: TexturePool | null;
+  /** Defer release until the command buffer using the texture has been submitted. */
+  releaseTexture: (
+    texture: GPUTexture,
+    width: number,
+    height: number,
+    usage: GPUTextureUsageFlags,
+  ) => void;
   /** Intermediate texture format for the rendering pipeline */
   intermediateFormat: GPUTextureFormat;
   /** Whether the GPU is rendering in Display P3 color space */
   supportsP3: boolean;
 }
 
+export interface ExternalTextureSource {
+  texture: GPUExternalTexture;
+}
+
+export function createExternalTextureShaderSource(source: string): string {
+  return source
+    .replace(
+      /@group\(0\)\s+@binding\(1\)\s+var\s+sourceTexture:\s+texture_2d<f32>;/,
+      "@group(0) @binding(1) var sourceTexture: texture_external;",
+    )
+    .replace(
+      /fn loadAtUV\(uv: vec2f\) -> vec4f \{\s*let dims = vec2f\(textureDimensions\(sourceTexture\)\);\s*let coord = vec2i\(clamp\(uv \* dims, vec2f\(0\.0\), dims - 1\.0\)\);\s*return textureLoad\(sourceTexture, coord, 0\);\s*\}/,
+      "fn loadAtUV(uv: vec2f) -> vec4f {\n  return textureSampleBaseClampToEdge(sourceTexture, sourceSampler, clamp(uv, vec2f(0.0), vec2f(1.0)));\n}",
+    )
+    .replace(
+      /textureSampleLevel\(sourceTexture,\s*sourceSampler,\s*([^,]+),\s*0\.0\)/g,
+      "textureSampleBaseClampToEdge(sourceTexture, sourceSampler, $1)",
+    )
+    .replace(
+      /textureSample\(sourceTexture,\s*sourceSampler,/g,
+      "textureSampleBaseClampToEdge(sourceTexture, sourceSampler,",
+    );
+}
+
 export abstract class ShaderPass {
   protected pipeline: GPURenderPipeline | null = null;
   protected bindGroupLayout: GPUBindGroupLayout | null = null;
+  protected externalPipeline: GPURenderPipeline | null = null;
+  protected externalBindGroupLayout: GPUBindGroupLayout | null = null;
   #textureViewCache = new WeakMap<GPUTexture, GPUTextureView>();
-  #bindGroupCache = new WeakMap<GPUTexture, GPUBindGroup>();
+  #uniformBufferCache = new Map<string, GPUBuffer>();
 
   constructor(protected readonly ctx: ShaderContext) {}
 
@@ -50,6 +81,8 @@ export abstract class ShaderPass {
   async initialize(): Promise<void> {
     this.bindGroupLayout = this.createBindGroupLayout();
     this.pipeline = this.createPipeline();
+    this.externalBindGroupLayout = this.createExternalBindGroupLayout();
+    this.externalPipeline = this.createExternalPipeline();
   }
 
   /**
@@ -166,6 +199,29 @@ export abstract class ShaderPass {
     });
   }
 
+  protected createExternalBindGroupLayout(): GPUBindGroupLayout {
+    return this.ctx.device.createBindGroupLayout({
+      label: `${this.constructor.name} external bind group layout`,
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.FRAGMENT,
+          externalTexture: {},
+        },
+        {
+          binding: 2,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: "filtering" },
+        },
+      ],
+    });
+  }
+
   /** Create render pipeline from shader source and layout */
   protected createPipeline(): GPURenderPipeline {
     const shaderModule = this.ctx.device.createShaderModule({
@@ -191,14 +247,70 @@ export abstract class ShaderPass {
     });
   }
 
+  protected createExternalPipeline(): GPURenderPipeline {
+    const shaderModule = this.ctx.device.createShaderModule({
+      label: `${this.constructor.name} external shader`,
+      code: createExternalTextureShaderSource(this.getShaderSource()),
+    });
+
+    const pipelineLayout = this.ctx.device.createPipelineLayout({
+      label: `${this.constructor.name} external pipeline layout`,
+      bindGroupLayouts: [this.externalBindGroupLayout!],
+    });
+
+    return this.ctx.device.createRenderPipeline({
+      label: `${this.constructor.name} external pipeline`,
+      layout: pipelineLayout,
+      vertex: { module: shaderModule, entryPoint: "vs_main" },
+      fragment: {
+        module: shaderModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.ctx.intermediateFormat }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+  }
+
+  #getUniformBuffer(entityId: string): GPUBuffer {
+    const cached = this.#uniformBufferCache.get(entityId);
+    if (cached) return cached;
+
+    const buffer = this.ctx.device.createBuffer({
+      label: `${this.constructor.name} uniforms ${entityId}`,
+      size: this.ctx.uniformData.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this.#uniformBufferCache.set(entityId, buffer);
+    return buffer;
+  }
+
+  protected writeEntityUniformBuffer(entity: EffectRenderEntity): GPUBuffer {
+    this.writeUniforms(entity);
+    const uniformBuffer = this.#getUniformBuffer(entity.id);
+    this.ctx.device.queue.writeBuffer(uniformBuffer, 0, this.ctx.uniformData);
+    return uniformBuffer;
+  }
+
   /** Create bind group for a source texture. Override for extra bindings (ASCII). */
-  createBindGroup(sourceTextureView: GPUTextureView): GPUBindGroup {
+  createBindGroup(sourceTextureView: GPUTextureView, uniformBuffer: GPUBuffer): GPUBindGroup {
     return this.ctx.device.createBindGroup({
       label: `${this.constructor.name} bind group`,
       layout: this.bindGroupLayout!,
       entries: [
-        { binding: 0, resource: { buffer: this.ctx.uniformBuffer } },
+        { binding: 0, resource: { buffer: uniformBuffer } },
         { binding: 1, resource: sourceTextureView },
+        { binding: 2, resource: this.ctx.sampler },
+      ],
+    });
+  }
+
+  createExternalBindGroup(source: ExternalTextureSource, uniformBuffer: GPUBuffer): GPUBindGroup {
+    return this.ctx.device.createBindGroup({
+      label: `${this.constructor.name} external bind group`,
+      layout: this.externalBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: source.texture },
         { binding: 2, resource: this.ctx.sampler },
       ],
     });
@@ -213,13 +325,8 @@ export abstract class ShaderPass {
     return view;
   }
 
-  protected getBindGroup(sourceTexture: GPUTexture): GPUBindGroup {
-    const cached = this.#bindGroupCache.get(sourceTexture);
-    if (cached) return cached;
-
-    const bindGroup = this.createBindGroup(this.getTextureView(sourceTexture));
-    this.#bindGroupCache.set(sourceTexture, bindGroup);
-    return bindGroup;
+  protected getBindGroup(sourceTexture: GPUTexture, uniformBuffer: GPUBuffer): GPUBindGroup {
+    return this.createBindGroup(this.getTextureView(sourceTexture), uniformBuffer);
   }
 
   /**
@@ -236,10 +343,8 @@ export abstract class ShaderPass {
   ): void {
     if (!this.pipeline) return;
 
-    this.writeUniforms(entity);
-    this.ctx.device.queue.writeBuffer(this.ctx.uniformBuffer, 0, this.ctx.uniformData);
-
-    const bindGroup = this.getBindGroup(sourceTexture);
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
+    const bindGroup = this.getBindGroup(sourceTexture, uniformBuffer);
 
     const pass = encoder.beginRenderPass({
       label: `${this.constructor.name} render pass`,
@@ -259,10 +364,45 @@ export abstract class ShaderPass {
     pass.end();
   }
 
+  executeExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    if (!this.externalPipeline) return;
+
+    const uniformBuffer = this.writeEntityUniformBuffer(entity);
+    const bindGroup = this.createExternalBindGroup(source, uniformBuffer);
+
+    const pass = encoder.beginRenderPass({
+      label: `${this.constructor.name} external render pass`,
+      colorAttachments: [
+        {
+          view: this.getTextureView(outputTexture),
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+        },
+      ],
+    });
+
+    pass.setPipeline(this.externalPipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+  }
+
   /** Cleanup GPU resources. Override to clean up additional resources. */
   destroy(): void {
+    for (const buffer of this.#uniformBufferCache.values()) {
+      buffer.destroy();
+    }
+    this.#uniformBufferCache.clear();
     // Pipeline and bind group layout don't need explicit destruction
     this.pipeline = null;
     this.bindGroupLayout = null;
+    this.externalPipeline = null;
+    this.externalBindGroupLayout = null;
   }
 }

--- a/renderer/shaders/shader-registry.ts
+++ b/renderer/shaders/shader-registry.ts
@@ -1,7 +1,7 @@
 import type { ShaderType } from "#types/canvas.ts";
 import type { TexturePool } from "../texture-pool.ts";
 import type { EffectRenderEntity } from "../effect-render-entity.ts";
-import type { ShaderPass } from "./shader-pass.ts";
+import type { ExternalTextureSource, ShaderPass } from "./shader-pass.ts";
 
 export class ShaderRegistry {
   #passes: Map<string, ShaderPass> = new Map();
@@ -31,6 +31,17 @@ export class ShaderRegistry {
     const pass = this.#passes.get(entity.shaderType);
     if (!pass) throw new Error(`Shader pass not registered: ${entity.shaderType}`);
     pass.execute(entity, sourceTexture, outputTexture, encoder);
+  }
+
+  applyShaderExternal(
+    entity: EffectRenderEntity,
+    source: ExternalTextureSource,
+    outputTexture: GPUTexture,
+    encoder: GPUCommandEncoder,
+  ): void {
+    const pass = this.#passes.get(entity.shaderType);
+    if (!pass) throw new Error(`Shader pass not registered: ${entity.shaderType}`);
+    pass.executeExternal(entity, source, outputTexture, encoder);
   }
 
   /**

--- a/types/canvas.ts
+++ b/types/canvas.ts
@@ -147,13 +147,6 @@ export const DITHERING_KIND_OPTIONS = [
   { value: DitheringKind.bayer8x8, label: "Bayer 8x8" },
   { value: DitheringKind.whiteNoise, label: "White Noise" },
   { value: DitheringKind.blueNoise, label: "Blue Noise" },
-  { value: DitheringKind.floydSteinberg, label: "Floyd-Steinberg" },
-  { value: DitheringKind.atkinson, label: "Atkinson" },
-  { value: DitheringKind.jarvisJudiceNinke, label: "Jarvis-Judice-Ninke" },
-  { value: DitheringKind.stucki, label: "Stucki" },
-  { value: DitheringKind.burkes, label: "Burkes" },
-  { value: DitheringKind.sierra, label: "Sierra" },
-  { value: DitheringKind.sierraLite, label: "Sierra Lite" },
 ];
 
 /** Check if a dithering kind requires compute shader (error diffusion) */


### PR DESCRIPTION
## Summary

- Improves canvas video rendering by adding zero-copy GPUExternalTexture paths for shader and composition work.
- Extends external video sampling through ASCII, ordered dithering, glass variants, adjustments, and composition so more video frames can avoid CPU-side materialization.
- Keeps the batched single-submit renderer stable by isolating per-entity shader and processing uniforms and deferring pooled intermediate texture release until after encoded work is submitted.

## Why

This branch is primarily a performance pass for video-heavy canvases. Instead of uploading every active video frame into an entity-owned GPUTexture before shader processing, supported paths can import the live HTMLVideoElement as a GPUExternalTexture and sample it directly on the GPU. That reduces copy/upload work for common video shader cases.

During that work, the new batched external-texture path exposed shared uniform buffers that were still safe in the older materialized-texture flow. Those uniforms include source resolution, output dimensions, and sampling/framing data, so they now need to be scoped per entity when multiple video entities are encoded before one queue submit.

## Impact

- Common processed video shaders can use the zero-copy path instead of materializing each frame.
- Multiple video entities with shaders no longer share framing/sizing uniforms during a batched render.
- Intermediate textures from compute/post-processing paths are returned to the pool only after the command buffer that references them is submitted.

## Remaining Work
- [x] Error-diffusion dithering still materializes video frames because the compute path does not yet support texture_external sources.
- [x] Pre-blur still materializes video frames because the first Kawase blur/downsample pass does not yet have an external-texture variant.
- [x] The external shader source conversion is intentionally limited to the current shader patterns; future WGSL changes should keep texture_external compatibility in mind.
- [x] REMOVED error diffusion algos from the UI for now, as the output of those is very  bad due to out-of-order reads of pixel rows

## Validation

- bun run lint:all
- bun run test
