### PR TITLE
Move renderer runtime state into RenderState

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,7 @@ flowchart LR
     loop["GameLoop<br/>input state machines<br/>RAF loop"]
     controllers["Per-frame controllers<br/>momentum<br/>viewport animation<br/>action layer<br/>drag visual<br/>disintegration timing<br/>perf overlay"]
     renderState["RenderState snapshot<br/>viewport<br/>sorted entities<br/>selection<br/>dirty flags<br/>overlay state"]
+    renderRuntime["Render-time controller snapshots<br/>action-layer offset/blur<br/>drag visual scale/phase<br/>disintegration overlay progress"]
   end
 
   subgraph MediaLib["Media + pure libraries"]
@@ -78,7 +79,9 @@ flowchart LR
   loop --> controllers
   controllers --> store
   loop -->|per animation frame| renderState
+  loop -->|attach render-time controller data| renderRuntime
   store -->|getRenderState| renderState
+  renderRuntime --> renderState
 
   rendererSvc --> canvasRenderer
   loop -->|render| canvasRenderer
@@ -119,7 +122,7 @@ flowchart LR
 
   class app,infinite,knobs,mediaControls react
   class commands,rendererSvc,urlState,undo context
-  class store,loop,controllers,renderState engine
+  class store,loop,controllers,renderState,renderRuntime engine
   class mediaLoader,math,serialization,palette lib
   class canvasRenderer,color,viewportUniforms,textures,shaderRuntime,shaders,processing,composite,overlays,lensAndWlur,gpu renderer
   class screen,imageExport,videoExport,upscale output
@@ -202,6 +205,9 @@ Completed internal seams:
 - `EntityDrawItemPreparer`: visible-entity traversal, culling, dirty/animation
   detection, action-layer bucketing, drag visual scale, and composition draw-item
   creation.
+- `RenderState` render-time controller snapshots: action-layer offset/blur, drag
+  visual scale/phase, and disintegration overlay progress now cross the engine →
+  renderer boundary as data instead of renderer modules importing engine singletons.
 - `ViewportUniforms`: shared viewport matrix buffer used by composition, labels,
   callouts, and disintegration overlays.
 - Overlay/effect passes: `GridPass`, `SelectionRectPass`, `DisintegrationPass`,
@@ -223,6 +229,9 @@ What remains in `InfiniteCanvasRenderer` should be orchestration or public facad
 `EntityDrawItemPreparer` now owns the visible-entity loop while the facade still owns
 actual render pass encoding, label drawing, and final overlay ordering. The next likely
 renderer seams are canvas surface/device setup and disintegration snapshot creation.
+Renderer internals should keep consuming `RenderState` or explicit renderer-private
+dependencies; importing engine singletons from renderer modules is not part of the
+target architecture.
 
 ## Would MVC help?
 
@@ -273,6 +282,7 @@ flowchart TD
   subgraph Runtime["Runtime controllers: event/frame orchestration"]
     inputController["CanvasInputController<br/>pointer/touch/wheel state machines<br/>hit testing<br/>gesture intents"]
     frameLoop["FrameLoop<br/>RAF scheduling<br/>animated media ticks<br/>per-frame controllers"]
+    renderRuntime["Render-time controller snapshots<br/>action-layer<br/>drag visual<br/>disintegration progress"]
   end
 
   subgraph Engine["Engine core: model + canvas rules"]
@@ -311,7 +321,9 @@ flowchart TD
   frameLoop --> animationControllers
   animationControllers --> store
   frameLoop --> store
+  frameLoop --> renderRuntime
   store --> renderSnapshot
+  renderRuntime --> renderSnapshot
   frameLoop --> rendererPort
   renderSnapshot --> rendererPort
 
@@ -402,7 +414,8 @@ time.
 5. **Keep `InfiniteCanvasRenderer` as a facade, split renderer internals only where it
    reduces complexity.**
    - Completed seams include entity texture/shader runtime, composition, viewport
-     uniforms, export/readback, and individual overlay/effect passes.
+     uniforms, render-time controller snapshots, export/readback, and individual
+     overlay/effect passes.
    - Next seams should be ownership-based, not file-size-based: canvas surface/device
      setup, disintegration snapshot creation, then an optional overlay coordinator if
      pass orchestration still feels noisy.

--- a/__tests__/helpers/game-loop-deps.mock.ts
+++ b/__tests__/helpers/game-loop-deps.mock.ts
@@ -1,5 +1,10 @@
 import { vi } from "vitest";
 import type { AnimationScheduler } from "#lib/animation-scheduler.ts";
