### PR TITLE
Extract WLUR overlay pass

### DIFF
--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -1,6 +1,5 @@
 import { config, getViewportLensDistortionConfig, type GridConfig } from "#config";
 import { logger } from "#lib/client.logger.ts";
-import { WlurPass } from "#wlur";
 import { setGpuContext } from "./gpu-color-space.ts";
 import { type RenderState, actionLayerController, entityDragVisual } from "#engine";
 import {
@@ -12,21 +11,21 @@ import {
 import type { ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
 import { CanvasLensing } from "#types/enums.ts";
 import { ActionLayerBlurPass } from "./action-layer-blur-pass.ts";
+import { CanvasCalloutPass } from "./canvas-callout-pass.ts";
 import { CompositionPass, type CompositionDrawItem } from "./composition-pass.ts";
-import { CopyPass } from "./copy-pass.ts";
 import { DisintegrationPass } from "./disintegration-pass.ts";
+import { EntityLabelPass } from "./entity-label-pass.ts";
 import { EntityTexturePipeline, type EntityCompositionSource } from "./entity-texture-pipeline.ts";
 import { ExportService } from "./export-service.ts";
 import { ExternalTextureCopyPass } from "./external-texture-copy-pass.ts";
+import type { ImageExportOptions } from "./export-formats.ts";
 import { detectGpuColorConfig, type GpuColorConfig } from "./gpu-color-space.ts";
 import { GridPass } from "./grid-pass.ts";
 import { SelectionRectPass } from "./selection-rect-pass.ts";
-import { CanvasCalloutPass } from "./canvas-callout-pass.ts";
-import { EntityLabelPass } from "./entity-label-pass.ts";
 import { TexturePool } from "./texture-pool.ts";
-import { resolveWlurOverlayRuntimeConfig, type WlurOverlayConfig } from "./wlur-overlay.ts";
-import type { ImageExportOptions } from "./export-formats.ts";
 import { ViewportLensPass, type ViewportLensDistortionConfig } from "./viewport-lens-pass.ts";
+import type { WlurOverlayConfig } from "./wlur-overlay.ts";
+import { WlurOverlayPass } from "./wlur-overlay-pass.ts";
 
 export type { ViewportLensDistortionConfig } from "./viewport-lens-pass.ts";
 
@@ -72,22 +71,9 @@ export class InfiniteCanvasRenderer {
 
   #selectionRectPass: SelectionRectPass | null = null;
 
-  #presentCopyPass: CopyPass | null = null;
-
   #viewportLensPass: ViewportLensPass | null = null;
 
-  // Wlur progressive full-canvas overlay
-  #wlurPass: WlurPass | null = null;
-  #wlurOverlayConfig: WlurOverlayConfig | null = null;
-  #wlurOverlayTextures: {
-    width: number;
-    height: number;
-    input: GPUTexture;
-    output: GPUTexture;
-  } | null = null;
-  #wlurOverlayCacheValid = false;
-  #wlurOverlayCacheKey = "";
-  #wlurLastQualityKey = "";
+  #wlurOverlayPass: WlurOverlayPass | null = null;
 
   #entityTexturePipeline: EntityTexturePipeline | null = null;
 
@@ -221,13 +207,11 @@ export class InfiniteCanvasRenderer {
       format: this.#canvasFormat,
       initialConfig: getViewportLensDistortionConfig(CanvasLensing.off),
     });
-    this.#presentCopyPass = new CopyPass(this.#device, this.#canvasFormat);
-    this.#wlurPass = new WlurPass({
+    this.#wlurOverlayPass = new WlurOverlayPass({
       device: this.#device,
-      format: this.#colorConfig.intermediateFormat,
-      label: "Wlur",
+      canvasFormat: this.#canvasFormat,
+      intermediateFormat: this.#colorConfig.intermediateFormat,
     });
-    this.#wlurPass.initialize();
 
     // Initialize export service with callbacks into renderer
     this.#exportService = new ExportService(
