### PR TITLE
Extract entity draw item preparation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,14 +35,16 @@ flowchart LR
   end
 
   subgraph Renderer["Renderer — WebGPU pixels"]
-    canvasRenderer["InfiniteCanvasRenderer<br/>WebGPU setup<br/>frame orchestration"]
+    canvasRenderer["InfiniteCanvasRenderer<br/>facade<br/>frame orchestration"]
     color["GPU color config<br/>Display P3 probe<br/>canvas/intermediate formats"]
-    textures["GPU caches<br/>entity textures<br/>source textures<br/>composition bind groups<br/>TexturePool"]
+    viewportUniforms["ViewportUniforms<br/>shared viewport matrix buffer"]
+    textures["EntityTexturePipeline<br/>source textures<br/>processed textures<br/>TexturePool"]
     shaderRuntime["EntityShaderRuntime<br/>effect dispatch"]
     shaders["Shader passes + WGSL<br/>dithering • halftone • ascii<br/>glass • blobs • melt • glitch"]
     processing["ProcessingPipeline<br/>adjustments<br/>blur<br/>bloom<br/>grain<br/>chromatic aberration"]
     composite["Composition pass<br/>viewport transform<br/>z-order compositing"]
     overlays["Canvas overlays<br/>grid<br/>selection rects<br/>entity labels/callouts<br/>action-layer blur<br/>disintegration particles"]
+    lensAndWlur["Full-canvas effects<br/>viewport lens<br/>WLUR overlay"]
     gpu[("Browser WebGPU<br/>GPUDevice<br/>GPUCanvasContext")]
   end
 
@@ -83,6 +85,7 @@ flowchart LR
   renderState --> canvasRenderer
 
   canvasRenderer --> color
+  canvasRenderer --> viewportUniforms
   canvasRenderer --> textures
   canvasRenderer --> shaderRuntime
   shaderRuntime --> shaders
@@ -90,8 +93,10 @@ flowchart LR
   processing --> textures
   canvasRenderer --> composite
   canvasRenderer --> overlays
+  canvasRenderer --> lensAndWlur
   composite --> gpu
   overlays --> gpu
+  lensAndWlur --> gpu
   gpu --> screen
 
   commands --> imageExport
@@ -116,7 +121,7 @@ flowchart LR
   class commands,rendererSvc,urlState,undo context
   class store,loop,controllers,renderState engine
   class mediaLoader,math,serialization,palette lib