+import type {
+  ActionLayerRenderState,
+  DisintegrationRenderState,
+  DragVisualRenderState,
+} from "#engine";
 import type { GameLoopDeps } from "../../engine/game-loop.ts";
 
 /**
@@ -28,6 +33,12 @@ export function createMockGameLoopDeps(scheduler: AnimationScheduler): GameLoopD
       getBlurIntensity: vi.fn<() => number>(() => 0),
       hasEntity: vi.fn<() => boolean>(() => false),
       updateSafeZoneProgress: vi.fn<() => void>(),
+      getRenderState: vi.fn<() => ActionLayerRenderState>(() => ({
+        active: false,
+        entityIds: new Set<string>(),
+        entityOffset: { x: 0, y: 0 },
+        blurIntensity: 0,
+      })),
     },
     dragVisual: {
       startPossibleDrag: vi.fn<() => void>(),
@@ -37,6 +48,15 @@ export function createMockGameLoopDeps(scheduler: AnimationScheduler): GameLoopD
       isDragPhase: vi.fn<() => boolean>(() => false),
       isActive: vi.fn<() => boolean>(() => false),
       getScale: vi.fn<() => number>(() => 1),
+      getRenderState: vi.fn<() => DragVisualRenderState>(() => ({
+        active: false,
+        isDragPhase: false,
+        entityIds: new Set<string>(),
+        scale: 1,
+      })),
+    },
+    disintegration: {
+      getRenderState: vi.fn<(now?: number) => DisintegrationRenderState>(() => ({ overlays: [] })),
     },
     perf: {
       setElement: vi.fn<() => void>(),

--- a/bench/render-bench.ts
+++ b/bench/render-bench.ts
@@ -758,8 +758,19 @@ function createRenderState(entities: ShaderCanvasEntity[], dirty: boolean): Rend
     canvasCallouts: [],
     dragSelectBounds: null,
     multiSelectBounds: null,
-    actionLayerActive: false,
-    actionLayerEntityIds: new Set(),
+    actionLayer: {
+      active: false,
+      entityIds: new Set(),
+      entityOffset: { x: 0, y: 0 },
+      blurIntensity: 0,
+    },
+    dragVisual: {
+      active: false,
+      isDragPhase: false,
+      entityIds: new Set(),
+      scale: 1,
+    },
+    disintegration: { overlays: [] },
   };
 }
 

--- a/context/canvas-context.tsx
+++ b/context/canvas-context.tsx
@@ -658,7 +658,15 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     // Snapshot the entity's rendered texture and start dust animation overlay.
     // This copies the GPU texture so the entity can be removed immediately.
     if (canvasStore.getState().fancyDelete) {
-      rendererRef.current?.startDisintegration(entity);
+      const overlay = disintegrationController.addOverlay(
+        entity.id,
+        entity.position,
+        entity.size,
+        entity.rotation,
+      );
+      if (!rendererRef.current?.startDisintegration(entity, overlay)) {
+        disintegrationController.cancelOverlay(entity.id);
+      }
     }
 
     // Clean up renderer texture cache and remove from store immediately
@@ -670,6 +678,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
       Command.create({
         undo: () => {
           // Cancel any still-playing disintegration overlay
+          disintegrationController.cancelOverlay(entityCopy.id);
           rendererRef.current?.cancelDisintegration(entityCopy.id);
           // Restore the entity with all its resources
           canvasStore.addEntity(entityCopy);
@@ -708,6 +717,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     disintegrationController.clear();
 
     for (const entity of entities) {
+      disintegrationController.cancelOverlay(entity.id);
       rendererRef.current?.cancelDisintegration(entity.id);
       rendererRef.current?.removeEntityTexture(entity.id);
       destroyEntityMediaResources(entity);

--- a/engine/action-layer-controller.ts
+++ b/engine/action-layer-controller.ts
@@ -1,6 +1,6 @@
 import { SpringBack } from "#lib/touch-scroll/spring-back.ts";
 import { config } from "#config";
-import { canvasStore } from "./canvas-store.ts";
+import { canvasStore, type ActionLayerRenderState } from "./canvas-store.ts";
 import type { Point } from "#types/canvas.ts";
 import {
   scheduler as defaultScheduler,
@@ -193,6 +193,15 @@ export class ActionLayerController {
   /** Whether we're in the main active phase (not dismissing/transitioning). */
   isInteractive(): boolean {
     return this.#phase === ActionLayerPhase.active;
+  }
+
+  getRenderState(): ActionLayerRenderState {
+    return {
+      active: this.isActive(),
+      entityIds: new Set(this.#entityIds),
+      entityOffset: this.getEntityOffset(),
+      blurIntensity: this.#blurIntensity,
+    };
   }
 
   /** Transition to entity drag mode. Snap entity and fade blur. */

--- a/engine/canvas-store.ts
+++ b/engine/canvas-store.ts
@@ -133,6 +133,45 @@ export interface SelectedVideoAudioSnapshot {
   version: number;
 }
 
+export interface ActionLayerRenderState {
+  /** Whether the action layer is active or dismiss/transition animation is still visible. */
+  active: boolean;
+  /** Entity IDs to keep sharp and offset while the action layer is rendering. */
+  entityIds: ReadonlySet<string>;
+  /** Rubber-band offset in CSS pixels. */
+  entityOffset: Point;
+  /** Current background blur/dim intensity, 0..1. */
+  blurIntensity: number;
+}
+
+export interface DragVisualRenderState {
+  /** Whether any drag visual animation is active. */
+  active: boolean;
+  /** Whether the active visual is in the dragging phase. */
+  isDragPhase: boolean;
+  /** Entity IDs receiving the shared visual scale. */
+  entityIds: ReadonlySet<string>;
+  /** Shared scale for active drag-visual entities. */
+  scale: number;
+}
+
+export interface DisintegrationRenderOverlay {
+  id: string;
+  startTime: number;
+  dissolveDuration: number;
+  duration: number;
+  seed: number;
+  position: Point;
+  size: { width: number; height: number };
+  rotation: number;
+  progress: number;
+  elapsedSeconds: number;
+}
+
+export interface DisintegrationRenderState {
+  overlays: readonly DisintegrationRenderOverlay[];
+}
+
 export interface RenderState {
   viewport: Viewport;
   entities: ShaderCanvasEntity[];
@@ -145,10 +184,9 @@ export interface RenderState {
   dragSelectBounds: Bounds | null;
   /** Multi-select bounding box in world coordinates (null if < 2 entities selected) */
   multiSelectBounds: Bounds | null;
-  /** Whether the mobile action layer is active (renderer applies blur overlay) */
-  actionLayerActive: boolean;
-  /** Entity IDs to keep sharp when action layer blur is active */
-  actionLayerEntityIds: ReadonlySet<string>;
+  actionLayer: ActionLayerRenderState;
+  dragVisual: DragVisualRenderState;
+  disintegration: DisintegrationRenderState;
 }
 
 export interface ParamResult<T> {
@@ -1000,8 +1038,19 @@ export class CanvasStore extends Store<CanvasState> {
       // dragSelectBounds and multiSelectBounds are set by game-loop after calling this method
       dragSelectBounds: null,
       multiSelectBounds: null,
-      actionLayerActive: this.state.actionLayerActive,
-      actionLayerEntityIds: this.state.actionLayerEntityIds,
+      actionLayer: {
+        active: this.state.actionLayerActive,
+        entityIds: this.state.actionLayerEntityIds,
+        entityOffset: { x: 0, y: 0 },
+        blurIntensity: 0,
+      },
+      dragVisual: {
+        active: this.state.entityDragActive,
+        isDragPhase: false,
+        entityIds: new Set(),
+        scale: 1,
+      },
+      disintegration: { overlays: [] },
     };
   }
 

--- a/engine/disintegration-controller.ts
+++ b/engine/disintegration-controller.ts
@@ -1,6 +1,10 @@
 import type { Point } from "#types/canvas.ts";
 import { easings } from "#lib/canvas-math.ts";
-import { canvasStore } from "./canvas-store.ts";
+import {
+  canvasStore,
+  type DisintegrationRenderOverlay,
+  type DisintegrationRenderState,
+} from "./canvas-store.ts";
 import {
   scheduler as defaultScheduler,
   type AnimationScheduler,
@@ -49,11 +53,11 @@ class DisintegrationController {
     position: Point,
     size: { width: number; height: number },
     rotation: number,
-  ): void {
+  ): DisintegrationRenderOverlay {
     const delay = this.#staggerIndex * STAGGER_DELAY_MS;
     this.#staggerIndex++;
 
-    this.#overlays.set(id, {
+    const overlay: DisintegrationOverlay = {
       id,
       startTime: performance.now() + delay,
       dissolveDuration: DISSOLVE_DURATION_MS,
@@ -62,7 +66,8 @@ class DisintegrationController {
       position: { x: position.x, y: position.y },
       size: { width: size.width, height: size.height },
       rotation,
-    });
+    };
+    this.#overlays.set(id, overlay);
 
     canvasStore.setContainerDirty();
 
@@ -72,15 +77,22 @@ class DisintegrationController {
         tag: "disintegration",
         tick: (now) => {
           // Evict completed overlays
+          let removed = false;
           for (const [overlayId, overlay] of this.#overlays) {
             if (now >= overlay.startTime && now - overlay.startTime >= overlay.duration) {
               this.#overlays.delete(overlayId);
+              removed = true;
             }
+          }
+          if (removed) {
+            canvasStore.setContainerDirty();
           }
           return this.#overlays.size > 0;
         },
       });
     }
+
+    return this.#toRenderOverlay(overlay, performance.now());
   }
 
   /** Reset stagger counter. Call before a batch of deletions. */
