### PR TITLE
Extract viewport lens pass

### DIFF
--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -25,22 +25,10 @@ import { EntityLabelPass } from "./entity-label-pass.ts";
 import { TexturePool } from "./texture-pool.ts";
 import { resolveWlurOverlayRuntimeConfig, type WlurOverlayConfig } from "./wlur-overlay.ts";
 import actionLayerBlitShaderSource from "./action-layer-blit.wgsl?raw";
-import viewportLensDistortionShaderSource from "./viewport-lens-distortion.wgsl?raw";
 import type { ImageExportOptions } from "./export-formats.ts";
+import { ViewportLensPass, type ViewportLensDistortionConfig } from "./viewport-lens-pass.ts";
 
-export interface ViewportLensDistortionConfig {
-  enabled: boolean;
-  strength: number;
-  radius: number;
-  falloff: number;
-  dispersion: number;
-  scale: number;
-  reflectionIntensity: number;
-  reflectionFocus: number;
-  occlusion: number;
-  vignetteLight: number;
-  vignetteDark: number;
-}
+export type { ViewportLensDistortionConfig } from "./viewport-lens-pass.ts";
 
 export class InfiniteCanvasRenderer {
   readonly canvas: HTMLCanvasElement;
@@ -102,25 +90,7 @@ export class InfiniteCanvasRenderer {
 
   #presentCopyPass: CopyPass | null = null;
 
-  // Full-canvas viewport lens distortion pass. Runs before mobile wlur overlay so
-  // the progressive bottom blur itself stays screen-space rather than warped.
-  #viewportLensConfig: ViewportLensDistortionConfig = getViewportLensDistortionConfig(
-    CanvasLensing.off,
-  );
-  #viewportLensDarkTheme = false;
-  #viewportLensPipeline: GPURenderPipeline | null = null;
-  #viewportLensBindGroupLayout: GPUBindGroupLayout | null = null;
-  #viewportLensUniformBuffer: GPUBuffer | null = null;
-  #viewportLensSampler: GPUSampler | null = null;
-  #viewportLensUniformData = new ArrayBuffer(48);
-  #viewportLensFloatView = new Float32Array(this.#viewportLensUniformData);
-  #viewportLensTexture: {
-    width: number;
-    height: number;
-    texture: GPUTexture;
-    view: GPUTextureView;
-    bindGroup: GPUBindGroup;
-  } | null = null;
+  #viewportLensPass: ViewportLensPass | null = null;
 
   // Wlur progressive full-canvas overlay
   #wlurPass: WlurPass | null = null;
@@ -257,7 +227,11 @@ export class InfiniteCanvasRenderer {
 
     this.#selectionRectPass = new SelectionRectPass(this.#device, this.#canvasFormat);
     this.#createActionLayerBlitPipeline();
-    this.#createViewportLensPipeline();
+    this.#viewportLensPass = new ViewportLensPass({
+      device: this.#device,
+      format: this.#canvasFormat,
+      initialConfig: getViewportLensDistortionConfig(CanvasLensing.off),
+    });
     this.#presentCopyPass = new CopyPass(this.#device, this.#canvasFormat);
     this.#wlurPass = new WlurPass({
       device: this.#device,
@@ -439,167 +413,6 @@ export class InfiniteCanvasRenderer {
       params.tint?.amount ?? "",
       params.tint?.curve?.join(",") ?? "",
     ].join("|");