-  class canvasRenderer,color,textures,shaderRuntime,shaders,processing,composite,overlays,gpu renderer
+  class canvasRenderer,color,viewportUniforms,textures,shaderRuntime,shaders,processing,composite,overlays,lensAndWlur,gpu renderer
   class screen,imageExport,videoExport,upscale output
 ```
 
@@ -182,6 +187,43 @@ I would rate the current architecture about **7/10**.
   large facade over WebGPU setup, entity rendering, composition, overlays, caches,
   export readback, and device-loss handling.
 
+## Renderer split status
+
+The renderer split is intentionally incremental. `InfiniteCanvasRenderer` is still the
+public facade, but most heavy GPU ownership has moved into smaller renderer-owned
+classes.
+
+Completed internal seams:
+
+- `EntityTexturePipeline` / `EntityShaderRuntime`: source upload, source/processed
+  texture caching, shader dispatch, and processing pipeline ownership.
+- `CompositionPass`: composition pipelines, per-entity uniform buffers, bind groups,
+  and composition cache invalidation.
+- `EntityDrawItemPreparer`: visible-entity traversal, culling, dirty/animation
+  detection, action-layer bucketing, drag visual scale, and composition draw-item
+  creation.
+- `ViewportUniforms`: shared viewport matrix buffer used by composition, labels,
+  callouts, and disintegration overlays.
+- Overlay/effect passes: `GridPass`, `SelectionRectPass`, `DisintegrationPass`,
+  `ViewportLensPass`, `ActionLayerBlurPass`, and `WlurOverlayPass`.
+- `ExportService`: image/GIF/video export helpers that render through the existing
+  entity shader path.
+
+What remains in `InfiniteCanvasRenderer` should be orchestration or public facade work:
+
+- WebGPU adapter/device/context setup and device-loss hooks.
+- Canvas sizing and swapchain texture acquisition.
+- Per-frame pass order.
+- Render pass encoding and draw submission for main entities, action-layer sharp
+  entities, overlays, viewport lens, and WLUR.
+- Public methods used by context/UI: renderer config, export helpers, entity time
+  helpers, entity texture removal, and disintegration start/cancel.
+- A few snapshot/copy helpers that still belong to later resource-lifecycle seams.
+
+`EntityDrawItemPreparer` now owns the visible-entity loop while the facade still owns
+actual render pass encoding, label drawing, and final overlay ordering. The next likely
+renderer seams are canvas surface/device setup and disintegration snapshot creation.
+
 ## Would MVC help?
 
 Classic MVC roughly maps like this:
@@ -243,10 +285,12 @@ flowchart TD
 
   subgraph Rendering["Rendering adapter: pixels only"]
     rendererPort[["CanvasRendererPort<br/>render(snapshot)<br/>snapshotEntityTexture()<br/>exportImage()"]]
-    webgpuRenderer["WebGPUCanvasRenderer<br/>implements renderer port"]
+    webgpuRenderer["InfiniteCanvasRenderer facade<br/>implements renderer port later<br/>orchestrates frame passes"]
+    viewportResources["Shared GPU resources<br/>ViewportUniforms<br/>canvas/surface state"]
     entityPipeline["Entity pipeline<br/>source upload<br/>shader runtime<br/>pre/post processing"]
     composition["Composition pipeline<br/>z-order<br/>viewport transform<br/>color space"]
-    overlays["Overlay pipeline<br/>grid<br/>selection<br/>labels/callouts<br/>action-layer blur<br/>disintegration particles"]
+    drawPrep["Entity draw preparation<br/>visibility culling<br/>dirty/animation detection<br/>action-layer bucketing"]
+    overlays["Overlay/effect passes<br/>grid<br/>selection<br/>labels/callouts<br/>action-layer blur<br/>disintegration<br/>viewport lens<br/>WLUR"]
     gpu[(Browser WebGPU)]
   end
 
@@ -272,9 +316,15 @@ flowchart TD
   renderSnapshot --> rendererPort
 
   rendererPort --> webgpuRenderer
+  webgpuRenderer --> viewportResources
+  webgpuRenderer --> drawPrep
   webgpuRenderer --> entityPipeline
   webgpuRenderer --> composition
   webgpuRenderer --> overlays
+  drawPrep --> entityPipeline
+  drawPrep --> composition
+  viewportResources --> composition
+  viewportResources --> overlays
   entityPipeline --> gpu
   composition --> gpu
   overlays --> gpu
@@ -351,8 +401,11 @@ time.
 
 5. **Keep `InfiniteCanvasRenderer` as a facade, split renderer internals only where it
    reduces complexity.**
-   - Good internal seams: `EntityRenderPipeline`, `OverlayRenderer`,
-     `GpuResourceCache`, and export/readback service.
+   - Completed seams include entity texture/shader runtime, composition, viewport
+     uniforms, export/readback, and individual overlay/effect passes.
+   - Next seams should be ownership-based, not file-size-based: canvas surface/device
+     setup, disintegration snapshot creation, then an optional overlay coordinator if
+     pass orchestration still feels noisy.
    - Do not leak WebGPU resources outside renderer-owned classes.
 
 ## What not to do

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -2,13 +2,13 @@ import { config, getViewportLensDistortionConfig, type GridConfig } from "#confi
 import { logger } from "#lib/client.logger.ts";
 import { setGpuContext } from "./gpu-color-space.ts";
 import { type RenderState, actionLayerController, entityDragVisual } from "#engine";
-import { boundsIntersect, getRotatedAABB, getViewportWorldBounds } from "#lib/canvas-math.ts";
 import type { ShaderCanvasEntity } from "#types/canvas.ts";
 import { CanvasLensing } from "#types/enums.ts";
 import { ActionLayerBlurPass } from "./action-layer-blur-pass.ts";
 import { CanvasCalloutPass } from "./canvas-callout-pass.ts";
 import { CompositionPass, type CompositionDrawItem } from "./composition-pass.ts";
 import { DisintegrationPass } from "./disintegration-pass.ts";
+import { EntityDrawItemPreparer } from "./entity-draw-item-preparer.ts";
 import { EntityLabelPass } from "./entity-label-pass.ts";
 import { EntityTexturePipeline, type EntityCompositionSource } from "./entity-texture-pipeline.ts";
 import { ExportService } from "./export-service.ts";
@@ -69,6 +69,7 @@ export class InfiniteCanvasRenderer {
 
   #wlurOverlayPass: WlurOverlayPass | null = null;
 
+  #entityDrawItemPreparer: EntityDrawItemPreparer | null = null;
   #entityTexturePipeline: EntityTexturePipeline | null = null;
 
   // Export service for rendering entities to blobs/bitmaps
@@ -184,6 +185,12 @@ export class InfiniteCanvasRenderer {
       },
     });
     await this.#entityTexturePipeline.initialize();
+    this.#entityDrawItemPreparer = new EntityDrawItemPreparer({
+      texturePipeline: this.#entityTexturePipeline,
+      compositionPass: this.#compositionPass,
+      actionLayer: actionLayerController,
+      dragVisual: entityDragVisual,
+    });
 
     this.#selectionRectPass = new SelectionRectPass(this.#device, this.#canvasFormat);
     this.#actionLayerBlurPass = new ActionLayerBlurPass({
@@ -297,7 +304,8 @@ export class InfiniteCanvasRenderer {
       !this.#context ||
       !this.#gridPass ||
       !this.#compositionPass ||
-      !this.#viewportUniforms
+      !this.#viewportUniforms ||
+      !this.#entityDrawItemPreparer
     ) {
       return;
     }
@@ -321,18 +329,6 @@ export class InfiniteCanvasRenderer {
       );
     };
 
-    // Compute action layer rubber-band offset in world coordinates
-    // Use controller state (not store) — offset continues during dismiss animation
-    let actionLayerOffsetX = 0;
-    let actionLayerOffsetY = 0;
-    const actionLayerControllerActive = actionLayerController.isActive();
-    if (actionLayerControllerActive) {
-      const cssOffset = actionLayerController.getEntityOffset();
-      const dprLocal = window.devicePixelRatio || 1;
-      actionLayerOffsetX = (cssOffset.x * dprLocal) / viewport.zoom;
-      actionLayerOffsetY = (cssOffset.y * dprLocal) / viewport.zoom;
-    }
-
     // Update canvas size if needed (uses cached dimensions from ResizeObserver)
     const dpr = window.devicePixelRatio || 1;
     const width = Math.floor(this.#cachedCanvasWidth * dpr);
@@ -351,9 +347,6 @@ export class InfiniteCanvasRenderer {
 
     this.#viewportUniforms.update(viewport, width, height);
 
-    // Sort entities in-place by z-index (avoid array copying)
-    entities.sort((a, b) => a.zIndex - b.zIndex);
-
     // Entity preprocessing can encode shader passes into this same command buffer.
     // External video textures must be imported, bound, encoded, finished, and submitted
     // inside the current render task.
@@ -363,65 +356,20 @@ export class InfiniteCanvasRenderer {
 
     // Pre-process entities: render to textures and prepare bind groups
     // Uses caching to avoid per-frame allocations
-    const entityDrawItems: CompositionDrawItem[] = [];
-    const actionLayerDrawItems: CompositionDrawItem[] = [];
-    let hasAnimatingContent = false;
     markPhaseStart("entity-prep");
-
-    // Compute viewport world bounds once for culling (with buffer to prevent pop-in)
-    const viewportBounds = getViewportWorldBounds(
+    const preparedEntityDrawItems = this.#entityDrawItemPreparer.prepare({
+      entities,
       viewport,
       width,
       height,
-      config.canvas.cullingBufferFraction,
-    );
-
-    for (const entity of entities) {
-      // Viewport culling: skip all GPU work for entities entirely outside the viewport.
-      // textureDirty is intentionally NOT cleared here — it stays true so the entity
-      // re-renders correctly when it scrolls back into view.
-      const entityAABB = getRotatedAABB(entity.position, entity.size, entity.rotation);
-      if (!boundsIntersect(entityAABB, viewportBounds)) {
-        continue;
-      }
-
-      // Check if texture needs regeneration. Animated media is marked dirty by the
-      // game loop only when the decoded frame changes.
-      const textureWasDirty = !!entity.textureDirty;
-      if (textureWasDirty || this.needsContinuousRenderForEntity(entity)) {
-        hasAnimatingContent = true;
-      }
-
-      const compositionSource = this.renderEntityToTexture(entity, encoder);
-      if (!compositionSource) continue;
-
-      // Clear dirty flag
-      entity.textureDirty = false;
-
-      // Determine if this entity is hovered or selected
-      const isHovered = entity.id === hoveredEntityId;
-      const isSelected = selectedEntityIds.has(entity.id);
-
-      // Action layer entities are drawn AFTER blur (not in main pass) to avoid halo
-      const isActionLayerEntity =
-        actionLayerControllerActive && actionLayerController.hasEntity(entity.id);
-      const drawItem = this.#compositionPass.prepareDrawItem({
-        entity,
-        source: compositionSource,
-        isHovered,
-        isSelected,
-        debugMode,
-        positionOffsetX: isActionLayerEntity ? actionLayerOffsetX : 0,
-        positionOffsetY: isActionLayerEntity ? actionLayerOffsetY : 0,
-        visualScale: entityDragVisual.getScale(entity.id),
-      });
-
-      if (isActionLayerEntity) {
-        actionLayerDrawItems.push(drawItem);
-      } else {
-        entityDrawItems.push(drawItem);
-      }
-    }
+      devicePixelRatio: dpr,
+      encoder,
+      hoveredEntityId,
+      selectedEntityIds,
+      debugMode,
+    });
+    const { entityDrawItems, actionLayerDrawItems } = preparedEntityDrawItems;
+    let hasAnimatingContent = preparedEntityDrawItems.hasAnimatingContent;
     markPhaseEnd("entity-prep");
 
     const texture = this.#context.getCurrentTexture();
@@ -854,6 +802,7 @@ export class InfiniteCanvasRenderer {
   }
 
   destroy(): void {
+    this.#entityDrawItemPreparer = null;
     this.#entityTexturePipeline?.destroy();
     this.#entityTexturePipeline = null;
     this.#compositionPass?.destroy();

--- a/renderer/entity-draw-item-preparer.ts
+++ b/renderer/entity-draw-item-preparer.ts
@@ -1,0 +1,138 @@
+import { config } from "#config";
+import { boundsIntersect, getRotatedAABB, getViewportWorldBounds } from "#lib/canvas-math.ts";
+import type { Point, ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
+import type { CompositionDrawItem, CompositionPass } from "./composition-pass.ts";
+import type { EntityTexturePipeline } from "./entity-texture-pipeline.ts";
+
+interface ActionLayerEntityState {
+  isActive(): boolean;
+  getEntityOffset(): Point;
+  hasEntity(entityId: string): boolean;
+}
+
+interface DragVisualState {
+  getScale(entityId: string): number;
+}
+
+interface EntityDrawItemPreparerOptions {
+  texturePipeline: EntityTexturePipeline;
+  compositionPass: CompositionPass;
+  actionLayer: ActionLayerEntityState;
+  dragVisual: DragVisualState;
+}
+
+interface PrepareEntityDrawItemsOptions {
+  entities: ShaderCanvasEntity[];
+  viewport: Viewport;
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+  encoder: GPUCommandEncoder;
+  hoveredEntityId: string | null;
+  selectedEntityIds: ReadonlySet<string>;
+  debugMode: boolean;
+}
+
+export interface PreparedEntityDrawItems {
+  entityDrawItems: CompositionDrawItem[];
+  actionLayerDrawItems: CompositionDrawItem[];
+  hasAnimatingContent: boolean;
+}
+
+export class EntityDrawItemPreparer {
+  readonly #texturePipeline: EntityTexturePipeline;
+  readonly #compositionPass: CompositionPass;
+  readonly #actionLayer: ActionLayerEntityState;
+  readonly #dragVisual: DragVisualState;
+
+  constructor(options: EntityDrawItemPreparerOptions) {
+    this.#texturePipeline = options.texturePipeline;
+    this.#compositionPass = options.compositionPass;
+    this.#actionLayer = options.actionLayer;
+    this.#dragVisual = options.dragVisual;
+  }
+
+  prepare(options: PrepareEntityDrawItemsOptions): PreparedEntityDrawItems {
+    const {
+      entities,
+      viewport,
+      width,
+      height,
+      devicePixelRatio,
+      encoder,
+      hoveredEntityId,
+      selectedEntityIds,
+      debugMode,
+    } = options;
+
+    entities.sort((a, b) => a.zIndex - b.zIndex);
+
+    const entityDrawItems: CompositionDrawItem[] = [];
+    const actionLayerDrawItems: CompositionDrawItem[] = [];
+    let hasAnimatingContent = false;
+
+    let actionLayerOffsetX = 0;
+    let actionLayerOffsetY = 0;
+    const actionLayerActive = this.#actionLayer.isActive();
+    if (actionLayerActive) {
+      const cssOffset = this.#actionLayer.getEntityOffset();
+      actionLayerOffsetX = (cssOffset.x * devicePixelRatio) / viewport.zoom;
+      actionLayerOffsetY = (cssOffset.y * devicePixelRatio) / viewport.zoom;
+    }
+
+    const viewportBounds = getViewportWorldBounds(
+      viewport,
+      width,
+      height,
+      config.canvas.cullingBufferFraction,
+    );
+
+    for (const entity of entities) {
+      // Viewport culling: skip all GPU work for entities entirely outside the viewport.
+      // textureDirty is intentionally NOT cleared here — it stays true so the entity
+      // re-renders correctly when it scrolls back into view.
+      const entityAABB = getRotatedAABB(entity.position, entity.size, entity.rotation);
+      if (!boundsIntersect(entityAABB, viewportBounds)) {
+        continue;
+      }
+
+      // Check if texture needs regeneration. Animated media is marked dirty by the
+      // game loop only when the decoded frame changes.
+      const textureWasDirty = !!entity.textureDirty;
+      if (textureWasDirty || this.#texturePipeline.needsContinuousRenderForEntity(entity)) {
+        hasAnimatingContent = true;
+      }
+
+      const compositionSource = this.#texturePipeline.renderEntityToTexture(entity, encoder);
+      if (!compositionSource) continue;
+
+      // Clear dirty flag
+      entity.textureDirty = false;
+
+      // Determine if this entity is hovered or selected
+      const isHovered = entity.id === hoveredEntityId;
+      const isSelected = selectedEntityIds.has(entity.id);
+
+      // Action layer entities are drawn AFTER blur (not in main pass) to avoid halo
+      const isActionLayerEntity = actionLayerActive && this.#actionLayer.hasEntity(entity.id);
+      const drawItem = this.#compositionPass.prepareDrawItem({
+        entity,
+        source: compositionSource,
+        isHovered,
+        isSelected,
+        debugMode,
+        positionOffsetX: isActionLayerEntity ? actionLayerOffsetX : 0,
+        positionOffsetY: isActionLayerEntity ? actionLayerOffsetY : 0,
+        visualScale: this.#dragVisual.getScale(entity.id),
+      });
+
+      if (isActionLayerEntity) {
+        actionLayerDrawItems.push(drawItem);
+      } else {
+        entityDrawItems.push(drawItem);
+      }
+    }
+
+    return { entityDrawItems, actionLayerDrawItems, hasAnimatingContent };
+  }
+}


### PR DESCRIPTION
## Summary
- update `ARCHITECTURE.md` with current renderer split progress and the next ownership seams
- add `EntityDrawItemPreparer` for visible-entity traversal, culling, dirty/animation detection, action-layer bucketing, drag visual scale, and `CompositionDrawItem` creation
- keep `InfiniteCanvasRenderer` as the pass-order facade for render pass encoding, labels, overlays, viewport lens, WLUR, and final submission

## Behavior preserved
- entities are still sorted in-place by `zIndex`
- culled entities still keep `textureDirty` until they re-enter the viewport
- entity texture prep still encodes into the frame `GPUCommandEncoder`
- action-layer entities are still bucketed separately and drawn sharp after blur
- frame stats still count only normal entity draw items

## Validation
- consulted Oracle for the extraction plan
- `./node_modules/.bin/oxfmt --check ARCHITECTURE.md renderer/canvas-renderer.ts renderer/entity-draw-item-preparer.ts`
- `bun run lint:all`
- `bun run test`
- Oracle review: no blockers