@@ -94,11 +106,7 @@ class DisintegrationController {
     if (!overlay) return 0;
 
     const now = performance.now();
-    if (now < overlay.startTime) return 0;
-
-    const elapsed = now - overlay.startTime;
-    const t = Math.min(elapsed / overlay.dissolveDuration, 1);
-    return easings.easeOutExpo(t);
+    return this.#getProgressAt(overlay, now);
   }
 
   /** Get a specific overlay by ID. */
@@ -116,9 +124,19 @@ class DisintegrationController {
     return this.#overlays.values();
   }
 
+  getRenderState(now = performance.now()): DisintegrationRenderState {
+    return {
+      overlays: Array.from(this.#overlays.values(), (overlay) =>
+        this.#toRenderOverlay(overlay, now),
+      ),
+    };
+  }
+
   /** Cancel a specific overlay (e.g., on undo). */
   cancelOverlay(id: string): void {
-    this.#overlays.delete(id);
+    if (this.#overlays.delete(id)) {
+      canvasStore.setContainerDirty();
+    }
   }
 
   /** Cancel all active overlays. */
@@ -126,6 +144,29 @@ class DisintegrationController {
     this.#overlays.clear();
     this.#staggerIndex = 0;
     canvasStore.setContainerDirty();
+  }
+
+  #toRenderOverlay(overlay: DisintegrationOverlay, now: number): DisintegrationRenderOverlay {
+    return {
+      id: overlay.id,
+      startTime: overlay.startTime,
+      dissolveDuration: overlay.dissolveDuration,
+      duration: overlay.duration,
+      seed: overlay.seed,
+      position: { x: overlay.position.x, y: overlay.position.y },
+      size: { width: overlay.size.width, height: overlay.size.height },
+      rotation: overlay.rotation,
+      progress: this.#getProgressAt(overlay, now),
+      elapsedSeconds: Math.max(now - overlay.startTime, 0) / 1000,
+    };
+  }
+
+  #getProgressAt(overlay: DisintegrationOverlay, now: number): number {
+    if (now < overlay.startTime) return 0;
+
+    const elapsed = now - overlay.startTime;
+    const t = Math.min(elapsed / overlay.dissolveDuration, 1);
+    return easings.easeOutExpo(t);
   }
 }
 

