### PR TITLE
extract render/frame responsibility out of GameLoop into a new FrameLoop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,399 @@
+# Architecture
+
+```mermaid
+flowchart LR
+  %% Voidmesh canvas-focused architecture
+
+  user(("User input<br/>pointer • touch • wheel<br/>drop • paste • keyboard"))
+
+  subgraph UI["React shell — light canvas-facing UI"]
+    app["App providers<br/>CanvasProvider wraps canvas feature"]
+    infinite["InfiniteCanvas component<br/>DOM canvas + container<br/>event wiring"]
+    knobs["Shader knobs / sidebars<br/>param editing<br/>selection controls"]
+    mediaControls["Media controls<br/>play/pause/seek/scrub"]
+  end
+
+  subgraph Context["Canvas context — React mutation boundary"]
+    commands["CanvasCommands<br/>add/update/delete/select<br/>params • export • undo"]
+    rendererSvc["CanvasRendererService<br/>register renderer<br/>color/debug services"]
+    urlState["URL shader state<br/>nuqs query params"]
+    undo["Undo stack<br/>Command pattern<br/>resource ownership"]
+  end
+
+  subgraph Engine["Engine — GPU-agnostic model + controller"]
+    store[("CanvasStore<br/>entities • viewport • selection<br/>dirty flags • version counters")]
+    loop["GameLoop<br/>input state machines<br/>RAF loop"]
+    controllers["Per-frame controllers<br/>momentum<br/>viewport animation<br/>action layer<br/>drag visual<br/>disintegration timing<br/>perf overlay"]
+    renderState["RenderState snapshot<br/>viewport<br/>sorted entities<br/>selection<br/>dirty flags<br/>overlay state"]
+  end
+
+  subgraph MediaLib["Media + pure libraries"]
+    mediaLoader["Media loading<br/>images • video • GIF • SVG<br/>palette extraction"]
+    math["Canvas math<br/>world/screen transforms<br/>bounds • hit testing<br/>zoom/pan"]
+    serialization["Workspace serialization<br/>.vdmsh import/export"]
+    palette["Palette store/config<br/>presets • custom • extracted"]
+  end
+
+  subgraph Renderer["Renderer — WebGPU pixels"]
+    canvasRenderer["InfiniteCanvasRenderer<br/>WebGPU setup<br/>frame orchestration"]
+    color["GPU color config<br/>Display P3 probe<br/>canvas/intermediate formats"]
+    textures["GPU caches<br/>entity textures<br/>source textures<br/>composition bind groups<br/>TexturePool"]
+    shaderRuntime["EntityShaderRuntime<br/>effect dispatch"]
+    shaders["Shader passes + WGSL<br/>dithering • halftone • ascii<br/>glass • blobs • melt • glitch"]
+    processing["ProcessingPipeline<br/>adjustments<br/>blur<br/>bloom<br/>grain<br/>chromatic aberration"]
+    composite["Composition pass<br/>viewport transform<br/>z-order compositing"]
+    overlays["Canvas overlays<br/>grid<br/>selection rects<br/>entity labels/callouts<br/>action-layer blur<br/>disintegration particles"]
+    gpu[("Browser WebGPU<br/>GPUDevice<br/>GPUCanvasContext")]
+  end
+
+  subgraph Outputs["Outputs"]
+    screen(("Visible canvas"))
+    imageExport["Image export<br/>PNG/JPEG readback"]
+    videoExport["Video/GIF export<br/>main-thread render<br/>worker encode/mux"]
+    upscale["Upscale queue<br/>Anime4K WebGPU compute<br/>new entities"]
+  end
+
+  user --> infinite
+  user --> knobs
+  user --> mediaControls
+
+  app --> infinite
+  app --> commands
+  infinite -->|registerRenderer| rendererSvc
+  infinite -->|pointer/touch/wheel/keyboard| loop
+  infinite -->|drop/paste files| mediaLoader
+
+  knobs -->|param changes| commands
+  mediaControls -->|playback changes| commands
+  commands <--> urlState
+  commands --> undo
+  commands --> store
+  mediaLoader --> commands
+  palette --> commands
+  serialization --> commands
+
+  loop -->|mutates viewport/selection/entities| store
+  loop --> controllers
+  controllers --> store
+  loop -->|per animation frame| renderState
+  store -->|getRenderState| renderState
+
+  rendererSvc --> canvasRenderer
+  loop -->|render| canvasRenderer
+  renderState --> canvasRenderer
+
+  canvasRenderer --> color
+  canvasRenderer --> textures
+  canvasRenderer --> shaderRuntime
+  shaderRuntime --> shaders
+  shaderRuntime --> processing
+  processing --> textures
+  canvasRenderer --> composite
+  canvasRenderer --> overlays
+  composite --> gpu
+  overlays --> gpu
+  gpu --> screen
+
+  commands --> imageExport
+  canvasRenderer --> imageExport
+  canvasRenderer --> videoExport
+  commands --> upscale
+  upscale -->|processed media| commands
+
+  math -. used by .-> loop
+  math -. used by .-> canvasRenderer
+  store -. selective subscriptions .-> knobs
+  store -. viewport/selection snapshots .-> infinite
+
+  classDef react fill:#20263a,stroke:#7aa2f7,color:#dbe7ff
+  classDef context fill:#24331f,stroke:#9ece6a,color:#ecffd8
+  classDef engine fill:#332b1f,stroke:#e0af68,color:#fff0d0
+  classDef renderer fill:#331f2f,stroke:#f7768e,color:#ffe1ea
+  classDef lib fill:#1f3331,stroke:#73daca,color:#dcfffb
+  classDef output fill:#2d2338,stroke:#bb9af7,color:#f2e8ff
+
+  class app,infinite,knobs,mediaControls react
+  class commands,rendererSvc,urlState,undo context
+  class store,loop,controllers,renderState engine
+  class mediaLoader,math,serialization,palette lib
+  class canvasRenderer,color,textures,shaderRuntime,shaders,processing,composite,overlays,gpu renderer
+  class screen,imageExport,videoExport,upscale output
+```
+
+## Core loop
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant IC as InfiniteCanvas
+  participant GL as GameLoop
+  participant CS as CanvasStore
+  participant RS as RenderState
+  participant R as InfiniteCanvasRenderer
+  participant GPU as WebGPU
+
+  IC->>GL: pointer/touch/wheel/keyboard events
+  GL->>CS: mutate viewport, selection, entities
+  GL->>CS: getRenderState() each RAF frame
+  CS-->>RS: viewport + entities + dirty flags + overlay state
+  GL->>R: render(RenderState)
+  R->>R: upload dirty source textures
+  R->>R: run entity shader + processing pipeline
+  R->>R: composite entities with viewport transform
+  R->>R: draw grid/selection/action/disintegration overlays
+  R->>GPU: submit command buffer
+  GPU-->>IC: present canvas frame
+```
+
+# Canvas Architecture Proposal
+
+This document is canvas-focused. It describes the current shape, where separation of
+concerns is strong, where it is blurry, and a simpler target architecture that can be
+reached incrementally.
+
+## Assessment
+
+I would rate the current architecture about **7/10**.
+
+### What is already working
+
+- The biggest boundary is correct: the **engine is GPU-agnostic** and the
+  **renderer owns WebGPU resources**.
+- `types/` sits at the bottom of the dependency graph, which keeps the domain model
+  reusable across React, engine, renderer, serialization, and export code.
+- `CanvasStore` uses selective snapshots and version counters, so high-frequency
+  viewport changes do not have to re-render the whole React tree.
+- `InfiniteCanvasRenderer` consumes a `RenderState` snapshot instead of reaching into
+  React state.
+- GPU resource ownership is mostly centralized in renderer/pipeline classes.
+
+### What is blurry
+
+- `CanvasProvider` is doing several jobs: React context wiring, URL state sync,
+  canvas commands, undo resource ownership, media lifecycle, image export, renderer
+  registration, and error handling.
+- `InfiniteCanvas` is a view component, but it also wires a lot of product behavior:
+  DOM events, keybind behavior, renderer configuration, canvas controls, drop/paste,
+  studio file import/export, and viewport actions.
+- `GameLoop` is both an input controller and a frame scheduler. It handles pointer,
+  touch, wheel, mobile gestures, momentum, video frame tracking, RAF scheduling, and
+  renderer calls.
+- `InfiniteCanvasRenderer` has the right ownership boundary, but internally it is a
+  large facade over WebGPU setup, entity rendering, composition, overlays, caches,
+  export readback, and device-loss handling.
+
+## Would MVC help?
+
+Classic MVC roughly maps like this:
+
+| MVC role   | Voidmesh equivalent                                                      |
+| ---------- | ------------------------------------------------------------------------ |
+| Model      | `CanvasStore`, `ShaderCanvasEntity`, `Viewport`, palettes, shader params |
+| View       | React controls **and** the WebGPU canvas                                 |
+| Controller | `GameLoop`, canvas commands, keybind/drop/paste handlers                 |
+
+That mapping is useful vocabulary, but a strict MVC rewrite would not simplify the
+app much. Voidmesh has two very different views:
+
+1. a React UI that edits state, and
+2. a high-frequency WebGPU viewport that renders state.
+
+The better target is a **model + use-cases + adapters** architecture:
+
+- **Model** stores canonical canvas state.
+- **Use cases** mutate the model through named product actions.
+- **Input adapters** translate DOM events into those actions.
+- **Render adapters** turn snapshots into pixels.
+- **React adapters** expose commands and selector hooks to UI components.
+
+This gives the useful parts of MVC without forcing a real-time rendering app into a
+request/response web-app shape.
+
+## Proposed simpler architecture
+
+```mermaid
+flowchart TD
+  %% Proposed Voidmesh canvas architecture
+
+  subgraph Adapters["Adapters: framework/browser edges"]
+    reactUI["React UI adapters<br/>knobs • sidebars • controls<br/>selector hooks + command hooks"]
+    canvasDOM["Canvas DOM adapter<br/>canvas element<br/>pointer/touch/wheel/keyboard/drop"]
+    urlAdapter["URL adapter<br/>shareable shader params"]
+    storageAdapter["Storage adapter<br/>.vdmsh import/export"]
+  end
+
+  subgraph Application["Application use cases: product actions"]
+    actions["CanvasActions<br/>add media<br/>update params<br/>select/duplicate/delete<br/>viewport commands"]
+    undo["Undo + resource lifecycle<br/>Command pattern<br/>media ownership/revocation"]
+    jobs["Long-running jobs<br/>image/video/GIF export<br/>upscale queue"]
+  end
+
+  subgraph Runtime["Runtime controllers: event/frame orchestration"]
+    inputController["CanvasInputController<br/>pointer/touch/wheel state machines<br/>hit testing<br/>gesture intents"]
+    frameLoop["FrameLoop<br/>RAF scheduling<br/>animated media ticks<br/>per-frame controllers"]
+  end
+
+  subgraph Engine["Engine core: model + canvas rules"]
+    store[(CanvasStore<br/>entities • viewport • selection<br/>preferences • dirty flags<br/>subscription snapshots)]
+    viewportController["ViewportController<br/>pan/zoom/fit animations<br/>momentum physics"]
+    selectionController["SelectionController<br/>hit selection<br/>drag select<br/>multi-select rules"]
+    animationControllers["Animation controllers<br/>action layer<br/>drag visual<br/>disintegration timing<br/>perf overlay"]
+    renderSnapshot["RenderState snapshot<br/>immutable frame input<br/>visible entities<br/>viewport + overlays"]
+  end
+
+  subgraph Rendering["Rendering adapter: pixels only"]
+    rendererPort[["CanvasRendererPort<br/>render(snapshot)<br/>snapshotEntityTexture()<br/>exportImage()"]]
+    webgpuRenderer["WebGPUCanvasRenderer<br/>implements renderer port"]
+    entityPipeline["Entity pipeline<br/>source upload<br/>shader runtime<br/>pre/post processing"]
+    composition["Composition pipeline<br/>z-order<br/>viewport transform<br/>color space"]
+    overlays["Overlay pipeline<br/>grid<br/>selection<br/>labels/callouts<br/>action-layer blur<br/>disintegration particles"]
+    gpu[(Browser WebGPU)]
+  end
+
+  reactUI --> actions
+  canvasDOM --> inputController
+  urlAdapter <--> actions
+  storageAdapter <--> actions
+
+  inputController --> actions
+  inputController --> viewportController
+  inputController --> selectionController
+  viewportController --> store
+  selectionController --> store
+  actions --> undo
+  actions --> store
+  actions --> jobs
+
+  frameLoop --> animationControllers
+  animationControllers --> store
+  frameLoop --> store
+  store --> renderSnapshot
+  frameLoop --> rendererPort
+  renderSnapshot --> rendererPort
+
+  rendererPort --> webgpuRenderer
+  webgpuRenderer --> entityPipeline
+  webgpuRenderer --> composition
+  webgpuRenderer --> overlays
+  entityPipeline --> gpu
+  composition --> gpu
+  overlays --> gpu
+```
+
+## Target responsibility boundaries
+
+| Area                   | Owns                                                             | Should not own                                                   |
+| ---------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| React components       | DOM layout, user-facing controls, calling hooks                  | Canvas business rules, direct `CanvasStore` reads, GPU calls     |
+| React context/hooks    | Exposing selectors and stable command objects                    | Large command implementations, media cleanup rules, render logic |
+| Application actions    | Product use cases and undoable state mutations                   | DOM event details, React state, WebGPU resources                 |
+| `CanvasStore`          | Canonical canvas state, dirty flags, snapshots                   | File loading, URL parsing, GPU cleanup, gesture interpretation   |
+| Input controllers      | Translating pointer/touch/wheel/key events into intents          | Rendering, media loading, React UI state                         |
+| Frame loop             | RAF scheduling and deciding when to render                       | Gesture rules, shader details, command implementations           |
+| Renderer port          | A small interface the engine can call                            | Concrete WebGPU setup details in engine code                     |
+| WebGPU renderer        | GPU resources, texture caches, shader/composition/overlay passes | Canvas state mutation, React subscriptions, product commands     |
+| Media/resource service | Creating/cloning/destroying browser media resources              | Selection rules, rendering passes, UI layout                     |
+
+## Simplified runtime flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant User
+  participant DOM as Canvas DOM adapter
+  participant Input as CanvasInputController
+  participant Actions as CanvasActions
+  participant Store as CanvasStore
+  participant Loop as FrameLoop
+  participant Renderer as CanvasRendererPort
+  participant GPU as WebGPU
+
+  User->>DOM: pointer / touch / wheel / keyboard / drop
+  DOM->>Input: normalized browser event
+  Input->>Actions: product intent<br/>select, drag, pan, zoom, add media
+  Actions->>Store: mutate canonical canvas state
+  Loop->>Store: get render snapshot on RAF/media tick
+  Store-->>Loop: RenderState snapshot
+  Loop->>Renderer: render(snapshot)
+  Renderer->>GPU: encode + submit passes
+```
+
+## Incremental migration plan
+
+This should not be a rewrite. Keep the working public APIs and split one seam at a
+time.
+
+1. **Keep `gameLoop` as a facade, split its internals.**
+   - Extract `CanvasInputController` for pointer/touch/wheel/context-menu/space-pan
+     state machines.
+   - Extract `FrameLoop` for RAF scheduling, animated media ticks, dirty checks, and
+     `renderer.render(snapshot)`.
+   - Existing components can still call `gameLoop.handlePointerDown()` while the
+     facade delegates internally.
+
+2. **Move command bodies out of `CanvasProvider`.**
+   - Create canvas action modules for add/update/delete/duplicate/select/viewport
+     operations.
+   - Keep the provider as composition glue: construct actions, provide contexts,
+     connect URL sync, and handle toasts/errors.
+   - This makes commands testable without React.
+
+3. **Make renderer dependency explicit.**
+   - Define a small `CanvasRendererPort` interface consumed by the frame loop.
+   - `WebGPUCanvasRenderer` implements that port.
+   - The engine should not know about concrete renderer internals beyond the port.
+
+4. **Extract media resource lifecycle.**
+   - Centralize clone/destroy/revoke behavior for images, videos, GIF frames, and SVG
+     bitmaps.
+   - Undo commands should claim ownership through this service instead of keeping
+     cleanup details inside React context.
+
+5. **Keep `InfiniteCanvasRenderer` as a facade, split renderer internals only where it
+   reduces complexity.**
+   - Good internal seams: `EntityRenderPipeline`, `OverlayRenderer`,
+     `GpuResourceCache`, and export/readback service.
+   - Do not leak WebGPU resources outside renderer-owned classes.
+
+## What not to do
+
+- Do not pursue MVC as a goal by itself. The useful goal is smaller ownership
+  boundaries, not terminology.
+- Do not create many new React providers. Prefer plain modules/services behind the
+  existing canvas context.
+- Do not move GPU logic into context or components.
+- Do not replace `CanvasStore` unless a concrete performance or correctness problem
+  appears; its snapshot/version design fits this app well.
+- Do not split shader code just to make files smaller. Split around ownership:
+  source upload, effect processing, composition, overlays, export.
+
+## Target dependency direction
+
+Arrows point from code that imports to code it is allowed to import.
+
+```mermaid
+flowchart LR
+  types["types/"]
+  lib["lib/ pure utilities"]
+  engine["engine/<br/>store + controllers + frame loop"]
+  app["application actions<br/>plain TS use cases"]
+  context["context/<br/>React providers/hooks"]
+  components["components/<br/>React UI"]
+  renderer["renderer/<br/>WebGPU adapter"]
+
+  components --> context
+  context --> app
+  context -. wires concrete renderer .-> renderer
+  app --> engine
+  app --> lib
+  app --> types
+  engine --> lib
+  engine --> types
+  renderer --> lib
+  renderer --> types
+  renderer -. type-only RenderState / RendererPort .-> engine
+```
+
+The key rule: **state changes flow through application actions into `CanvasStore`; pixels
+flow from a `RenderState` snapshot into the renderer.** Keeping those flows separate is
+the main architectural simplification.