-  }
-
-  #destroyViewportLensTexture(): void {
-    this.#viewportLensTexture?.texture.destroy();
-    this.#viewportLensTexture = null;
-  }
-
-  #shouldApplyViewportLensDistortion(): boolean {
-    const lens = this.#viewportLensConfig;
-    return (
-      lens.enabled &&
-      (lens.strength > 0.001 || lens.dispersion > 0.001) &&
-      this.#viewportLensPipeline !== null &&
-      this.#viewportLensBindGroupLayout !== null &&
-      this.#viewportLensUniformBuffer !== null &&
-      this.#viewportLensSampler !== null
-    );
-  }
-
-  #getOrCreateViewportLensTexture(
-    width: number,
-    height: number,
-  ): { texture: GPUTexture; view: GPUTextureView } | null {
-    const cached = this.#viewportLensTexture;
-    if (cached && cached.width === width && cached.height === height) {
-      return cached;
-    }
-
-    if (
-      !this.#device ||
-      !this.#viewportLensBindGroupLayout ||
-      !this.#viewportLensUniformBuffer ||
-      !this.#viewportLensSampler
-    ) {
-      return null;
-    }
-
-    this.#destroyViewportLensTexture();
-    const texture = this.#device.createTexture({
-      label: `Viewport lens input (${width}x${height})`,
-      size: [width, height],
-      format: this.#canvasFormat,
-      usage:
-        GPUTextureUsage.TEXTURE_BINDING |
-        GPUTextureUsage.RENDER_ATTACHMENT |
-        GPUTextureUsage.COPY_SRC,
-    });
-    const view = texture.createView();
-    const bindGroup = this.#device.createBindGroup({
-      label: "Viewport lens distortion bind group",
-      layout: this.#viewportLensBindGroupLayout,
-      entries: [
-        { binding: 0, resource: view },
-        { binding: 1, resource: this.#viewportLensSampler },
-        { binding: 2, resource: { buffer: this.#viewportLensUniformBuffer } },
-      ],
-    });
-    this.#viewportLensTexture = { width, height, texture, view, bindGroup };
-    return this.#viewportLensTexture;
-  }
-
-  #createViewportLensPipeline(): void {
-    if (!this.#device) return;
-
-    const shaderModule = this.#device.createShaderModule({
-      label: "Viewport lens distortion shader",
-      code: viewportLensDistortionShaderSource,
-    });
-
-    this.#viewportLensBindGroupLayout = this.#device.createBindGroupLayout({
-      label: "Viewport lens distortion bind group layout",
-      entries: [
-        { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
-        { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
-        { binding: 2, visibility: GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } },
-      ],
-    });
-
-    this.#viewportLensUniformBuffer = this.#device.createBuffer({
-      label: "Viewport lens distortion uniforms",
-      size: this.#viewportLensUniformData.byteLength,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
-
-    this.#viewportLensSampler = this.#device.createSampler({
-      label: "Viewport lens distortion sampler",
-      magFilter: "linear",
-      minFilter: "linear",
-      addressModeU: "clamp-to-edge",
-      addressModeV: "clamp-to-edge",
-    });
-
-    const pipelineLayout = this.#device.createPipelineLayout({
-      label: "Viewport lens distortion pipeline layout",
-      bindGroupLayouts: [this.#viewportLensBindGroupLayout],
-    });
-
-    this.#viewportLensPipeline = this.#device.createRenderPipeline({
-      label: "Viewport lens distortion pipeline",
-      layout: pipelineLayout,
-      vertex: { module: shaderModule, entryPoint: "vs_main" },
-      fragment: {
-        module: shaderModule,
-        entryPoint: "fs_main",
-        targets: [{ format: this.#canvasFormat }],
-      },
-      primitive: { topology: "triangle-list" },
-    });
-  }
-
-  #encodeViewportLensDistortion(
-    encoder: GPUCommandEncoder,
-    targetView: GPUTextureView,
-    width: number,
-    height: number,
-  ): boolean {
-    if (!this.#shouldApplyViewportLensDistortion()) {
-      return false;
-    }
-
-    const lens = this.#viewportLensConfig;
-    const lensTexture = this.#getOrCreateViewportLensTexture(width, height);
-    if (!lensTexture || !this.#viewportLensUniformBuffer || !this.#viewportLensPipeline) {
-      return false;
-    }
-
-    const v = this.#viewportLensFloatView;
-    v[0] = width;
-    v[1] = height;
-    v[2] = lens.strength;
-    v[3] = lens.radius;
-    v[4] = lens.falloff;
-    v[5] = lens.dispersion;
-    v[6] = lens.scale;
-    v[7] = lens.reflectionIntensity;
-    v[8] = lens.reflectionFocus;
-    v[9] = lens.occlusion;
-    v[10] = this.#viewportLensDarkTheme ? lens.vignetteDark : lens.vignetteLight;
-    v[11] = 0;
-    this.#device!.queue.writeBuffer(
-      this.#viewportLensUniformBuffer,
-      0,
-      this.#viewportLensUniformData,
-    );
-
-    const pass = encoder.beginRenderPass({
-      label: "Viewport lens distortion pass",
-      colorAttachments: [
-        {
-          view: targetView,
-          loadOp: "clear",
-          storeOp: "store",
-          clearValue: { r: 0, g: 0, b: 0, a: 0 },
-        },
-      ],
-    });
-    pass.setPipeline(this.#viewportLensPipeline);
-    pass.setBindGroup(0, this.#viewportLensTexture!.bindGroup);
-    pass.draw(3);
-    pass.end();
-    return true;
   }
 
   #createActionLayerBlitPipeline(): void {
@@ -853,9 +666,7 @@ export class InfiniteCanvasRenderer {
       return;
     }
     const targetView = texture.createView();
-    const viewportLensTarget = this.#shouldApplyViewportLensDistortion()
-      ? this.#getOrCreateViewportLensTexture(width, height)
-      : null;
+    const viewportLensTarget = this.#viewportLensPass?.getTarget(width, height) ?? null;
     const sceneTargetTexture = viewportLensTarget?.texture ?? texture;
     const sceneTargetView = viewportLensTarget?.view ?? targetView;
 
@@ -1029,7 +840,7 @@ export class InfiniteCanvasRenderer {
 
     markPhaseStart("viewport-lens-distortion");
     const lensApplied = viewportLensTarget
-      ? this.#encodeViewportLensDistortion(encoder, targetView, width, height)
+      ? this.#viewportLensPass!.encode(encoder, targetView, width, height)
       : false;
     markPhaseEnd("viewport-lens-distortion");
 
@@ -1160,18 +971,18 @@ export class InfiniteCanvasRenderer {
   }
 
   setViewportLensDistortion(config: ViewportLensDistortionConfig): void {
-    this.#viewportLensConfig = { ...config };
+    this.#viewportLensPass?.setConfig(config);
     this.#invalidateWlurOverlayCache();
   }
 
   setViewportLensColorScheme(isDark: boolean): void {
-    if (this.#viewportLensDarkTheme === isDark) return;
-    this.#viewportLensDarkTheme = isDark;
-    this.#invalidateWlurOverlayCache();
+    if (this.#viewportLensPass?.setColorScheme(isDark)) {
+      this.#invalidateWlurOverlayCache();
+    }
   }
 
   get viewPortLensConfig(): ViewportLensDistortionConfig {
-    return this.#viewportLensConfig;
+    return this.#viewportLensPass?.config ?? getViewportLensDistortionConfig(CanvasLensing.off);
   }
 
   /**
@@ -1420,12 +1231,8 @@ export class InfiniteCanvasRenderer {
     this.#destroyWlurOverlayTextures();
     this.#invalidateWlurOverlayCache();
 
-    this.#destroyViewportLensTexture();
-    this.#viewportLensUniformBuffer?.destroy();
-    this.#viewportLensPipeline = null;
-    this.#viewportLensBindGroupLayout = null;
-    this.#viewportLensUniformBuffer = null;
-    this.#viewportLensSampler = null;
+    this.#viewportLensPass?.destroy();
+    this.#viewportLensPass = null;
 
     // Destroy export service
     this.#exportService = null;

--- a/renderer/viewport-lens-pass.ts
+++ b/renderer/viewport-lens-pass.ts
@@ -1,0 +1,204 @@
+import viewportLensDistortionShaderSource from "./viewport-lens-distortion.wgsl?raw";
+
+export interface ViewportLensDistortionConfig {
+  enabled: boolean;
+  strength: number;
+  radius: number;
+  falloff: number;
+  dispersion: number;
+  scale: number;
+  reflectionIntensity: number;
+  reflectionFocus: number;
+  occlusion: number;
+  vignetteLight: number;
+  vignetteDark: number;
+}
+
+export interface ViewportLensTarget {
+  texture: GPUTexture;
+  view: GPUTextureView;
+}
+
+interface ViewportLensPassOptions {
+  device: GPUDevice;
+  format: GPUTextureFormat;
+  initialConfig: ViewportLensDistortionConfig;
+}
+
+const UNIFORM_BUFFER_SIZE_BYTES = 48;
+
+export class ViewportLensPass {
+  readonly #device: GPUDevice;
+  readonly #format: GPUTextureFormat;
+  readonly #pipeline: GPURenderPipeline;
+  readonly #bindGroupLayout: GPUBindGroupLayout;
+  readonly #uniformBuffer: GPUBuffer;
+  readonly #sampler: GPUSampler;
+  readonly #uniformData = new ArrayBuffer(UNIFORM_BUFFER_SIZE_BYTES);
+  readonly #floatView = new Float32Array(this.#uniformData);
+
+  #config: ViewportLensDistortionConfig;
+  #darkTheme = false;
+  #texture: {
+    width: number;
+    height: number;
+    texture: GPUTexture;
+    view: GPUTextureView;
+    bindGroup: GPUBindGroup;
+  } | null = null;
+
+  constructor(options: ViewportLensPassOptions) {
+    this.#device = options.device;
+    this.#format = options.format;
+    this.#config = { ...options.initialConfig };
+
+    const shaderModule = this.#device.createShaderModule({
+      label: "Viewport lens distortion shader",
+      code: viewportLensDistortionShaderSource,
+    });
+
+    this.#bindGroupLayout = this.#device.createBindGroupLayout({
+      label: "Viewport lens distortion bind group layout",
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } },
+      ],
+    });
+
+    this.#uniformBuffer = this.#device.createBuffer({
+      label: "Viewport lens distortion uniforms",
+      size: this.#uniformData.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    this.#sampler = this.#device.createSampler({
+      label: "Viewport lens distortion sampler",
+      magFilter: "linear",
+      minFilter: "linear",
+      addressModeU: "clamp-to-edge",
+      addressModeV: "clamp-to-edge",
+    });
+
+    const pipelineLayout = this.#device.createPipelineLayout({
+      label: "Viewport lens distortion pipeline layout",
+      bindGroupLayouts: [this.#bindGroupLayout],
+    });
+
+    this.#pipeline = this.#device.createRenderPipeline({
+      label: "Viewport lens distortion pipeline",
+      layout: pipelineLayout,
+      vertex: { module: shaderModule, entryPoint: "vs_main" },
+      fragment: {
+        module: shaderModule,
+        entryPoint: "fs_main",
+        targets: [{ format: this.#format }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+  }
+
+  get config(): ViewportLensDistortionConfig {
+    return this.#config;
+  }
+
+  setConfig(config: ViewportLensDistortionConfig): void {
+    this.#config = { ...config };
+  }
+
+  setColorScheme(isDark: boolean): boolean {
+    if (this.#darkTheme === isDark) return false;
+    this.#darkTheme = isDark;
+    return true;
+  }
+
+  getTarget(width: number, height: number): ViewportLensTarget | null {
+    if (!this.#shouldApply()) return null;
+
+    const cached = this.#texture;
+    if (cached && cached.width === width && cached.height === height) {
+      return cached;
+    }
+
+    this.#destroyTexture();
+    const texture = this.#device.createTexture({
+      label: `Viewport lens input (${width}x${height})`,
+      size: [width, height],
+      format: this.#format,
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.COPY_SRC,
+    });
+    const view = texture.createView();
+    const bindGroup = this.#device.createBindGroup({
+      label: "Viewport lens distortion bind group",
+      layout: this.#bindGroupLayout,
+      entries: [
+        { binding: 0, resource: view },
+        { binding: 1, resource: this.#sampler },
+        { binding: 2, resource: { buffer: this.#uniformBuffer } },
+      ],
+    });
+    this.#texture = { width, height, texture, view, bindGroup };
+    return this.#texture;
+  }
+
+  encode(
+    encoder: GPUCommandEncoder,
+    targetView: GPUTextureView,
+    width: number,
+    height: number,
+  ): boolean {
+    const lensTexture = this.getTarget(width, height);
+    if (!lensTexture || !this.#texture) return false;
+
+    const lens = this.#config;
+    const v = this.#floatView;
+    v[0] = width;
+    v[1] = height;
+    v[2] = lens.strength;
+    v[3] = lens.radius;
+    v[4] = lens.falloff;
+    v[5] = lens.dispersion;
+    v[6] = lens.scale;
+    v[7] = lens.reflectionIntensity;
+    v[8] = lens.reflectionFocus;
+    v[9] = lens.occlusion;
+    v[10] = this.#darkTheme ? lens.vignetteDark : lens.vignetteLight;
+    v[11] = 0;
+    this.#device.queue.writeBuffer(this.#uniformBuffer, 0, this.#uniformData);
+
+    const pass = encoder.beginRenderPass({
+      label: "Viewport lens distortion pass",
+      colorAttachments: [
+        {
+          view: targetView,
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+        },
+      ],
+    });
+    pass.setPipeline(this.#pipeline);
+    pass.setBindGroup(0, this.#texture.bindGroup);
+    pass.draw(3);
+    pass.end();
+    return true;
+  }
+
+  destroy(): void {
+    this.#destroyTexture();
+    this.#uniformBuffer.destroy();
+  }
+
+  #shouldApply(): boolean {
+    const lens = this.#config;
+    return lens.enabled && (lens.strength > 0.001 || lens.dispersion > 0.001);
+  }
+
+  #destroyTexture(): void {
+    this.#texture?.texture.destroy();
+    this.#texture = null;
+  }
+}


### PR DESCRIPTION
## Summary
- move viewport lens pipeline, uniforms, sampler, cached target texture, and encode logic into ViewportLensPass
- keep InfiniteCanvasRenderer facade methods for lens config/color scheme and re-export the config type for existing consumers
- preserve render target routing so scene rendering uses the lens intermediate only when the lens is active, before WLUR overlay handling

## Validation
- ./node_modules/.bin/oxfmt --check renderer/canvas-renderer.ts renderer/viewport-lens-pass.ts
- bun run lint:all
- bun run test
- Oracle behavior review: no blockers