--- a/engine/entity-drag-visual.ts
+++ b/engine/entity-drag-visual.ts
@@ -1,5 +1,5 @@
 import { config, type DragVisualSpringConfig } from "#config";
-import { canvasStore } from "./canvas-store.ts";
+import { canvasStore, type DragVisualRenderState } from "./canvas-store.ts";
 import {
   scheduler as defaultScheduler,
   type AnimationScheduler,
@@ -54,6 +54,15 @@ class EntityDragVisualController {
   /** Whether we're specifically in the dragging phase (for label state). */
   isDragPhase(): boolean {
     return this.#phase === DragVisualPhase.dragging;
+  }
+
+  getRenderState(): DragVisualRenderState {
+    return {
+      active: this.isActive(),
+      isDragPhase: this.isDragPhase(),
+      entityIds: new Set(this.#entityIds),
+      scale: this.#currentScale,
+    };
   }
 
   /**

--- a/engine/frame-loop.ts
+++ b/engine/frame-loop.ts
@@ -1,6 +1,12 @@
 import type { AnimationScheduler } from "#lib/animation-scheduler.ts";
 import { MediaType, type Bounds, type ShaderCanvasEntity } from "#types/canvas.ts";
-import { canvasStore, type RenderState } from "./canvas-store.ts";
+import {
+  canvasStore,
+  type ActionLayerRenderState,
+  type DisintegrationRenderState,
+  type DragVisualRenderState,
+  type RenderState,
+} from "./canvas-store.ts";
 import type { FrameStats } from "./perf-overlay.ts";
 
 interface VideoFrameTracker {
@@ -41,6 +47,9 @@ interface FrameLoopCallbacks {
   processInput(): void;
   getDragSelectBounds(): Bounds | null;
   getMultiSelectBounds(): Bounds | null;
+  getActionLayerRenderState(): ActionLayerRenderState;
+  getDragVisualRenderState(): DragVisualRenderState;
+  getDisintegrationRenderState(now: number): DisintegrationRenderState;
   isPointerDragging(): boolean;
   isDragSelectActive(): boolean;
   onAfterFrame(): void;
@@ -141,6 +150,9 @@ export class FrameLoop {
     // 6. Add selection bounds to render state (managed by game-loop, not store)
     renderState.dragSelectBounds = this.#callbacks.getDragSelectBounds();
     renderState.multiSelectBounds = this.#callbacks.getMultiSelectBounds();
+    renderState.actionLayer = this.#callbacks.getActionLayerRenderState();
+    renderState.dragVisual = this.#callbacks.getDragVisualRenderState();
+    renderState.disintegration = this.#callbacks.getDisintegrationRenderState(now);
 
     // 7. Determine if we need to render this frame
     const needsRender =

--- a/engine/game-loop.ts
+++ b/engine/game-loop.ts
@@ -27,6 +27,7 @@ import { createEnum } from "#types/index.ts";
 import { canvasStore, type CanvasState } from "./canvas-store.ts";
 import { entityDragVisual } from "./entity-drag-visual.ts";
 import { actionLayerController } from "./action-layer-controller.ts";
+import { disintegrationController } from "./disintegration-controller.ts";
 import { perfOverlay } from "./perf-overlay.ts";
 import { viewportAnimation } from "./viewport-animation.ts";
 import { MomentumController, type MomentumDeps } from "./momentum-controller.ts";
@@ -50,6 +51,7 @@ function createDefaultDeps() {
     viewportAnimation,
     actionLayer: actionLayerController,
     dragVisual: entityDragVisual,
+    disintegration: disintegrationController,
     perf: perfOverlay,
     haptic,
     analytics,
@@ -246,6 +248,9 @@ export class GameLoop {
         processInput: () => this.processInput(),
         getDragSelectBounds: () => this.getDragSelectBounds(),
         getMultiSelectBounds: () => this.getMultiSelectBounds(),
+        getActionLayerRenderState: () => this.#deps.actionLayer.getRenderState(),
+        getDragVisualRenderState: () => this.#deps.dragVisual.getRenderState(),
+        getDisintegrationRenderState: (now) => this.#deps.disintegration.getRenderState(now),
         isPointerDragging: () => this.#inputState.pointerDown && !!this.#dragTarget,
         isDragSelectActive: () => this.#dragSelect?.isActive === true,
         onAfterFrame: () => this.#startPendingScrollMomentum(),

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -2,6 +2,10 @@ export { CanvasStore, canvasStore } from "./canvas-store.ts";
 export type {
   CanvasState,
   RenderState,
+  ActionLayerRenderState,
+  DragVisualRenderState,
+  DisintegrationRenderOverlay,
+  DisintegrationRenderState,
   ParamResult,
   DragSnapshot,
   ActionLayerSnapshot,

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -1,7 +1,7 @@
 import { config, getViewportLensDistortionConfig, type GridConfig } from "#config";
 import { logger } from "#lib/client.logger.ts";
 import { setGpuContext } from "./gpu-color-space.ts";
-import { type RenderState, actionLayerController, entityDragVisual } from "#engine";
+import type { DisintegrationRenderOverlay, RenderState } from "#engine";
 import type { ShaderCanvasEntity } from "#types/canvas.ts";
 import { CanvasLensing } from "#types/enums.ts";
 import { ActionLayerBlurPass } from "./action-layer-blur-pass.ts";
@@ -188,8 +188,6 @@ export class InfiniteCanvasRenderer {
     this.#entityDrawItemPreparer = new EntityDrawItemPreparer({
       texturePipeline: this.#entityTexturePipeline,
       compositionPass: this.#compositionPass,
-      actionLayer: actionLayerController,
-      dragVisual: entityDragVisual,
     });
 
     this.#selectionRectPass = new SelectionRectPass(this.#device, this.#canvasFormat);
@@ -366,6 +364,8 @@ export class InfiniteCanvasRenderer {
       encoder,
       hoveredEntityId,
       selectedEntityIds,
+      actionLayer: state.actionLayer,
+      dragVisual: state.dragVisual,
       debugMode,
     });
     const { entityDrawItems, actionLayerDrawItems } = preparedEntityDrawItems;
@@ -392,7 +392,7 @@ export class InfiniteCanvasRenderer {
     markPhaseStart("entity-pass");
 
     // Update label animation state once per frame
-    this.#entityLabelPass?.beginFrame(viewport, width, height);
+    this.#entityLabelPass?.beginFrame(viewport, width, height, state.dragVisual.isDragPhase);
     const selectedEntityCount = selectedEntityIds.size;
     const entityPass = encoder.beginRenderPass({
       label: "Entity composition pass",
@@ -415,7 +415,7 @@ export class InfiniteCanvasRenderer {
 
     // Pass 2a: Action layer blur overlay
     // Blur+dim everything, then re-render selected entities sharp on top
-    const blurIntensity = actionLayerController.getBlurIntensity();
+    const blurIntensity = state.actionLayer.blurIntensity;
     if (
       blurIntensity > 0.01 &&
       this.#canvasFormat === this.#colorConfig.intermediateFormat &&
@@ -480,7 +480,12 @@ export class InfiniteCanvasRenderer {
     }
 
     // Pass 2b: Render disintegration overlays (on top of entities)
-    this.#disintegrationPass?.encode(encoder, sceneTargetView, frameDt);
+    this.#disintegrationPass?.encode(
+      encoder,
+      sceneTargetView,
+      frameDt,
+      state.disintegration.overlays,
+    );
 
     // Pass 3: Render all selection rectangles (drag-select and multi-select bounds)
     if ((state.dragSelectBounds || state.multiSelectBounds) && this.#selectionRectPass) {
@@ -662,13 +667,14 @@ export class InfiniteCanvasRenderer {
     return snapshotTexture;
   }
 
-  startDisintegration(entity: ShaderCanvasEntity): void {
-    if (!this.#device || !this.#disintegrationPass) return;
+  startDisintegration(entity: ShaderCanvasEntity, overlay: DisintegrationRenderOverlay): boolean {
+    if (!this.#device || !this.#disintegrationPass) return false;
 
     const snapshotTexture = this.#createDisintegrationSnapshot(entity);
-    if (!snapshotTexture) return;
+    if (!snapshotTexture) return false;
 
-    this.#disintegrationPass.start(entity, snapshotTexture);
+    this.#disintegrationPass.start(entity, snapshotTexture, overlay);
+    return true;
   }
 
   /**

--- a/renderer/disintegration-particles.ts
+++ b/renderer/disintegration-particles.ts
@@ -1,7 +1,4 @@
-import {
-  PARTICLE_LIFETIME_MS,
-  type DisintegrationOverlay,
-} from "../engine/disintegration-controller.ts";
+import type { DisintegrationRenderOverlay } from "#engine";
 import spawnShaderSource from "./disintegration-spawn.wgsl?raw";
 import updateShaderSource from "./disintegration-update.wgsl?raw";
 import renderShaderSource from "./disintegration-render.wgsl?raw";
@@ -171,7 +168,7 @@ export class DisintegrationParticleSystem {
     });
   }
 
-  spawn(id: string, snapshotTexture: GPUTexture, overlay: DisintegrationOverlay): void {
+  spawn(id: string, snapshotTexture: GPUTexture, overlay: DisintegrationRenderOverlay): void {
     if (
       !this.#spawnPipeline ||
       !this.#spawnBindGroupLayout ||
@@ -198,7 +195,7 @@ export class DisintegrationParticleSystem {
     const cosR = Math.cos(rotRad);
     const sinR = Math.sin(rotRad);
     const dissolveSec = overlay.dissolveDuration / 1000;
-    const particleLifetimeSec = PARTICLE_LIFETIME_MS / 1000;
+    const particleLifetimeSec = Math.max(overlay.duration - overlay.dissolveDuration, 0) / 1000;
 
     // Particle size scales with entity size
     const maxDim = Math.max(overlay.size.width, overlay.size.height);

--- a/renderer/disintegration-pass.ts
+++ b/renderer/disintegration-pass.ts
@@ -1,5 +1,5 @@
 import { config } from "#config";
-import { disintegrationController } from "#engine";
+import type { DisintegrationRenderOverlay } from "#engine";
 import type { ShaderCanvasEntity } from "#types/canvas.ts";
 import { CompositionPass } from "./composition-pass.ts";
 import { DisintegrationParticleSystem } from "./disintegration-particles.ts";
@@ -42,7 +42,11 @@ export class DisintegrationPass {
     await this.#particleSystem.initialize(this.#canvasFormat, this.#viewportUniformBuffer);
   }
 
-  start(entity: ShaderCanvasEntity, snapshotTexture: GPUTexture): void {
+  start(
+    entity: ShaderCanvasEntity,
+    snapshotTexture: GPUTexture,
+    overlay: DisintegrationRenderOverlay,
+  ): void {
     const textureView = snapshotTexture.createView();
     const uniformBuffer = this.#device.createBuffer({
       label: `Disintegration uniform ${entity.id}`,
@@ -63,29 +67,28 @@ export class DisintegrationPass {
       bindGroup,
     });
 
-    // Register with the animation controller.
-    disintegrationController.addOverlay(entity.id, entity.position, entity.size, entity.rotation);
-
     // Spawn particles from the snapshot texture.
-    const overlayData = disintegrationController.getOverlay(entity.id);
-    if (overlayData) {
-      this.#particleSystem.spawn(entity.id, snapshotTexture, overlayData);
-    }
+    this.#particleSystem.spawn(entity.id, snapshotTexture, overlay);
   }
 
   cancel(id: string): void {
-    disintegrationController.cancelOverlay(id);
     this.#cleanupOverlay(id);
   }
 
-  encode(encoder: GPUCommandEncoder, targetView: GPUTextureView, dt: number): void {
-    if (this.#overlays.size === 0) return;
+  encode(
+    encoder: GPUCommandEncoder,
+    targetView: GPUTextureView,
+    dt: number,
+    overlays: readonly DisintegrationRenderOverlay[],
+  ): void {
+    if (this.#overlays.size === 0 && overlays.length === 0) return;
 
     // Clean up GPU resources for overlays whose animations have completed.
-    // The controller removes them from its map when tick() finds them finished.
+    // The engine snapshot omits overlays once their animation has completed.
+    const liveIds = new Set(overlays.map((overlay) => overlay.id));
     const completedIds: string[] = [];
     for (const id of this.#overlays.keys()) {
-      if (!disintegrationController.hasOverlay(id)) {
+      if (!liveIds.has(id)) {
         completedIds.push(id);
       }
     }
@@ -94,21 +97,18 @@ export class DisintegrationPass {
     }
 
     // Render active overlays.
-    const now = performance.now();
-    for (const overlay of disintegrationController.getOverlays()) {
+    for (const overlay of overlays) {
       const gpu = this.#overlays.get(overlay.id);
       if (!gpu) continue;
-      if (now < overlay.startTime) continue;
-
-      const progress = disintegrationController.getProgress(overlay.id);
+      if (overlay.elapsedSeconds <= 0) continue;
 
       // Render dissolve front only while dissolve is still in progress (< 1.0).
-      if (progress > 0 && progress < 1) {
+      if (overlay.progress > 0 && overlay.progress < 1) {
         this.#compositionPass.writeDisintegrationUniforms(gpu.uniformBuffer, {
           position: overlay.position,
           size: overlay.size,
           rotation: overlay.rotation,
-          progress,
+          progress: overlay.progress,
           seed: overlay.seed,
         });
 
@@ -128,8 +128,7 @@ export class DisintegrationPass {
       }
 
       // Update + render particles (compute pass must precede render pass).
-      const elapsed = Math.max(now - overlay.startTime, 0) / 1000;
-      this.#particleSystem.update(overlay.id, elapsed, dt, encoder);
+      this.#particleSystem.update(overlay.id, overlay.elapsedSeconds, dt, encoder);
       this.#particleSystem.render(overlay.id, encoder, targetView);
     }
   }

--- a/renderer/entity-draw-item-preparer.ts
+++ b/renderer/entity-draw-item-preparer.ts
@@ -1,24 +1,13 @@
 import { config } from "#config";
+import type { ActionLayerRenderState, DragVisualRenderState } from "#engine";
 import { boundsIntersect, getRotatedAABB, getViewportWorldBounds } from "#lib/canvas-math.ts";
-import type { Point, ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
+import type { ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
 import type { CompositionDrawItem, CompositionPass } from "./composition-pass.ts";
 import type { EntityTexturePipeline } from "./entity-texture-pipeline.ts";
-
-interface ActionLayerEntityState {
-  isActive(): boolean;
-  getEntityOffset(): Point;
-  hasEntity(entityId: string): boolean;
-}
-
-interface DragVisualState {
-  getScale(entityId: string): number;
-}
 
 interface EntityDrawItemPreparerOptions {
   texturePipeline: EntityTexturePipeline;
   compositionPass: CompositionPass;
-  actionLayer: ActionLayerEntityState;
-  dragVisual: DragVisualState;
 }
 
 interface PrepareEntityDrawItemsOptions {
@@ -30,6 +19,8 @@ interface PrepareEntityDrawItemsOptions {
   encoder: GPUCommandEncoder;
   hoveredEntityId: string | null;
   selectedEntityIds: ReadonlySet<string>;
+  actionLayer: ActionLayerRenderState;
+  dragVisual: DragVisualRenderState;
   debugMode: boolean;
 }
 
@@ -42,14 +33,10 @@ export interface PreparedEntityDrawItems {
 export class EntityDrawItemPreparer {
   readonly #texturePipeline: EntityTexturePipeline;
   readonly #compositionPass: CompositionPass;
-  readonly #actionLayer: ActionLayerEntityState;
-  readonly #dragVisual: DragVisualState;
 
   constructor(options: EntityDrawItemPreparerOptions) {
     this.#texturePipeline = options.texturePipeline;
     this.#compositionPass = options.compositionPass;
-    this.#actionLayer = options.actionLayer;
-    this.#dragVisual = options.dragVisual;
   }
 
   prepare(options: PrepareEntityDrawItemsOptions): PreparedEntityDrawItems {
@@ -62,6 +49,8 @@ export class EntityDrawItemPreparer {
       encoder,
       hoveredEntityId,
       selectedEntityIds,
+      actionLayer,
+      dragVisual,
       debugMode,
     } = options;
 
@@ -73,9 +62,9 @@ export class EntityDrawItemPreparer {
 
     let actionLayerOffsetX = 0;
     let actionLayerOffsetY = 0;
-    const actionLayerActive = this.#actionLayer.isActive();
+    const actionLayerActive = actionLayer.active;
     if (actionLayerActive) {
-      const cssOffset = this.#actionLayer.getEntityOffset();
+      const cssOffset = actionLayer.entityOffset;
       actionLayerOffsetX = (cssOffset.x * devicePixelRatio) / viewport.zoom;
       actionLayerOffsetY = (cssOffset.y * devicePixelRatio) / viewport.zoom;
     }
@@ -114,7 +103,7 @@ export class EntityDrawItemPreparer {
       const isSelected = selectedEntityIds.has(entity.id);
 
       // Action layer entities are drawn AFTER blur (not in main pass) to avoid halo
-      const isActionLayerEntity = actionLayerActive && this.#actionLayer.hasEntity(entity.id);
+      const isActionLayerEntity = actionLayerActive && actionLayer.entityIds.has(entity.id);
       const drawItem = this.#compositionPass.prepareDrawItem({
         entity,
         source: compositionSource,
@@ -123,7 +112,8 @@ export class EntityDrawItemPreparer {
         debugMode,
         positionOffsetX: isActionLayerEntity ? actionLayerOffsetX : 0,
         positionOffsetY: isActionLayerEntity ? actionLayerOffsetY : 0,
-        visualScale: this.#dragVisual.getScale(entity.id),
+        visualScale:
+          dragVisual.active && dragVisual.entityIds.has(entity.id) ? dragVisual.scale : 1,
       });
 
       if (isActionLayerEntity) {

--- a/renderer/entity-label-pass.ts
+++ b/renderer/entity-label-pass.ts
@@ -1,4 +1,3 @@
-import { entityDragVisual } from "#engine";
 import { scheduler, type AnimationHandle } from "#lib/animation-scheduler.ts";
 import { getCssVarValue, resolveCssColor, resolveCssVarColor } from "#lib/css.ts";
 import type { ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
@@ -192,13 +191,18 @@ export class EntityLabelPass {
    * Update shared animation state for the current frame.
    * Call once per frame before any drawLabel() calls.
    */
-  beginFrame(viewport: Viewport, canvasWidth: number, _canvasHeight: number): void {
+  beginFrame(
+    viewport: Viewport,
+    canvasWidth: number,
+    _canvasHeight: number,
+    isDragPhase: boolean,
+  ): void {
     if (!this.#pipeline) return;
 
     this.#dpr = devicePixelRatio || 1;
     this.#isMobile = canvasWidth / this.#dpr < MOBILE_BREAKPOINT;
     this.#viewport = viewport;
-    this.#syncDragAnimation();
+    this.#syncDragAnimation(isDragPhase);
     this.#isAnimating = this.#dragAnimHandle?.isActive ?? false;
   }
 
@@ -262,8 +266,8 @@ export class EntityLabelPass {
     }
   }
 
-  #syncDragAnimation(): void {
-    const nextTarget = entityDragVisual.isDragPhase() ? 1 : 0;
+  #syncDragAnimation(isDragPhase: boolean): void {
+    const nextTarget = isDragPhase ? 1 : 0;
     if (nextTarget === this.#dragAnimTarget) return;
 
     this.#dragAnimTarget = nextTarget;


### PR DESCRIPTION
## Summary
- move action-layer, drag visual, and disintegration render-time data into `RenderState`
- have `FrameLoop` attach controller snapshots after scheduler/input ticks, before `renderer.render(state)`
- remove renderer value imports of engine singletons; renderer modules now consume `RenderState` data/type-only engine imports
- move disintegration overlay registration/cancel ownership out of `DisintegrationPass` and into the context/engine boundary
- update `ARCHITECTURE.md` to make the RenderState boundary explicit

## Behavior notes
- action-layer offset/blur and sharp-entity bucketing now come from `state.actionLayer`
- drag visual scale and label drag-icon phase now come from `state.dragVisual`
- disintegration progress/elapsed timing now comes from `state.disintegration.overlays`
- disintegration controller marks the canvas dirty when overlays complete/cancel so renderer receives an empty snapshot and cleans GPU resources
- if renderer snapshot creation fails, context cancels the just-created engine overlay immediately

## Validation
- `./node_modules/.bin/oxfmt --check ARCHITECTURE.md __tests__/helpers/game-loop-deps.mock.ts bench/render-bench.ts context/canvas-context.tsx engine/action-layer-controller.ts engine/canvas-store.ts engine/disintegration-controller.ts engine/entity-drag-visual.ts engine/frame-loop.ts engine/game-loop.ts engine/index.ts renderer/canvas-renderer.ts renderer/disintegration-particles.ts renderer/disintegration-pass.ts renderer/entity-draw-item-preparer.ts renderer/entity-label-pass.ts`
- `bun run lint:all`
- `bun run test`
- Oracle review found one disintegration completion invalidation issue; fixed by dirtying the canvas on overlay completion/cancel