--- a/engine/frame-loop.ts
+++ b/engine/frame-loop.ts
@@ -1,0 +1,266 @@
+import type { AnimationScheduler } from "#lib/animation-scheduler.ts";
+import { MediaType, type Bounds, type ShaderCanvasEntity } from "#types/canvas.ts";
+import { canvasStore, type RenderState } from "./canvas-store.ts";
+import type { FrameStats } from "./perf-overlay.ts";
+
+interface VideoFrameTracker {
+  video: HTMLVideoElement;
+  requestId: number | null;
+  dirty: boolean;
+  initialized: boolean;
+  fallbackFrameIndex: number;
+  generation: number;
+}
+
+export interface CanvasRendererPort {
+  readonly isReady: boolean;
+  readonly device: GPUDevice | null;
+  readonly colorConfig: {
+    readonly canvasFormat: GPUTextureFormat;
+    readonly canvasColorSpace: PredefinedColorSpace;
+  };
+  render(state: RenderState): void;
+  getFrameStats(): FrameStats;
+  needsContinuousRenderForEntity(entity: ShaderCanvasEntity): boolean;
+}
+
+interface FrameLoopDeps {
+  scheduler: AnimationScheduler;
+  perf: {
+    setRenderer(
+      device: GPUDevice | null,
+      canvasFormat: GPUTextureFormat | null,
+      canvasColorSpace?: PredefinedColorSpace,
+    ): void;
+    onFrame(debugMode: boolean, timestamp?: number): void;
+    onRender(frameStats: FrameStats, debugMode: boolean): void;
+  };
+}
+
+interface FrameLoopCallbacks {
+  processInput(): void;
+  getDragSelectBounds(): Bounds | null;
+  getMultiSelectBounds(): Bounds | null;
+  isPointerDragging(): boolean;
+  isDragSelectActive(): boolean;
+  onAfterFrame(): void;
+  onRenderError(error: unknown): void;
+}
+
+export class FrameLoop {
+  readonly #deps: FrameLoopDeps;
+  readonly #callbacks: FrameLoopCallbacks;
+  #renderer: CanvasRendererPort | null = null;
+  #running = false;
+  #animationFrameId: number | null = null;
+  #videoFrameTrackers = new Map<string, VideoFrameTracker>();
+  #videoFrameTrackerGeneration = 0;
+  #firstFrameRendered = false;
+  #lastFrameTime: number | null = null;
+
+  constructor(deps: FrameLoopDeps, callbacks: FrameLoopCallbacks) {
+    this.#deps = deps;
+    this.#callbacks = callbacks;
+  }
+
+  setRenderer(renderer: CanvasRendererPort): void {
+    this.#renderer = renderer;
+    this.#deps.perf.setRenderer(
+      renderer.device,
+      renderer.colorConfig.canvasFormat,
+      renderer.colorConfig.canvasColorSpace,
+    );
+    this.#firstFrameRendered = false;
+  }
+
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.#tick();
+  }
+
+  stop(): void {
+    this.#running = false;
+    this.#lastFrameTime = null;
+    this.#clearVideoFrameTrackers();
+    if (this.#animationFrameId !== null) {
+      cancelAnimationFrame(this.#animationFrameId);
+      this.#animationFrameId = null;
+    }
+  }
+
+  #tick = (): void => {
+    if (!this.#running) return;
+
+    // 1. Compute delta time for GIF playback advancement
+    const now = performance.now();
+    const deltaSeconds = this.#lastFrameTime !== null ? (now - this.#lastFrameTime) / 1000 : 0;
+    this.#lastFrameTime = now;
+
+    let hasAnimatedFrameUpdate = false;
+    let hasContinuousShaderRender = false;
+    this.#videoFrameTrackerGeneration++;
+
+    // 2. Advance GIF playback and update video time for all playing animated entities.
+    // Uses entity refs directly — getRenderState() is deferred until after all ticks
+    // so the viewport snapshot reflects this frame's updates, not the previous frame's.
+    for (const entity of canvasStore.getState().entities.values()) {
+      if (entity.mediaSource.type === MediaType.gif && entity.playback?.isPlaying) {
+        canvasStore.advanceGifPlayback(entity.id, deltaSeconds);
+        // Notify playback subscribers for real-time time display updates
+        canvasStore.updateGifPlaybackTime(entity.id, entity.playback.currentTime);
+        if (entity.textureDirty) hasAnimatedFrameUpdate = true;
+      }
+      // Update video playback time continuously
+      if (entity.mediaSource.type === MediaType.video && entity.playback?.isPlaying) {
+        const video = entity.mediaSource.videoElement;
+        canvasStore.updatePlaybackTime(entity.id, video.currentTime);
+        if (this.#consumeVideoFrameUpdate(entity.id, video, entity.mediaSource.fps)) {
+          canvasStore.markEntityTextureDirty(entity.id);
+          hasAnimatedFrameUpdate = true;
+        }
+      }
+      // Check if any shader needs continuous re-rendering (e.g., time-based animation)
+      if (!hasContinuousShaderRender && this.#renderer?.needsContinuousRenderForEntity(entity)) {
+        hasContinuousShaderRender = true;
+      }
+    }
+    this.#cleanupInactiveVideoFrameTrackers();
+
+    // 3. Advance all scheduler-managed animations (viewport, etc.)
+    this.#deps.scheduler.tick(now);
+
+    // 4. Process input (hover detection, drag updates)
+    this.#callbacks.processInput();
+
+    // 5. Snapshot render state AFTER all ticks so the viewport reflects
+    // this frame's animation/momentum/input updates, not the previous frame's.
+    const renderState = canvasStore.getRenderState();
+    this.#deps.perf.onFrame(renderState.debugMode, now);
+
+    // 6. Add selection bounds to render state (managed by game-loop, not store)
+    renderState.dragSelectBounds = this.#callbacks.getDragSelectBounds();
+    renderState.multiSelectBounds = this.#callbacks.getMultiSelectBounds();
+
+    // 7. Determine if we need to render this frame
+    const needsRender =
+      !this.#firstFrameRendered ||
+      renderState.dirty ||
+      hasAnimatedFrameUpdate ||
+      hasContinuousShaderRender ||
+      this.#deps.scheduler.hasActive ||
+      this.#callbacks.isPointerDragging() ||
+      this.#callbacks.isDragSelectActive();
+
+    // 8. Render only when needed (skip idle frames)
+    if (this.#renderer?.isReady && needsRender) {
+      if (renderState.debugMode) performance.mark("studio-render-start");
+      try {
+        this.#renderer.render(renderState);
+        this.#firstFrameRendered = true;
+        if (renderState.debugMode) {
+          performance.mark("studio-render-end");
+          performance.measure("studio-render", "studio-render-start", "studio-render-end");
+        }
+        this.#deps.perf.onRender(this.#renderer.getFrameStats(), renderState.debugMode);
+      } catch (error) {
+        this.#callbacks.onRenderError(error);
+      }
+    }
+
+    // 10. Clear dirty flags
+    canvasStore.clearDirtyFlags();
+
+    // 11. Run frame-end work after the final touch-driven viewport has passed
+    // through this render tick.
+    this.#callbacks.onAfterFrame();
+
+    // 12. Schedule next frame
+    this.#animationFrameId = requestAnimationFrame(this.#tick);
+  };
+
+  #consumeVideoFrameUpdate(entityId: string, video: HTMLVideoElement, fps: number | null): boolean {
+    let tracker = this.#videoFrameTrackers.get(entityId);
+    if (!tracker || tracker.video !== video) {
+      if (tracker) this.#cancelVideoFrameCallback(tracker);
+      tracker = {
+        video,
+        requestId: null,
+        dirty: true,
+        initialized: false,
+        fallbackFrameIndex: this.#getVideoFallbackFrameIndex(video, fps),
+        generation: this.#videoFrameTrackerGeneration,
+      };
+      this.#videoFrameTrackers.set(entityId, tracker);
+    }
+
+    tracker.generation = this.#videoFrameTrackerGeneration;
+
+    if ("requestVideoFrameCallback" in video) {
+      this.#scheduleVideoFrameCallback(entityId, tracker);
+      if (!tracker.initialized) {
+        tracker.initialized = true;
+        tracker.dirty = true;
+      }
+      if (!tracker.dirty) return false;
+      tracker.dirty = false;
+      return true;
+    }
+
+    const frameIndex = this.#getVideoFallbackFrameIndex(video, fps);
+    if (!tracker.initialized) {
+      tracker.initialized = true;
+      tracker.fallbackFrameIndex = frameIndex;
+      return true;
+    }
+    if (frameIndex === tracker.fallbackFrameIndex) return false;
+
+    tracker.fallbackFrameIndex = frameIndex;
+    return true;
+  }
+
+  #scheduleVideoFrameCallback(entityId: string, tracker: VideoFrameTracker): void {
+    if (tracker.requestId !== null) return;
+    if (!("requestVideoFrameCallback" in tracker.video)) return;
+
+    tracker.requestId = tracker.video.requestVideoFrameCallback(() => {
+      tracker.requestId = null;
+      if (this.#videoFrameTrackers.get(entityId) !== tracker) return;
+
+      tracker.dirty = true;
+      if (!tracker.video.paused && !tracker.video.ended) {
+        this.#scheduleVideoFrameCallback(entityId, tracker);
+      }
+    });
+  }
+
+  #getVideoFallbackFrameIndex(video: HTMLVideoElement, fps: number | null): number {
+    const effectiveFps = fps && Number.isFinite(fps) && fps > 0 ? fps : 30;
+    return Math.floor(video.currentTime * effectiveFps + 0.0001);
+  }
+
+  #cleanupInactiveVideoFrameTrackers(): void {
+    for (const [entityId, tracker] of this.#videoFrameTrackers) {
+      if (tracker.generation === this.#videoFrameTrackerGeneration) continue;
+
+      this.#cancelVideoFrameCallback(tracker);
+      this.#videoFrameTrackers.delete(entityId);
+    }
+  }
+
+  #clearVideoFrameTrackers(): void {
+    for (const tracker of this.#videoFrameTrackers.values()) {
+      this.#cancelVideoFrameCallback(tracker);
+    }
+    this.#videoFrameTrackers.clear();
+  }
+
+  #cancelVideoFrameCallback(tracker: VideoFrameTracker): void {
+    if (tracker.requestId === null) return;
+
+    if ("cancelVideoFrameCallback" in tracker.video) {
+      tracker.video.cancelVideoFrameCallback(tracker.requestId);
+    }
+    tracker.requestId = null;
+  }
+}