@@ -286,79 +270,6 @@ export class InfiniteCanvasRenderer {
     const initialRect = this.canvas.getBoundingClientRect();
     this.#cachedCanvasWidth = initialRect.width;
     this.#cachedCanvasHeight = initialRect.height;
-  }
-
-  #invalidateWlurOverlayCache(): void {
-    this.#wlurOverlayCacheValid = false;
-    this.#wlurOverlayCacheKey = "";
-  }
-
-  #destroyWlurOverlayTextures(): void {
-    if (!this.#wlurOverlayTextures) return;
-
-    this.#wlurOverlayTextures.input.destroy();
-    this.#wlurOverlayTextures.output.destroy();
-    this.#wlurOverlayTextures = null;
-  }
-
-  #getOrCreateWlurOverlayTextures(
-    width: number,
-    height: number,
-  ): { input: GPUTexture; output: GPUTexture } {
-    const cached = this.#wlurOverlayTextures;
-    if (cached && cached.width === width && cached.height === height) {
-      return cached;
-    }
-
-    this.#destroyWlurOverlayTextures();
-    this.#invalidateWlurOverlayCache();
-
-    const usage =
-      GPUTextureUsage.TEXTURE_BINDING |
-      GPUTextureUsage.RENDER_ATTACHMENT |
-      GPUTextureUsage.COPY_DST |
-      GPUTextureUsage.COPY_SRC;
-
-    const input = this.#device!.createTexture({
-      label: `Wlur input (${width}x${height})`,
-      size: [width, height],
-      format: this.#colorConfig.intermediateFormat,
-      usage,
-    });
-
-    const output = this.#device!.createTexture({
-      label: `Wlur output (${width}x${height})`,
-      size: [width, height],
-      format: this.#colorConfig.intermediateFormat,
-      usage,
-    });
-
-    this.#wlurOverlayTextures = { width, height, input, output };
-    return this.#wlurOverlayTextures;
-  }
-
-  #buildWlurOverlayCacheKey(
-    width: number,
-    height: number,
-    resolvedConfig: NonNullable<ReturnType<typeof resolveWlurOverlayRuntimeConfig>>,
-  ): string {
-    const { params, quality } = resolvedConfig;
-    return [
-      width,
-      height,
-      quality.kernelSize,
-      quality.resolutionScale,
-      params.radius,
-      params.offset,
-      params.interpolation,
-      params.direction,
-      params.noise,
-      params.curve?.join(",") ?? "",
-      params.mixCurve?.join(",") ?? "",
-      params.tint?.color.join(",") ?? "",
-      params.tint?.amount ?? "",
-      params.tint?.curve?.join(",") ?? "",
-    ].join("|");
   }
 
   #updateViewportUniforms(viewport: Viewport): void {
