### PR TITLE
Reduce WebGPU texture and object churn

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@ if [ -z "$STAGED_FILES" ]; then
 fi
 
 echo "Formatting staged files..."
-bun run format
+./node_modules/.bin/oxfmt $STAGED_FILES
 
 # Only re-add the files that were originally staged
 echo "$STAGED_FILES" | xargs git add

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -13,7 +13,13 @@ import {
   getViewportMatrix,
   getViewportWorldBounds,
 } from "../lib/canvas-math.ts";
-import { type Bounds, type RGBA, type ShaderCanvasEntity, type Viewport } from "#types/canvas.ts";
+import {
+  MediaType,
+  type Bounds,
+  type RGBA,
+  type ShaderCanvasEntity,
+  type Viewport,
+} from "#types/canvas.ts";
 import compositionShaderSource from "./composition.wgsl?raw";
 import { CopyPass } from "./copy-pass.ts";
 import { DisintegrationParticleSystem } from "./disintegration-particles.ts";
@@ -1147,6 +1153,8 @@ export class InfiniteCanvasRenderer {
       width: entity.originalSize.width,
       height: entity.originalSize.height,
       respectShowOriginal: true,
+      sourceAlphaMode:
+        entity.mediaSource.type === MediaType.video ? entity.mediaSource.alphaMode : undefined,
     });
 
     this.#device.queue.submit([encoder.finish()]);
@@ -1484,6 +1492,8 @@ export class InfiniteCanvasRenderer {
       width,
       height,
       respectShowOriginal: true,
+      sourceAlphaMode:
+        entity.mediaSource.type === MediaType.video ? entity.mediaSource.alphaMode : undefined,
     });
 
     // Cache and return (source texture stays in #entitySourceTextures)

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -221,7 +221,13 @@ export class InfiniteCanvasRenderer {
   #viewportLensSampler: GPUSampler | null = null;
   #viewportLensUniformData = new ArrayBuffer(48);
   #viewportLensFloatView = new Float32Array(this.#viewportLensUniformData);
-  #viewportLensTexture: { width: number; height: number; texture: GPUTexture } | null = null;
+  #viewportLensTexture: {
+    width: number;
+    height: number;
+    texture: GPUTexture;
+    view: GPUTextureView;
+    bindGroup: GPUBindGroup;
+  } | null = null;
 
   // Wlur progressive full-canvas overlay
   #wlurPass: WlurPass | null = null;
@@ -819,25 +825,58 @@ export class InfiniteCanvasRenderer {
     this.#viewportLensTexture = null;
   }
 
-  #getOrCreateViewportLensTexture(width: number, height: number): GPUTexture {
+  #shouldApplyViewportLensDistortion(): boolean {
+    const lens = this.#viewportLensConfig;
+    return (
+      lens.enabled &&
+      (lens.strength > 0.001 || lens.dispersion > 0.001) &&
+      this.#viewportLensPipeline !== null &&
+      this.#viewportLensBindGroupLayout !== null &&
+      this.#viewportLensUniformBuffer !== null &&
+      this.#viewportLensSampler !== null
+    );
+  }
+
+  #getOrCreateViewportLensTexture(
+    width: number,
+    height: number,
+  ): { texture: GPUTexture; view: GPUTextureView } | null {
     const cached = this.#viewportLensTexture;
     if (cached && cached.width === width && cached.height === height) {
-      return cached.texture;
+      return cached;
+    }
+
+    if (
+      !this.#device ||
+      !this.#viewportLensBindGroupLayout ||
+      !this.#viewportLensUniformBuffer ||
+      !this.#viewportLensSampler
+    ) {
+      return null;
     }
 
     this.#destroyViewportLensTexture();
-    const texture = this.#device!.createTexture({
+    const texture = this.#device.createTexture({
       label: `Viewport lens input (${width}x${height})`,
       size: [width, height],
       format: this.#canvasFormat,
       usage:
         GPUTextureUsage.TEXTURE_BINDING |
         GPUTextureUsage.RENDER_ATTACHMENT |
-        GPUTextureUsage.COPY_DST |
         GPUTextureUsage.COPY_SRC,
     });