--- a/engine/game-loop.ts
+++ b/engine/game-loop.ts
@@ -14,7 +14,6 @@ import {
 } from "#lib/canvas-math.ts";
 import { config, type TouchConfig } from "#config";
 import { VelocityTracker } from "#lib/touch-scroll/index.ts";
-import type { InfiniteCanvasRenderer } from "#renderer/canvas-renderer.ts";
 import {
   DragTargetType,
   isAnimatedEntity,
@@ -35,6 +34,7 @@ import { scheduler, type AnimationHandle } from "#lib/animation-scheduler.ts";
 import { haptic } from "#lib/haptic.ts";
 import { OnboardingStepId } from "#lib/onboarding.ts";
 import { completeOnboardingStepFromEvent } from "#lib/onboarding-runtime.ts";
+import { FrameLoop, type CanvasRendererPort } from "./frame-loop.ts";
 import {
   getEntityAlphaGrid,
   isAlphaGridCellOpaque,
@@ -142,32 +142,18 @@ export interface DragSelectState {
   previousSelection: Set<string>;
 }
 
-interface VideoFrameTracker {
-  video: HTMLVideoElement;
-  requestId: number | null;
-  dirty: boolean;
-  initialized: boolean;
-  fallbackFrameIndex: number;
-  generation: number;
-}
-
 export type RenderErrorHandler = (error: unknown) => boolean | void;
+export type { CanvasRendererPort } from "./frame-loop.ts";
 
 export class GameLoop {
   readonly #deps: GameLoopDeps;
   #logger = logger;
-  #renderer: InfiniteCanvasRenderer | null = null;
+  readonly #frameLoop: FrameLoop;
   #onRenderError: RenderErrorHandler | null = null;
   #container: HTMLElement | null = null;
   #containerRect: DOMRect = new DOMRect(0, 0, 0, 0);
   #resizeObserver: ResizeObserver | null = null;
-  #running = false;
-  #animationFrameId: number | null = null;
-  #videoFrameTrackers = new Map<string, VideoFrameTracker>();
-  #videoFrameTrackerGeneration = 0;
   #pendingScrollMomentumVelocity: Point | null = null;
-  #firstFrameRendered = false;
-  #lastFrameTime: number | null = null;
 
   #inputState: InputState = {
     pointerPosition: null,
@@ -251,17 +237,25 @@ export class GameLoop {
   constructor(deps?: Partial<GameLoopDeps>) {
     this.#deps = { ...createDefaultDeps(), ...deps };
     this.#momentum = new MomentumController(this.#deps.scheduler, this.#constructMomentumDeps());
+    this.#frameLoop = new FrameLoop(
+      {
+        scheduler: this.#deps.scheduler,
+        perf: this.#deps.perf,
+      },
+      {
+        processInput: () => this.processInput(),
+        getDragSelectBounds: () => this.getDragSelectBounds(),
+        getMultiSelectBounds: () => this.getMultiSelectBounds(),
+        isPointerDragging: () => this.#inputState.pointerDown && !!this.#dragTarget,
+        isDragSelectActive: () => this.#dragSelect?.isActive === true,
+        onAfterFrame: () => this.#startPendingScrollMomentum(),
+        onRenderError: (error) => this.#handleFrameRenderError(error),
+      },
+    );
   }
 
-  setRenderer(renderer: InfiniteCanvasRenderer): void {
-    this.#renderer = renderer;
-    this.#deps.perf.setRenderer(
-      renderer.device,
-      renderer.colorConfig.canvasFormat,
-      renderer.colorConfig.canvasColorSpace,
-    );
-    // Reset first frame flag when renderer changes
-    this.#firstFrameRendered = false;
+  setRenderer(renderer: CanvasRendererPort): void {
+    this.#frameLoop.setRenderer(renderer);
   }
 
   setRenderErrorHandler(handler: RenderErrorHandler | null): void {
@@ -315,201 +309,21 @@ export class GameLoop {
   }
 
   start(): void {
-    if (this.#running) return;
-    this.#running = true;
-    this.tick();
+    this.#frameLoop.start();
   }
 
   stop(): void {
-    this.#running = false;
-    this.#lastFrameTime = null;
+    this.#frameLoop.stop();
     this.#cancelPendingScrollMomentum();
     this.#cancelLongPressTimer();
     this.#cancelDoubleTapTimer();
-    this.#clearVideoFrameTrackers();
-    if (this.#animationFrameId !== null) {
-      cancelAnimationFrame(this.#animationFrameId);
-      this.#animationFrameId = null;
-    }
   }
 
-  private tick = (): void => {
-    if (!this.#running) return;
-
-    // 1. Compute delta time for GIF playback advancement
-    const now = performance.now();
-    const deltaSeconds = this.#lastFrameTime !== null ? (now - this.#lastFrameTime) / 1000 : 0;
-    this.#lastFrameTime = now;
-
-    let hasAnimatedFrameUpdate = false;
-    let hasContinuousShaderRender = false;
-    this.#videoFrameTrackerGeneration++;
-
-    // 2. Advance GIF playback and update video time for all playing animated entities.
-    // Uses entity refs directly — getRenderState() is deferred until after all ticks
-    // so the viewport snapshot reflects this frame's updates, not the previous frame's.
-    for (const entity of canvasStore.getState().entities.values()) {
-      if (entity.mediaSource.type === MediaType.gif && entity.playback?.isPlaying) {
-        canvasStore.advanceGifPlayback(entity.id, deltaSeconds);
-        // Notify playback subscribers for real-time time display updates
-        canvasStore.updateGifPlaybackTime(entity.id, entity.playback.currentTime);
-        if (entity.textureDirty) hasAnimatedFrameUpdate = true;
-      }
-      // Update video playback time continuously
-      if (entity.mediaSource.type === MediaType.video && entity.playback?.isPlaying) {
-        const video = entity.mediaSource.videoElement;
-        canvasStore.updatePlaybackTime(entity.id, video.currentTime);
-        if (this.#consumeVideoFrameUpdate(entity.id, video, entity.mediaSource.fps)) {
-          canvasStore.markEntityTextureDirty(entity.id);
-          hasAnimatedFrameUpdate = true;
-        }
-      }
-      // Check if any shader needs continuous re-rendering (e.g., time-based animation)
-      if (!hasContinuousShaderRender && this.#renderer?.needsContinuousRenderForEntity(entity)) {
-        hasContinuousShaderRender = true;
-      }
+  #handleFrameRenderError(error: unknown): void {
+    const handled = this.#onRenderError?.(error) === true;
+    if (!handled) {
+      this.#logger.error("[GameLoop] Render failed", error);
     }
-    this.#cleanupInactiveVideoFrameTrackers();
-
-    // 3. Advance all scheduler-managed animations (viewport, etc.)
-    this.#deps.scheduler.tick(now);
-
-    // 4. Process input (hover detection, drag updates)
-    this.processInput();
-
-    // 5. Snapshot render state AFTER all ticks so the viewport reflects
-    // this frame's animation/momentum/input updates, not the previous frame's.
-    const renderState = canvasStore.getRenderState();
-    this.#deps.perf.onFrame(renderState.debugMode, now);
-
-    // 6. Add selection bounds to render state (managed by game-loop, not store)
-    renderState.dragSelectBounds = this.getDragSelectBounds();
-    renderState.multiSelectBounds = this.getMultiSelectBounds();
-
-    // 7. Determine if we need to render this frame
-    const needsRender =
-      !this.#firstFrameRendered ||
-      renderState.dirty ||
-      hasAnimatedFrameUpdate ||
-      hasContinuousShaderRender ||
-      this.#deps.scheduler.hasActive ||
-      (this.#inputState.pointerDown && !!this.#dragTarget) ||
-      this.#dragSelect?.isActive;
-
-    // 8. Render only when needed (skip idle frames)
-    if (this.#renderer?.isReady && needsRender) {
-      if (renderState.debugMode) performance.mark("studio-render-start");
-      try {
-        this.#renderer.render(renderState);
-        this.#firstFrameRendered = true;
-        if (renderState.debugMode) {
-          performance.mark("studio-render-end");
-          performance.measure("studio-render", "studio-render-start", "studio-render-end");
-        }
-        this.#deps.perf.onRender(this.#renderer.getFrameStats(), renderState.debugMode);
-      } catch (error) {
-        const handled = this.#onRenderError?.(error) === true;
-        if (!handled) {
-          this.#logger.error("[GameLoop] Render failed", error);
-        }
-      }
-    }
-
-    // 10. Clear dirty flags
-    canvasStore.clearDirtyFlags();
-
-    // 11. Start queued pan momentum only after the final touch-driven viewport
-    // has passed through this render tick. This prevents the release frame from
-    // combining late touch movement and the first fling delta.
-    this.#startPendingScrollMomentum();
-
-    // 12. Schedule next frame
-    this.#animationFrameId = requestAnimationFrame(this.tick);
-  };
-
-  #consumeVideoFrameUpdate(entityId: string, video: HTMLVideoElement, fps: number | null): boolean {
-    let tracker = this.#videoFrameTrackers.get(entityId);
-    if (!tracker || tracker.video !== video) {
-      if (tracker) this.#cancelVideoFrameCallback(tracker);
-      tracker = {
-        video,
-        requestId: null,
-        dirty: true,
-        initialized: false,
-        fallbackFrameIndex: this.#getVideoFallbackFrameIndex(video, fps),
-        generation: this.#videoFrameTrackerGeneration,
-      };
-      this.#videoFrameTrackers.set(entityId, tracker);
-    }
-
-    tracker.generation = this.#videoFrameTrackerGeneration;
-
-    if ("requestVideoFrameCallback" in video) {
-      this.#scheduleVideoFrameCallback(entityId, tracker);
-      if (!tracker.initialized) {
-        tracker.initialized = true;
-        tracker.dirty = true;
-      }
-      if (!tracker.dirty) return false;
-      tracker.dirty = false;
-      return true;
-    }
-
-    const frameIndex = this.#getVideoFallbackFrameIndex(video, fps);
-    if (!tracker.initialized) {
-      tracker.initialized = true;
-      tracker.fallbackFrameIndex = frameIndex;
-      return true;
-    }
-    if (frameIndex === tracker.fallbackFrameIndex) return false;
-
-    tracker.fallbackFrameIndex = frameIndex;
-    return true;
-  }
-
-  #scheduleVideoFrameCallback(entityId: string, tracker: VideoFrameTracker): void {
-    if (tracker.requestId !== null) return;
-    if (!("requestVideoFrameCallback" in tracker.video)) return;
-
-    tracker.requestId = tracker.video.requestVideoFrameCallback(() => {
-      tracker.requestId = null;
-      if (this.#videoFrameTrackers.get(entityId) !== tracker) return;
-
-      tracker.dirty = true;
-      if (!tracker.video.paused && !tracker.video.ended) {
-        this.#scheduleVideoFrameCallback(entityId, tracker);
-      }
-    });
-  }
-
-  #getVideoFallbackFrameIndex(video: HTMLVideoElement, fps: number | null): number {
-    const effectiveFps = fps && Number.isFinite(fps) && fps > 0 ? fps : 30;
-    return Math.floor(video.currentTime * effectiveFps + 0.0001);
-  }
-
-  #cleanupInactiveVideoFrameTrackers(): void {
-    for (const [entityId, tracker] of this.#videoFrameTrackers) {
-      if (tracker.generation === this.#videoFrameTrackerGeneration) continue;
-
-      this.#cancelVideoFrameCallback(tracker);
-      this.#videoFrameTrackers.delete(entityId);
-    }
-  }
-
-  #clearVideoFrameTrackers(): void {
-    for (const tracker of this.#videoFrameTrackers.values()) {
-      this.#cancelVideoFrameCallback(tracker);
-    }
-    this.#videoFrameTrackers.clear();
-  }
-
-  #cancelVideoFrameCallback(tracker: VideoFrameTracker): void {
-    if (tracker.requestId === null) return;
-
-    if ("cancelVideoFrameCallback" in tracker.video) {
-      tracker.video.cancelVideoFrameCallback(tracker.requestId);
-    }
-    tracker.requestId = null;
   }
 
   /** Stop any active momentum scrolling and zoom momentum (public API for external callers) */

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -11,7 +11,7 @@ export type {
 export { actionLayerController } from "./action-layer-controller.ts";
 
 export { GameLoop, gameLoop, SpacePanMode } from "./game-loop.ts";
-export type { InputState } from "./game-loop.ts";
+export type { CanvasRendererPort, InputState } from "./game-loop.ts";
 
 export { viewportAnimation } from "./viewport-animation.ts";
 export type { ViewportAnimationOptions } from "./viewport-animation.ts";


### PR DESCRIPTION
- Added CanvasRendererPort, so the frame loop depends on a narrow renderer interface instead of InfiniteCanvasRenderer.
- Moved RAF scheduling, animated GIF/video ticking, render-state preparation, renderer calls, perf hooks, render-error forwarding, and video-frame tracking into FrameLoop
- Kept GameLoop as the public facade for existing component call sites.
- GameLoop now owns interaction/input state and delegates frame ticking to FrameLoop.
- Exported CanvasRendererPort from the engine barrel at engine/index.ts