@@ -670,84 +581,25 @@ export class InfiniteCanvasRenderer {
     markPhaseEnd("viewport-lens-distortion");
 
     // Final pass: WLUR progressive blur overlay (renders on top of everything)
-    const resolvedWlurOverlay = resolveWlurOverlayRuntimeConfig(
-      this.#wlurOverlayConfig,
-      height,
-      dpr,
-    );
-    if (
-      resolvedWlurOverlay &&
-      this.#wlurPass &&
-      this.#entityTexturePipeline &&
-      this.#presentCopyPass
-    ) {
-      const wlurTextures = this.#getOrCreateWlurOverlayTextures(width, height);
-      const wlurCacheKey = this.#buildWlurOverlayCacheKey(width, height, resolvedWlurOverlay);
-      const wlurNeedsUpdate =
-        !resolvedWlurOverlay.cache ||
-        !this.#wlurOverlayCacheValid ||
-        this.#wlurOverlayCacheKey !== wlurCacheKey ||
-        state.dirty ||
-        hasAnimatingContent ||
-        lensApplied ||
-        !!this.#disintegrationPass?.hasOverlays ||
-        blurIntensity > 0.01 ||
-        state.dragSelectBounds !== null;
-
-      const qualityKey = [
-        resolvedWlurOverlay.quality.kernelSize,
-        resolvedWlurOverlay.quality.resolutionScale,
-      ].join("|");
-      if (qualityKey !== this.#wlurLastQualityKey) {
-        this.#wlurPass.updateConfig({ quality: resolvedWlurOverlay.quality });
-        this.#wlurLastQualityKey = qualityKey;
-      }
-
+    if (this.#wlurOverlayPass) {
       markPhaseStart("wlur-overlay");
-      if (wlurNeedsUpdate) {
-        if (this.#canvasFormat === this.#colorConfig.intermediateFormat) {
-          encoder.copyTextureToTexture(
-            { texture },
-            { texture: wlurTextures.input },
-            { width, height },
-          );
-        } else {
-          this.#entityTexturePipeline.passthroughCopyPass.encode(
-            encoder,
-            texture,
-            wlurTextures.input,
-          );
-        }
-
-        this.#wlurPass.encode(
-          encoder,
-          wlurTextures.input,
-          wlurTextures.output,
-          width,
-          height,
-          resolvedWlurOverlay.params,
-        );
-
-        if (resolvedWlurOverlay.cache) {
-          this.#wlurOverlayCacheValid = true;
-          this.#wlurOverlayCacheKey = wlurCacheKey;
-        } else {
-          this.#invalidateWlurOverlayCache();
-        }
-      }
-
-      if (this.#canvasFormat === this.#colorConfig.intermediateFormat) {
-        encoder.copyTextureToTexture(
-          { texture: wlurTextures.output },
-          { texture },
-          { width, height },
-        );
-      } else {
-        this.#presentCopyPass!.encode(encoder, wlurTextures.output, targetView);
-      }
+      this.#wlurOverlayPass.encode({
+        encoder,
+        sourceTexture: texture,
+        targetTexture: texture,
+        targetView,
+        width,
+        height,
+        devicePixelRatio: dpr,
+        contentDirty:
+          state.dirty ||
+          hasAnimatingContent ||
+          lensApplied ||
+          !!this.#disintegrationPass?.hasOverlays ||
+          blurIntensity > 0.01 ||
+          state.dragSelectBounds !== null,
+      });
       markPhaseEnd("wlur-overlay");
-    } else {
-      this.#invalidateWlurOverlayCache();
     }
 
     // Single submission for all passes