-    this.#viewportLensTexture = { width, height, texture };
-    return texture;
+    const view = texture.createView();
+    const bindGroup = this.#device.createBindGroup({
+      label: "Viewport lens distortion bind group",
+      layout: this.#viewportLensBindGroupLayout,
+      entries: [
+        { binding: 0, resource: view },
+        { binding: 1, resource: this.#viewportLensSampler },
+        { binding: 2, resource: { buffer: this.#viewportLensUniformBuffer } },
+      ],
+    });
+    this.#viewportLensTexture = { width, height, texture, view, bindGroup };
+    return this.#viewportLensTexture;
   }
 
   #createViewportLensPipeline(): void {
@@ -891,29 +930,19 @@ export class InfiniteCanvasRenderer {
 
   #encodeViewportLensDistortion(
     encoder: GPUCommandEncoder,
-    sourceTexture: GPUTexture,
     targetView: GPUTextureView,
     width: number,
     height: number,
   ): boolean {
-    const lens = this.#viewportLensConfig;
-    if (
-      !lens.enabled ||
-      (lens.strength <= 0.001 && lens.dispersion <= 0.001) ||
-      !this.#viewportLensPipeline ||
-      !this.#viewportLensBindGroupLayout ||
-      !this.#viewportLensUniformBuffer ||
-      !this.#viewportLensSampler
-    ) {
+    if (!this.#shouldApplyViewportLensDistortion()) {
       return false;
     }
 
-    const inputTexture = this.#getOrCreateViewportLensTexture(width, height);
-    encoder.copyTextureToTexture(
-      { texture: sourceTexture },
-      { texture: inputTexture },
-      { width, height },
-    );
+    const lens = this.#viewportLensConfig;
+    const lensTexture = this.#getOrCreateViewportLensTexture(width, height);
+    if (!lensTexture || !this.#viewportLensUniformBuffer || !this.#viewportLensPipeline) {
+      return false;
+    }
 
     const v = this.#viewportLensFloatView;
     v[0] = width;
@@ -934,16 +963,6 @@ export class InfiniteCanvasRenderer {
       this.#viewportLensUniformData,
     );
 
-    const bindGroup = this.#device!.createBindGroup({
-      label: "Viewport lens distortion bind group",
-      layout: this.#viewportLensBindGroupLayout,
-      entries: [
-        { binding: 0, resource: inputTexture.createView() },
-        { binding: 1, resource: this.#viewportLensSampler },
-        { binding: 2, resource: { buffer: this.#viewportLensUniformBuffer } },
-      ],
-    });
-
     const pass = encoder.beginRenderPass({
       label: "Viewport lens distortion pass",
       colorAttachments: [
@@ -956,7 +975,7 @@ export class InfiniteCanvasRenderer {
       ],
     });
     pass.setPipeline(this.#viewportLensPipeline);
-    pass.setBindGroup(0, bindGroup);
+    pass.setBindGroup(0, this.#viewportLensTexture!.bindGroup);
     pass.draw(3);
     pass.end();
     return true;
@@ -1741,6 +1760,11 @@ export class InfiniteCanvasRenderer {
       return;
     }
     const targetView = texture.createView();
+    const viewportLensTarget = this.#shouldApplyViewportLensDistortion()
+      ? this.#getOrCreateViewportLensTexture(width, height)
+      : null;
+    const sceneTargetTexture = viewportLensTarget?.texture ?? texture;
+    const sceneTargetView = viewportLensTarget?.view ?? targetView;
 
     // Pass 1: Render dot grid background
     markPhaseStart("grid-pass");
@@ -1748,7 +1772,7 @@ export class InfiniteCanvasRenderer {
       label: "Grid render pass",
       colorAttachments: [
         {
-          view: targetView,
+          view: sceneTargetView,
           loadOp: "clear",
           storeOp: "store",
           clearValue: { r: 0, g: 0, b: 0, a: 0 },
@@ -1772,7 +1796,7 @@ export class InfiniteCanvasRenderer {
       label: "Entity composition pass",
       colorAttachments: [
         {
-          view: targetView,
+          view: sceneTargetView,
           loadOp: "load",
           storeOp: "store",
         },
@@ -1808,9 +1832,9 @@ export class InfiniteCanvasRenderer {
           !this.#actionLayerBlurCacheValid || state.dirty || hasAnimatingContent;
 
         if (blurNeedsUpdate) {
-          // Copy swapchain → input texture
+          // Copy the pre-lens scene → input texture
           encoder.copyTextureToTexture(
-            { texture },
+            { texture: sceneTargetTexture },
             { texture: blurTextures.input },
             { width, height },
           );
@@ -1850,7 +1874,7 @@ export class InfiniteCanvasRenderer {
           label: "Action layer blit pass",
           colorAttachments: [
             {
-              view: targetView,
+              view: sceneTargetView,
               loadOp: "load",
               storeOp: "store",
             },
@@ -1876,7 +1900,7 @@ export class InfiniteCanvasRenderer {
         label: "Action layer sharp entity pass",
         colorAttachments: [
           {
-            view: targetView,
+            view: sceneTargetView,
             loadOp: "load",
             storeOp: "store",
           },
@@ -1893,7 +1917,7 @@ export class InfiniteCanvasRenderer {
         label: "Canvas callout pass",
         colorAttachments: [
           {
-            view: targetView,
+            view: sceneTargetView,
             loadOp: "load",
             storeOp: "store",
           },
@@ -1908,7 +1932,7 @@ export class InfiniteCanvasRenderer {
     }
 
     // Pass 2b: Render disintegration overlays (on top of entities)
-    this.#renderDisintegrationOverlays(encoder, targetView, frameDt);
+    this.#renderDisintegrationOverlays(encoder, sceneTargetView, frameDt);
 
     // Pass 3: Render all selection rectangles (drag-select and multi-select bounds)
     // Collect all active rectangles
@@ -1949,7 +1973,7 @@ export class InfiniteCanvasRenderer {
         label: "Selection rectangles render pass",
         colorAttachments: [
           {
-            view: targetView,
+            view: sceneTargetView,
             loadOp: "load", // Preserve previous content
             storeOp: "store",
           },
@@ -1964,13 +1988,9 @@ export class InfiniteCanvasRenderer {
     }
 
     markPhaseStart("viewport-lens-distortion");
-    const lensApplied = this.#encodeViewportLensDistortion(
-      encoder,
-      texture,
-      targetView,
-      width,
-      height,
-    );
+    const lensApplied = viewportLensTarget
+      ? this.#encodeViewportLensDistortion(encoder, targetView, width, height)
+      : false;
     markPhaseEnd("viewport-lens-distortion");
 
     // Final pass: WLUR progressive blur overlay (renders on top of everything)

--- a/renderer/entity-shader-runtime.ts
+++ b/renderer/entity-shader-runtime.ts
@@ -204,6 +204,7 @@ export class EntityShaderRuntime {
     let pipelineOutputTexture = outputTexture;
     let alphaMaskIntermediateTexture: GPUTexture | null = null;
     let postProcessIntermediateTexture: GPUTexture | null = null;
+    const reuseOutputTextureForPostProcessSource = postProcessEnabled && applySourceAlphaMask;
 
     if (applySourceAlphaMask) {
       alphaMaskIntermediateTexture = this.#acquireTexture(
@@ -217,13 +218,17 @@ export class EntityShaderRuntime {
 
     let mainShaderOutputTexture = pipelineOutputTexture;
     if (postProcessEnabled) {
-      postProcessIntermediateTexture = this.#acquireTexture(
-        width,
-        height,
-        postProcessUsage,
-        "Post-process intermediate texture",
-      );
-      mainShaderOutputTexture = postProcessIntermediateTexture;
+      if (reuseOutputTextureForPostProcessSource) {
+        mainShaderOutputTexture = outputTexture;
+      } else {
+        postProcessIntermediateTexture = this.#acquireTexture(
+          width,
+          height,
+          postProcessUsage,
+          "Post-process intermediate texture",
+        );
+        mainShaderOutputTexture = postProcessIntermediateTexture;
+      }
     }
 
     if (shaderSource.kind === "external") {
@@ -249,13 +254,16 @@ export class EntityShaderRuntime {
       this.#releaseTexture(adjustmentsOutputTexture, width, height, preProcessUsage);
     }
 
-    if (postProcessIntermediateTexture) {
+    if (postProcessEnabled) {
       this.#processingPipeline.applyPostProcessing(
         entity,
-        postProcessIntermediateTexture,
+        mainShaderOutputTexture,
         pipelineOutputTexture,
         encoder,
       );
+    }
+
+    if (postProcessIntermediateTexture) {
       this.#releaseTexture(postProcessIntermediateTexture, width, height, postProcessUsage);
     }
 

--- a/renderer/entity-shader-runtime.ts
+++ b/renderer/entity-shader-runtime.ts
@@ -1,6 +1,6 @@
 import { config } from "#config";
 import { isErrorDiffusion, ShaderType } from "#types/canvas.ts";
-import type { RGBA } from "#types/canvas.ts";
+import type { MediaAlphaMode, RGBA } from "#types/canvas.ts";
 import { AlphaMaskPass } from "./alpha-mask-pass.ts";
 import { CopyPass } from "./copy-pass.ts";
 import type { EffectRenderEntity } from "./effect-render-entity.ts";
@@ -130,6 +130,7 @@ export class EntityShaderRuntime {
     width: number;
     height: number;
     respectShowOriginal: boolean;
+    sourceAlphaMode?: MediaAlphaMode;
   }): void {
     const { entity, source, outputTexture, encoder, width, height } = params;
 
@@ -140,7 +141,7 @@ export class EntityShaderRuntime {
       return;
     }
 
-    const applySourceAlphaMask = shouldApplySourceAlphaMask(entity);
+    const applySourceAlphaMask = shouldApplySourceAlphaMask(entity, params.sourceAlphaMode);
     const needsBlur = this.#processingPipeline.needsBlur(entity);
     const needsAdjustments = this.#processingPipeline.needsAdjustments(entity);
     const postProcessEnabled = entity.shaderParams.postProcess?.enabled ?? false;
@@ -344,7 +345,14 @@ function shaderImmediatesDisabledByLocation(): boolean {
   return new URLSearchParams(search).get("shaderImmediates") === "0";
 }
 
-function shouldApplySourceAlphaMask(entity: EffectRenderEntity): boolean {
+function shouldApplySourceAlphaMask(
+  entity: EffectRenderEntity,
+  sourceAlphaMode: MediaAlphaMode | undefined,
+): boolean {
+  if (sourceAlphaMode === "none") {
+    return false;
+  }
+
   if (entity.shaderType !== ShaderType.dithering) return true;
 
   const ditheringKind = entity.shaderParams.dithering?.kind;

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -113,6 +113,8 @@ export class ProcessingPipeline {
   #postProcessFloatView = new Float32Array(this.#postProcessUniformData);
   #postProcessUintView = new Uint32Array(this.#postProcessUniformData);
   #postProcessTime = 0; // Animated time for grain effect
+  #dummyBloomTexture: GPUTexture | null = null;
+  #dummyBloomTextureView: GPUTextureView | null = null;
 
   // Bloom pipeline (multi-pass downsample/upsample)
   #bloomDownsamplePipeline: GPURenderPipeline | null = null;
@@ -1790,18 +1792,7 @@ export class ProcessingPipeline {
 
     // If no bloom texture was generated, create a 1x1 black texture as placeholder
     // (the shader expects a texture at binding 3)
-    let bloomTextureView: GPUTextureView;
-    if (bloomTexture) {
-      bloomTextureView = bloomTexture.createView();
-    } else {
-      const dummyTexture = this.#device.createTexture({
-        label: "Dummy bloom texture",
-        size: [1, 1],
-        format: this.#intermediateFormat,
-        usage: GPUTextureUsage.TEXTURE_BINDING,
-      });
-      bloomTextureView = dummyTexture.createView();
-    }
+    const bloomTextureView = bloomTexture?.createView() ?? this.#getDummyBloomTextureView();
 
     this.#updatePostProcessUniforms(entity);
     const uniformBuffer = this.#getOrCreateUniformBuffer(
@@ -1842,6 +1833,19 @@ export class ProcessingPipeline {
 
     // Increment time for animated grain
     this.#postProcessTime += 0.016; // ~60fps increment
+  }
+
+  #getDummyBloomTextureView(): GPUTextureView {
+    if (this.#dummyBloomTextureView) return this.#dummyBloomTextureView;
+
+    this.#dummyBloomTexture = this.#device.createTexture({
+      label: "Dummy bloom texture",
+      size: [1, 1],
+      format: this.#intermediateFormat,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+    });
+    this.#dummyBloomTextureView = this.#dummyBloomTexture.createView();
+    return this.#dummyBloomTextureView;
   }
 
   removeEntity(entityId: string): void {
@@ -1889,6 +1893,9 @@ export class ProcessingPipeline {
     this.#blurMixUniformBuffer?.destroy();
     for (const buf of this.#bloomDownsampleUniformBuffers) buf.destroy();
     for (const buf of this.#bloomUpsampleUniformBuffers) buf.destroy();
+    this.#dummyBloomTexture?.destroy();
+    this.#dummyBloomTexture = null;
+    this.#dummyBloomTextureView = null;
 
     // Destroy blur mip chain textures
     for (const cached of this.#blurMipChainCache.values()) {

--- a/renderer/processing-pipeline.ts
+++ b/renderer/processing-pipeline.ts
@@ -30,6 +30,20 @@ interface BloomUniformSet {
   upsample: GPUBuffer[];
 }
 
+interface PostProcessBindGroupCacheEntry {
+  uniformBuffer: GPUBuffer;
+  inputTexture: GPUTexture;
+  bloomTexture: GPUTexture | null;
+  bindGroup: GPUBindGroup;
+}
+
+interface BloomBindGroupCacheEntry {
+  dimensionsKey: string;
+  sourceTexture: GPUTexture;
+  downsample: GPUBindGroup[];
+  upsample: GPUBindGroup[];
+}
+
 type BlurInputSource =
   | { kind: "texture"; texture: GPUTexture }
   | { kind: "external"; texture: GPUExternalTexture };
@@ -113,8 +127,10 @@ export class ProcessingPipeline {
   #postProcessFloatView = new Float32Array(this.#postProcessUniformData);
   #postProcessUintView = new Uint32Array(this.#postProcessUniformData);
   #postProcessTime = 0; // Animated time for grain effect
+  #postProcessBindGroupCache = new Map<string, PostProcessBindGroupCacheEntry>();
   #dummyBloomTexture: GPUTexture | null = null;
   #dummyBloomTextureView: GPUTextureView | null = null;
+  #textureViewCache = new WeakMap<GPUTexture, GPUTextureView>();
 
   // Bloom pipeline (multi-pass downsample/upsample)
   #bloomDownsamplePipeline: GPURenderPipeline | null = null;
@@ -125,11 +141,13 @@ export class ProcessingPipeline {
   #bloomDownsampleUniformBuffers: GPUBuffer[] = [];
   #bloomUpsampleUniformBuffers: GPUBuffer[] = [];
   #bloomSampler: GPUSampler | null = null;
+  #bloomBindGroupCache = new Map<string, BloomBindGroupCacheEntry>();
   // Bloom mip chain textures (cached per entity dimensions)
   #bloomMipChainCache: Map<
     string,
     {
       textures: GPUTexture[];
+      views: GPUTextureView[];
       width: number;
       height: number;
     }
@@ -159,6 +177,15 @@ export class ProcessingPipeline {
     });
     cache.set(entityId, buffer);
     return buffer;
+  }
+
+  #getTextureView(texture: GPUTexture): GPUTextureView {
+    const cached = this.#textureViewCache.get(texture);
+    if (cached) return cached;
+
+    const view = texture.createView();
+    this.#textureViewCache.set(texture, view);
+    return view;
   }
 
   #getOrCreateBlurUniformSet(entityId: string): BlurUniformSet {
@@ -802,6 +829,7 @@ export class ProcessingPipeline {
     if (cached) return cached.textures;
 
     const textures: GPUTexture[] = [];
+    const views: GPUTextureView[] = [];
     let mipWidth = Math.floor(width / 2);
     let mipHeight = Math.floor(height / 2);
 
@@ -821,13 +849,14 @@ export class ProcessingPipeline {
       });
 
       textures.push(texture);
+      views.push(this.#getTextureView(texture));
 
       // Halve for next mip
       mipWidth = Math.floor(mipWidth / 2);
       mipHeight = Math.floor(mipHeight / 2);
     }
 
-    this.#bloomMipChainCache.set(key, { textures, width, height });
+    this.#bloomMipChainCache.set(key, { textures, views, width, height });
     return textures;
   }
 
@@ -856,8 +885,10 @@ export class ProcessingPipeline {
     }
 
     const uniformSet = this.#getOrCreateBloomUniformSet(entityId);
+    const dimensionsKey = `${width}x${height}`;
     const mipChain = this.#getOrCreateBloomMipChain(width, height);
     if (mipChain.length === 0) return null;
+    const mipViews = this.#bloomMipChainCache.get(dimensionsKey)!.views;
 
     // Write all uniform data upfront (each mip has its own buffer)
     let srcWidth = width;
@@ -897,31 +928,26 @@ export class ProcessingPipeline {
       this.#device.queue.writeBuffer(uniformSet.upsample[bufIdx]!, 0, upsampleUniformData);
     }
 
+    const bindGroups = this.#getOrCreateBloomBindGroups(
+      entityId,
+      dimensionsKey,
+      sourceTexture,
+      uniformSet,
+      mipViews,
+    );
+
     // === Downsample passes ===
-    let srcTexture = sourceTexture;
     for (let i = 0; i < mipChain.length; i++) {
       const dstTexture = mipChain[i]!;
+      const dstView = mipViews[i]!;
       const dstWidth = dstTexture.width;
       const dstHeight = dstTexture.height;
-
-      const bindGroup = this.#device.createBindGroup({
-        label: `Bloom downsample bind group mip ${i}`,
-        layout: this.#bloomDownsampleBindGroupLayout,
-        entries: [
-          {
-            binding: 0,
-            resource: { buffer: uniformSet.downsample[i]! },
-          },
-          { binding: 1, resource: srcTexture.createView() },
-          { binding: 2, resource: this.#bloomSampler },
-        ],
-      });
 
       const pass = encoder.beginRenderPass({
         label: `Bloom downsample pass mip ${i}`,
         colorAttachments: [
           {
-            view: dstTexture.createView(),
+            view: dstView,
             loadOp: "clear",
             storeOp: "store",
             clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -930,40 +956,25 @@ export class ProcessingPipeline {
       });
 
       pass.setPipeline(this.#bloomDownsamplePipeline);
-      pass.setBindGroup(0, bindGroup);
+      pass.setBindGroup(0, bindGroups.downsample[i]!);
       pass.setViewport(0, 0, dstWidth, dstHeight, 0, 1);
       pass.draw(3);
       pass.end();
-
-      srcTexture = dstTexture;
     }
 
     // === Upsample passes ===
     for (let i = mipChain.length - 1; i > 0; i--) {
-      const srcMip = mipChain[i]!;
       const dstMip = mipChain[i - 1]!;
+      const dstView = mipViews[i - 1]!;
       const dstWidth = dstMip.width;
       const dstHeight = dstMip.height;
       const bufIdx = mipChain.length - 1 - i;
-
-      const bindGroup = this.#device.createBindGroup({
-        label: `Bloom upsample bind group mip ${i}`,
-        layout: this.#bloomUpsampleBindGroupLayout,
-        entries: [
-          {
-            binding: 0,
-            resource: { buffer: uniformSet.upsample[bufIdx]! },
-          },
-          { binding: 1, resource: srcMip.createView() },
-          { binding: 2, resource: this.#bloomSampler },
-        ],
-      });
 
       const pass = encoder.beginRenderPass({
         label: `Bloom upsample pass mip ${i}`,
         colorAttachments: [
           {
-            view: dstMip.createView(),
+            view: dstView,
             loadOp: "load",
             storeOp: "store",
           },
@@ -971,13 +982,74 @@ export class ProcessingPipeline {
       });
 
       pass.setPipeline(this.#bloomUpsamplePipeline);
-      pass.setBindGroup(0, bindGroup);
+      pass.setBindGroup(0, bindGroups.upsample[bufIdx]!);
       pass.setViewport(0, 0, dstWidth, dstHeight, 0, 1);
       pass.draw(3);
       pass.end();
     }
 
     return mipChain[0] ?? null;
+  }
+
+  #getOrCreateBloomBindGroups(
+    entityId: string,
+    dimensionsKey: string,
+    sourceTexture: GPUTexture,
+    uniformSet: BloomUniformSet,
+    mipViews: GPUTextureView[],
+  ): BloomBindGroupCacheEntry {
+    const cached = this.#bloomBindGroupCache.get(entityId);
+    if (
+      cached &&
+      cached.dimensionsKey === dimensionsKey &&
+      cached.sourceTexture === sourceTexture
+    ) {
+      return cached;
+    }
+
+    const downsample: GPUBindGroup[] = [];
+    for (let i = 0; i < BLOOM_MIP_LEVELS; i++) {
+      downsample.push(
+        this.#device.createBindGroup({
+          label: `Bloom downsample bind group mip ${i}`,
+          layout: this.#bloomDownsampleBindGroupLayout!,
+          entries: [
+            {
+              binding: 0,
+              resource: { buffer: uniformSet.downsample[i]! },
+            },
+            {
+              binding: 1,
+              resource: i === 0 ? this.#getTextureView(sourceTexture) : mipViews[i - 1]!,
+            },
+            { binding: 2, resource: this.#bloomSampler! },
+          ],
+        }),
+      );
+    }
+
+    const upsample: GPUBindGroup[] = [];
+    for (let i = BLOOM_MIP_LEVELS - 1; i > 0; i--) {
+      const bufIdx = BLOOM_MIP_LEVELS - 1 - i;
+      upsample.push(
+        this.#device.createBindGroup({
+          label: `Bloom upsample bind group mip ${i}`,
+          layout: this.#bloomUpsampleBindGroupLayout!,
+          entries: [
+            {
+              binding: 0,
+              resource: { buffer: uniformSet.upsample[bufIdx]! },
+            },
+            { binding: 1, resource: mipViews[i]! },
+            { binding: 2, resource: this.#bloomSampler! },
+          ],
+        }),
+      );
+    }
+
+    const entry = { dimensionsKey, sourceTexture, downsample, upsample };
+    this.#bloomBindGroupCache.set(entityId, entry);
+    return entry;
   }
 
   /**
@@ -1790,10 +1862,6 @@ export class ProcessingPipeline {
       );
     }
 
-    // If no bloom texture was generated, create a 1x1 black texture as placeholder
-    // (the shader expects a texture at binding 3)
-    const bloomTextureView = bloomTexture?.createView() ?? this.#getDummyBloomTextureView();
-
     this.#updatePostProcessUniforms(entity);
     const uniformBuffer = this.#getOrCreateUniformBuffer(
       this.#postProcessUniformBuffers,
@@ -1803,22 +1871,20 @@ export class ProcessingPipeline {
     );
     this.#device.queue.writeBuffer(uniformBuffer, 0, this.#postProcessUniformData);
 
-    const bindGroup = this.#device.createBindGroup({
-      label: "Post-process bind group",
-      layout: this.#postProcessBindGroupLayout,
-      entries: [
-        { binding: 0, resource: { buffer: uniformBuffer } },
-        { binding: 1, resource: inputTexture.createView() },
-        { binding: 2, resource: this.#postProcessSampler },
-        { binding: 3, resource: bloomTextureView },
-      ],
-    });
+    const cached = this.#postProcessBindGroupCache.get(entity.id);
+    const bindGroup =
+      cached &&
+      cached.uniformBuffer === uniformBuffer &&
+      cached.inputTexture === inputTexture &&
+      cached.bloomTexture === bloomTexture
+        ? cached.bindGroup
+        : this.#createPostProcessBindGroup(entity.id, uniformBuffer, inputTexture, bloomTexture);
 
     const pass = encoder.beginRenderPass({
       label: "Post-process render pass",
       colorAttachments: [
         {
-          view: outputTexture.createView(),
+          view: this.#getTextureView(outputTexture),
           loadOp: "clear",
           storeOp: "store",
           clearValue: { r: 0, g: 0, b: 0, a: 0 },
@@ -1833,6 +1899,34 @@ export class ProcessingPipeline {
 
     // Increment time for animated grain
     this.#postProcessTime += 0.016; // ~60fps increment
+  }
+
+  #createPostProcessBindGroup(
+    entityId: string,
+    uniformBuffer: GPUBuffer,
+    inputTexture: GPUTexture,
+    bloomTexture: GPUTexture | null,
+  ): GPUBindGroup {
+    const bloomTextureView = bloomTexture
+      ? this.#getTextureView(bloomTexture)
+      : this.#getDummyBloomTextureView();
+    const bindGroup = this.#device.createBindGroup({
+      label: "Post-process bind group",
+      layout: this.#postProcessBindGroupLayout!,
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: this.#getTextureView(inputTexture) },
+        { binding: 2, resource: this.#postProcessSampler! },
+        { binding: 3, resource: bloomTextureView },
+      ],
+    });
+    this.#postProcessBindGroupCache.set(entityId, {
+      uniformBuffer,
+      inputTexture,
+      bloomTexture,
+      bindGroup,
+    });
+    return bindGroup;
   }
 
   #getDummyBloomTextureView(): GPUTextureView {
@@ -1854,6 +1948,7 @@ export class ProcessingPipeline {
 
     this.#postProcessUniformBuffers.get(entityId)?.destroy();
     this.#postProcessUniformBuffers.delete(entityId);
+    this.#postProcessBindGroupCache.delete(entityId);
 
     const blurUniforms = this.#entityBlurUniforms.get(entityId);
     if (blurUniforms) {
@@ -1869,6 +1964,7 @@ export class ProcessingPipeline {
       for (const buffer of bloomUniforms.upsample) buffer.destroy();
       this.#entityBloomUniforms.delete(entityId);
     }
+    this.#bloomBindGroupCache.delete(entityId);
   }
 
   destroy(): void {
@@ -1888,6 +1984,8 @@ export class ProcessingPipeline {
       for (const buffer of uniforms.upsample) buffer.destroy();
     }
     this.#entityBloomUniforms.clear();
+    this.#postProcessBindGroupCache.clear();
+    this.#bloomBindGroupCache.clear();
     for (const buf of this.#blurDownsampleUniformBuffers) buf.destroy();
     for (const buf of this.#blurUpsampleUniformBuffers) buf.destroy();
     this.#blurMixUniformBuffer?.destroy();


### PR DESCRIPTION
## Summary

This PR reduces WebGPU memory/bandwidth pressure and per-frame object churn in the canvas/entity rendering path.

### Performance changes

- Avoids a full-canvas copy for viewport lens distortion by rendering the pre-lens scene directly into the lens input texture when lensing is active, then applying the lens pass to the canvas.
- Reuses the existing entity output texture as the post-process source before alpha masking when possible, removing the extra full-resolution post-process intermediate in that path.
- Caches bloom/post-process GPU texture views and bind groups so the active video+bloom path no longer creates bloom/postprocess wrapper objects every frame.
- Adds a cached dummy bloom texture/view instead of recreating a placeholder resource.
- Skips the source-alpha-mask pass for videos proven opaque via `mediaSource.alphaMode === "none"`, removing the alpha-mask render pass and external alpha-mask bind group for normal opaque videos.

### WebGPU Inspector results

With one running opaque video entity using post-process/bloom:

- `createBindGroup` over 2 captured frames dropped to **2 total**, only the expected external-video shader bind groups.
- `createView` over 2 captured frames dropped to **2 total**, only swapchain/current-texture views.
- `AlphaMaskPass external render pass` is gone for videos with `alphaMode: "none"`.
- Validation errors: **0**.
- Copy commands: **0**.

Notes:

- The opaque-video alpha skip removes a pass and bind-group churn. For post-process-enabled videos, it does not eliminate the need for one full-resolution scratch texture because post-processing still cannot read and write the same texture in WebGPU.
- External-video bind groups are intentionally not cached because they bind `GPUExternalTexture`, whose lifetime is frame/import-task scoped.

## Verification

- `bun run lint:all`
- WebGPU Inspector MCP captures on a fresh instrumented Chrome Dev page