@@ -770,7 +622,7 @@ export class InfiniteCanvasRenderer {
    */
   setGridConfig(config: Partial<GridConfig>): void {
     this.#gridPass?.setConfig(config);
-    this.#invalidateWlurOverlayCache();
+    this.#wlurOverlayPass?.invalidateCache();
   }
 
   setActionLayerTint(color: [number, number, number]): void {
@@ -785,24 +637,17 @@ export class InfiniteCanvasRenderer {
   }
 
   setWlurOverlay(config: WlurOverlayConfig | null): void {
-    this.#wlurOverlayConfig = config;
-    this.#wlurLastQualityKey = "";
-    if (config?.quality) {
-      this.#wlurPass?.updateConfig({ quality: config.quality });
-    } else if (!config) {
-      this.#destroyWlurOverlayTextures();
-    }
-    this.#invalidateWlurOverlayCache();
+    this.#wlurOverlayPass?.setConfig(config);
   }
 
   setViewportLensDistortion(config: ViewportLensDistortionConfig): void {
     this.#viewportLensPass?.setConfig(config);
-    this.#invalidateWlurOverlayCache();
+    this.#wlurOverlayPass?.invalidateCache();
   }
 
   setViewportLensColorScheme(isDark: boolean): void {
     if (this.#viewportLensPass?.setColorScheme(isDark)) {
-      this.#invalidateWlurOverlayCache();
+      this.#wlurOverlayPass?.invalidateCache();
     }
   }
 
@@ -1048,13 +893,8 @@ export class InfiniteCanvasRenderer {
     this.#canvasCalloutPass?.destroy();
     this.#canvasCalloutPass = null;
 
-    this.#presentCopyPass = null;
-    this.#wlurPass?.destroy();
-    this.#wlurPass = null;
-    this.#wlurOverlayConfig = null;
-    this.#wlurLastQualityKey = "";
-    this.#destroyWlurOverlayTextures();
-    this.#invalidateWlurOverlayCache();
+    this.#wlurOverlayPass?.destroy();
+    this.#wlurOverlayPass = null;
 
     this.#viewportLensPass?.destroy();
     this.#viewportLensPass = null;

--- a/renderer/wlur-overlay-pass.ts
+++ b/renderer/wlur-overlay-pass.ts
@@ -1,0 +1,212 @@
+import { WlurPass } from "#wlur";
+import { CopyPass } from "./copy-pass.ts";
+import {
+  resolveWlurOverlayRuntimeConfig,
+  type ResolvedWlurOverlayConfig,
+  type WlurOverlayConfig,
+} from "./wlur-overlay.ts";
+
+interface WlurOverlayPassOptions {
+  device: GPUDevice;
+  canvasFormat: GPUTextureFormat;
+  intermediateFormat: GPUTextureFormat;
+}
+
+interface EncodeWlurOverlayOptions {
+  encoder: GPUCommandEncoder;
+  sourceTexture: GPUTexture;
+  targetTexture: GPUTexture;
+  targetView: GPUTextureView;
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+  contentDirty: boolean;
+}
+
+export class WlurOverlayPass {
+  readonly #device: GPUDevice;
+  readonly #canvasFormat: GPUTextureFormat;
+  readonly #intermediateFormat: GPUTextureFormat;
+  readonly #wlurPass: WlurPass;
+  readonly #sourceCopyPass: CopyPass;
+  readonly #presentCopyPass: CopyPass;
+
+  #config: WlurOverlayConfig | null = null;
+  #textures: {
+    width: number;
+    height: number;
+    input: GPUTexture;
+    output: GPUTexture;
+  } | null = null;
+  #cacheValid = false;
+  #cacheKey = "";
+  #lastQualityKey = "";
+
+  constructor(options: WlurOverlayPassOptions) {
+    this.#device = options.device;
+    this.#canvasFormat = options.canvasFormat;
+    this.#intermediateFormat = options.intermediateFormat;
+    this.#sourceCopyPass = new CopyPass(this.#device, this.#intermediateFormat);
+    this.#presentCopyPass = new CopyPass(this.#device, this.#canvasFormat);
+    this.#wlurPass = new WlurPass({
+      device: this.#device,
+      format: this.#intermediateFormat,
+      label: "Wlur",
+    });
+    this.#wlurPass.initialize();
+  }
+
+  setConfig(config: WlurOverlayConfig | null): void {
+    this.#config = config;
+    this.#lastQualityKey = "";
+    if (config?.quality) {
+      this.#wlurPass.updateConfig({ quality: config.quality });
+    } else if (!config) {
+      this.#destroyTextures();
+    }
+    this.invalidateCache();
+  }
+
+  invalidateCache(): void {
+    this.#cacheValid = false;
+    this.#cacheKey = "";
+  }
+
+  encode(options: EncodeWlurOverlayOptions): boolean {
+    const resolvedConfig = resolveWlurOverlayRuntimeConfig(
+      this.#config,
+      options.height,
+      options.devicePixelRatio,
+    );
+    if (!resolvedConfig) {
+      this.invalidateCache();
+      return false;
+    }
+
+    const textures = this.#getOrCreateTextures(options.width, options.height);
+    const cacheKey = this.#buildCacheKey(options.width, options.height, resolvedConfig);
+    const needsUpdate =
+      !resolvedConfig.cache ||
+      !this.#cacheValid ||
+      this.#cacheKey !== cacheKey ||
+      options.contentDirty;
+
+    const qualityKey = [
+      resolvedConfig.quality.kernelSize,
+      resolvedConfig.quality.resolutionScale,
+    ].join("|");
+    if (qualityKey !== this.#lastQualityKey) {
+      this.#wlurPass.updateConfig({ quality: resolvedConfig.quality });
+      this.#lastQualityKey = qualityKey;
+    }
+
+    if (needsUpdate) {
+      if (this.#canvasFormat === this.#intermediateFormat) {
+        options.encoder.copyTextureToTexture(
+          { texture: options.sourceTexture },
+          { texture: textures.input },
+          { width: options.width, height: options.height },
+        );
+      } else {
+        this.#sourceCopyPass.encode(options.encoder, options.sourceTexture, textures.input);
+      }
+
+      this.#wlurPass.encode(
+        options.encoder,
+        textures.input,
+        textures.output,
+        options.width,
+        options.height,
+        resolvedConfig.params,
+      );
+
+      if (resolvedConfig.cache) {
+        this.#cacheValid = true;
+        this.#cacheKey = cacheKey;
+      } else {
+        this.invalidateCache();
+      }
+    }
+
+    if (this.#canvasFormat === this.#intermediateFormat) {
+      options.encoder.copyTextureToTexture(
+        { texture: textures.output },
+        { texture: options.targetTexture },
+        { width: options.width, height: options.height },
+      );
+    } else {
+      this.#presentCopyPass.encode(options.encoder, textures.output, options.targetView);
+    }
+
+    return true;
+  }
+
+  destroy(): void {
+    this.#wlurPass.destroy();
+    this.#config = null;
+    this.#lastQualityKey = "";
+    this.#destroyTextures();
+    this.invalidateCache();
+  }
+
+  #destroyTextures(): void {
+    if (!this.#textures) return;
+
+    this.#textures.input.destroy();
+    this.#textures.output.destroy();
+    this.#textures = null;
+  }
+
+  #getOrCreateTextures(width: number, height: number): { input: GPUTexture; output: GPUTexture } {
+    const cached = this.#textures;
+    if (cached && cached.width === width && cached.height === height) {
+      return cached;
+    }
+
+    this.#destroyTextures();
+    this.invalidateCache();
+
+    const usage =
+      GPUTextureUsage.TEXTURE_BINDING |
+      GPUTextureUsage.RENDER_ATTACHMENT |
+      GPUTextureUsage.COPY_DST |
+      GPUTextureUsage.COPY_SRC;
+
+    const input = this.#device.createTexture({
+      label: `Wlur input (${width}x${height})`,
+      size: [width, height],
+      format: this.#intermediateFormat,
+      usage,
+    });
+
+    const output = this.#device.createTexture({
+      label: `Wlur output (${width}x${height})`,
+      size: [width, height],
+      format: this.#intermediateFormat,
+      usage,
+    });
+
+    this.#textures = { width, height, input, output };
+    return this.#textures;
+  }
+
+  #buildCacheKey(width: number, height: number, resolvedConfig: ResolvedWlurOverlayConfig): string {
+    const { params, quality } = resolvedConfig;
+    return [
+      width,
+      height,
+      quality.kernelSize,
+      quality.resolutionScale,
+      params.radius,
+      params.offset,
+      params.interpolation,
+      params.direction,
+      params.noise,
+      params.curve?.join(",") ?? "",
+      params.mixCurve?.join(",") ?? "",
+      params.tint?.color.join(",") ?? "",
+      params.tint?.amount ?? "",
+      params.tint?.curve?.join(",") ?? "",
+    ].join("|");
+  }
+}


### PR DESCRIPTION
## Summary
- move final full-canvas WLUR overlay ownership into `WlurOverlayPass`
- keep `InfiniteCanvasRenderer` responsible for pass ordering and the single content-dirty signal
- move WLUR config resolution, quality updates, cached textures, cache keys, and canvas/intermediate copy paths into the pass

## Validation
- `./node_modules/.bin/oxfmt --check renderer/canvas-renderer.ts renderer/wlur-overlay-pass.ts`
- `bun run lint:all`
- `bun run test`
- Oracle review: no blockers
