### PR TITLE
Add canvas debug view with alpha and spatial modes

### DIFF
--- a/__tests__/lib/entity-spatial-index.spec.ts
+++ b/__tests__/lib/entity-spatial-index.spec.ts
@@ -99,4 +99,47 @@ describe("EntitySpatialIndex", () => {
       front,
     ]);
   });
+
+  test("collects visible occupied buckets and entity centers across index levels", () => {
+    const index = new EntitySpatialIndex(16);
+    const smallA = createTestEntity({
+      id: "small-a",
+      position: { x: -15, y: -15 },
+      size: { width: 4, height: 4 },
+    });
+    const smallB = createTestEntity({
+      id: "small-b",
+      position: { x: -12, y: -12 },
+      size: { width: 4, height: 4 },
+    });
+    const large = createTestEntity({
+      id: "large-debug",
+      position: { x: 32, y: 0 },
+      size: { width: 30, height: 10 },
+    });
+    index.upsert(smallA);
+    index.upsert(smallB);
+    index.upsert(large);
+
+    const buckets: Parameters<EntitySpatialIndex["collectDebugGeometry"]>[1] = [];
+    const centers: Parameters<EntitySpatialIndex["collectDebugGeometry"]>[2] = [];
+    index.collectDebugGeometry({ x: -20, y: -20, width: 80, height: 40 }, buckets, centers);
+
+    expect(buckets).toEqual([
+      { cellSize: 16, cellX: -1, cellY: -1 },
+      { cellSize: 32, cellX: 1, cellY: 0 },
+    ]);
+    expect(centers).toEqual([
+      { x: -13, y: -13, cellSize: 16 },
+      { x: -10, y: -10, cellSize: 16 },
+      { x: 47, y: 5, cellSize: 32 },
+    ]);
+
+    smallA.position = { x: 200, y: 200 };
+    index.upsert(smallA);
+    index.remove(smallB.id);
+    index.collectDebugGeometry({ x: -20, y: -20, width: 80, height: 40 }, buckets, centers);
+    expect(buckets).toEqual([{ cellSize: 32, cellX: 1, cellY: 0 }]);
+    expect(centers).toEqual([{ x: 47, y: 5, cellSize: 32 }]);
+  });
 });

--- a/bench/render-bench.ts
+++ b/bench/render-bench.ts
@@ -1262,6 +1262,7 @@ function createRenderState(
     geometryVersion: 0,
     selectedEntityIds: new Set(),
     debugMode: false,
+    debugView: "none",
     dirty,
     canvasCallouts: [],
     dragSelectBounds: null,

--- a/context/canvas-context.tsx
+++ b/context/canvas-context.tsx
@@ -255,7 +255,9 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     "debug",
     parseAsStringEnum(Object.values(DebugType)),
   );
-  const debug = debugType !== null;
+  const isCanvasDebugType =
+    debugType === DebugType.alpha || debugType === DebugType.spatial || debugType === DebugType.all;
+  const debug = debugType !== null && (import.meta.env.DEV || !isCanvasDebugType);
   const [wlurDebugConfig, setWlurDebugConfigState] = useState<WlurOverlayDebugConfig>(() =>
     createDefaultWlurOverlayDebugConfig(),
   );
@@ -276,7 +278,8 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
         .catch(console.error);
     }
     canvasStore.setDebugMode(debug);
-  }, [debugType, debug]);
+    canvasStore.setDebugView(import.meta.env.DEV && isCanvasDebugType ? debugType : "none");
+  }, [debugType, debug, isCanvasDebugType]);
 
   // Hydrate persisted preferences on mount
   useEffect(() => {

--- a/context/use-canvas.ts
+++ b/context/use-canvas.ts
@@ -23,6 +23,12 @@ export const DebugType = createEnum({
   load: "load",
   /** just set debug mode */
   default: "default",
+  /** visualize alpha hit-test occupancy */
+  alpha: "alpha",
+  /** visualize occupied spatial-index buckets */
+  spatial: "spatial",
+  /** visualize both canvas debug grids */
+  all: "all",
 });
 export type DebugType = typeof DebugType.infer;
 

--- a/engine/canvas-store.ts
+++ b/engine/canvas-store.ts
@@ -186,6 +186,7 @@ export interface RenderState {
   geometryVersion: number;
   selectedEntityIds: ReadonlySet<string>;
   debugMode: boolean;
+  debugView: "none" | "alpha" | "spatial" | "all";
   dirty: boolean;
   canvasCallouts: readonly CanvasCallout[];
   /** Drag-select rectangle bounds in world coordinates (null if not active) */
@@ -252,6 +253,7 @@ export class CanvasStore extends Store<CanvasState> {
     geometryVersion: 0,
     selectedEntityIds: new Set<string>(),
     debugMode: false,
+    debugView: "none",
     dirty: false,
     canvasCallouts: [],
     dragSelectBounds: null,
@@ -870,6 +872,10 @@ export class CanvasStore extends Store<CanvasState> {
     this.#logger.setLevel(enabled ? LogLevel.DEBUG : LogLevel.ERROR);
     this.notifySelectionChange();
     this.#logger.debug(`Debug mode set to: ${this.state.debugMode}`);
+  }
+
+  setDebugView(view: RenderState["debugView"]): void {
+    this.#renderState.debugView = view;
   }
 
   // Snap-to-grid toggle

--- a/lib/entity-spatial-index.ts
+++ b/lib/entity-spatial-index.ts
@@ -15,6 +15,18 @@ interface IndexedEntity {
   cellY: number;
 }
 
+export interface SpatialDebugBucket {
+  cellSize: number;
+  cellX: number;
+  cellY: number;
+}
+
+export interface SpatialDebugCenter {
+  x: number;
+  y: number;
+  cellSize: number;
+}
+
 const DEFAULT_CELL_SIZE = 256;
 
 /** Incremental multi-resolution broad-phase index for viewport and point queries. */
@@ -93,6 +105,36 @@ export class EntitySpatialIndex {
     this.#overallBounds.width = 0;
     this.#overallBounds.height = 0;
     this.#overallBoundsDirty = false;
+  }
+
+  /** Collects occupied buckets and indexed centers for development visualization. */
+  collectDebugGeometry(
+    bounds: Bounds,
+    buckets: SpatialDebugBucket[],
+    centers: SpatialDebugCenter[],
+  ): void {
+    buckets.length = 0;
+    centers.length = 0;
+    for (const level of this.#levels.values()) {
+      const minCellX = this.#cellCoordinate(bounds.x, level.cellSize);
+      const minCellY = this.#cellCoordinate(bounds.y, level.cellSize);
+      const maxCellX = this.#cellCoordinate(bounds.x + bounds.width, level.cellSize);
+      const maxCellY = this.#cellCoordinate(bounds.y + bounds.height, level.cellSize);
+      for (const [cellY, row] of level.rows) {
+        if (cellY < minCellY || cellY > maxCellY) continue;
+        for (const [cellX, entries] of row) {
+          if (cellX < minCellX || cellX > maxCellX) continue;
+          buckets.push({ cellSize: level.cellSize, cellX, cellY });
+          for (const entry of entries) {
+            centers.push({
+              x: entry.bounds.x + entry.bounds.width / 2,
+              y: entry.bounds.y + entry.bounds.height / 2,
+              cellSize: level.cellSize,
+            });
+          }
+        }
+      }
+    }
   }
 
   queryBounds(bounds: Bounds, output: ShaderCanvasEntity[]): ShaderCanvasEntity[];

--- a/renderer/canvas-debug-pass.ts
+++ b/renderer/canvas-debug-pass.ts
@@ -1,0 +1,266 @@
+import { config } from "#config";
+import { getViewportWorldBounds } from "#lib/canvas-math.ts";
+import type {
+  EntitySpatialIndex,
+  SpatialDebugBucket,
+  SpatialDebugCenter,
+} from "#lib/entity-spatial-index.ts";
+import { getEntityAlphaGrid } from "#lib/alpha-hit-testing.ts";
+import { logger } from "#lib/client.logger.ts";
+import type { AlphaHitGrid, Bounds, ShaderCanvasEntity, Viewport } from "#types/canvas.ts";
+import shaderSource from "./canvas-debug.wgsl?raw";
+
+export type CanvasDebugView = "none" | "alpha" | "spatial" | "all";
+
+interface AlphaGpuEntry {
+  cells: GPUBuffer;
+}
+
+interface EntityGpuEntry {
+  uniform: GPUBuffer;
+  grid: AlphaHitGrid;
+  bindGroup: GPUBindGroup;
+  seen: boolean;
+}
+
+const ALPHA_UNIFORM_BYTES = 32;
+const SPATIAL_INSTANCE_BYTES = 32;
+
+export class CanvasDebugPass {
+  readonly #device: GPUDevice;
+  readonly #viewportBuffer: GPUBuffer;
+  readonly #alphaLayout: GPUBindGroupLayout;
+  readonly #spatialLayout: GPUBindGroupLayout;
+  readonly #alphaPipeline: GPURenderPipeline;
+  readonly #spatialPipeline: GPURenderPipeline;
+  readonly #gridEntries = new Map<AlphaHitGrid, AlphaGpuEntry>();
+  readonly #entityEntries = new Map<string, EntityGpuEntry>();
+  readonly #buckets: SpatialDebugBucket[] = [];
+  readonly #centers: SpatialDebugCenter[] = [];
+  readonly #bounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
+  readonly #alphaUniformData = new ArrayBuffer(ALPHA_UNIFORM_BYTES);
+  readonly #skippedAlphaEntities = new Set<string>();
+  #spatialBuffer: GPUBuffer;
+  #spatialBindGroup: GPUBindGroup;
+  #spatialCapacity = 256;
+
+  constructor(device: GPUDevice, format: GPUTextureFormat, viewportBuffer: GPUBuffer) {
+    this.#device = device;
+    this.#viewportBuffer = viewportBuffer;
+    const module = device.createShaderModule({ label: "Canvas debug shader", code: shaderSource });
+    this.#alphaLayout = device.createBindGroupLayout({
+      label: "Alpha grid debug layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        {
+          binding: 1,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, buffer: { type: "read-only-storage" } },
+      ],
+    });
+    this.#spatialLayout = device.createBindGroupLayout({
+      label: "Spatial debug layout",
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          buffer: { type: "uniform" },
+        },
+        { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: "read-only-storage" } },
+      ],
+    });
+    const blend: GPUBlendState = {
+      color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
+      alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
+    };
+    this.#alphaPipeline = device.createRenderPipeline({
+      label: "Alpha grid debug pipeline",
+      layout: device.createPipelineLayout({ bindGroupLayouts: [this.#alphaLayout] }),
+      vertex: { module, entryPoint: "vs_alpha" },
+      fragment: { module, entryPoint: "fs_alpha", targets: [{ format, blend }] },
+    });
+    this.#spatialPipeline = device.createRenderPipeline({
+      label: "Spatial debug pipeline",
+      layout: device.createPipelineLayout({
+        bindGroupLayouts: [device.createBindGroupLayout({ entries: [] }), this.#spatialLayout],
+      }),
+      vertex: { module, entryPoint: "vs_spatial" },
+      fragment: { module, entryPoint: "fs_spatial", targets: [{ format, blend }] },
+    });
+    this.#spatialBuffer = this.#createSpatialBuffer(this.#spatialCapacity);
+    this.#spatialBindGroup = this.#createSpatialBindGroup();
+  }
+
+  encode(options: {
+    encoder: GPUCommandEncoder;
+    targetView: GPUTextureView;
+    view: CanvasDebugView;
+    viewport: Viewport;
+    width: number;
+    height: number;
+    entities: readonly ShaderCanvasEntity[];
+    spatialIndex: EntitySpatialIndex;
+  }): void {
+    const alpha = options.view === "alpha" || options.view === "all";
+    const spatial = options.view === "spatial" || options.view === "all";
+    if (!alpha && !spatial) return;
+    const pass = options.encoder.beginRenderPass({
+      label: "Canvas debug pass",
+      colorAttachments: [{ view: options.targetView, loadOp: "load", storeOp: "store" }],
+    });
+    if (alpha) this.#drawAlpha(pass, options.entities);
+    if (spatial) {
+      getViewportWorldBounds(options.viewport, options.width, options.height, 0, this.#bounds);
+      this.#drawSpatial(pass, options.spatialIndex, options.viewport.zoom);
+    }
+    pass.end();
+  }
+
+  destroy(): void {
+    for (const entry of this.#gridEntries.values()) entry.cells.destroy();
+    for (const entry of this.#entityEntries.values()) entry.uniform.destroy();
+    this.#spatialBuffer.destroy();
+    this.#gridEntries.clear();
+    this.#entityEntries.clear();
+  }
+
+  #drawAlpha(pass: GPURenderPassEncoder, entities: readonly ShaderCanvasEntity[]): void {
+    for (const entry of this.#entityEntries.values()) entry.seen = false;
+    pass.setPipeline(this.#alphaPipeline);
+    for (const entity of entities) {
+      const grid = getEntityAlphaGrid(entity);
+      if (!grid) continue;
+      if (grid.cells.length > config.hitTesting.alphaGrid.debugMaxCellsPerEntity) {
+        if (!this.#skippedAlphaEntities.has(entity.id)) {
+          this.#skippedAlphaEntities.add(entity.id);
+          logger.debug(
+            `[canvas-debug] skipped alpha grid for ${entity.id}: ${grid.cells.length} cells`,
+          );
+        }
+        continue;
+      }
+      this.#skippedAlphaEntities.delete(entity.id);
+      const entry = this.#getEntityEntry(entity.id, grid);
+      entry.seen = true;
+      const floats = new Float32Array(this.#alphaUniformData);
+      const uints = new Uint32Array(this.#alphaUniformData);
+      floats[0] = entity.position.x;
+      floats[1] = entity.position.y;
+      floats[2] = entity.size.width;
+      floats[3] = entity.size.height;
+      floats[4] = (entity.rotation * Math.PI) / 180;
+      uints[5] = grid.cols;
+      uints[6] = grid.rows;
+      this.#device.queue.writeBuffer(entry.uniform, 0, this.#alphaUniformData);
+      pass.setBindGroup(0, entry.bindGroup);
+      pass.draw(6);
+    }
+    for (const [id, entry] of this.#entityEntries) {
+      if (entry.seen) continue;
+      entry.uniform.destroy();
+      this.#entityEntries.delete(id);
+    }
+  }
+
+  #getEntityEntry(id: string, grid: AlphaHitGrid): EntityGpuEntry {
+    const current = this.#entityEntries.get(id);
+    if (current?.grid === grid) return current;
+    current?.uniform.destroy();
+    let gridEntry = this.#gridEntries.get(grid);
+    if (!gridEntry) {
+      const values = Uint32Array.from(grid.cells);
+      const cells = this.#device.createBuffer({
+        label: "Alpha grid debug cells",
+        size: Math.max(4, values.byteLength),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      });
+      this.#device.queue.writeBuffer(cells, 0, values);
+      gridEntry = { cells };
+      this.#gridEntries.set(grid, gridEntry);
+    }
+    const uniform = this.#device.createBuffer({
+      label: `Alpha grid debug entity ${id}`,
+      size: ALPHA_UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    const bindGroup = this.#device.createBindGroup({
+      label: `Alpha grid debug bind group ${id}`,
+      layout: this.#alphaLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.#viewportBuffer } },
+        { binding: 1, resource: { buffer: uniform } },
+        { binding: 2, resource: { buffer: gridEntry.cells } },
+      ],
+    });
+    const entry = { uniform, grid, bindGroup, seen: true };
+    this.#entityEntries.set(id, entry);
+    return entry;
+  }
+
+  #drawSpatial(pass: GPURenderPassEncoder, index: EntitySpatialIndex, zoom: number): void {
+    index.collectDebugGeometry(this.#bounds, this.#buckets, this.#centers);
+    const count = this.#buckets.length + this.#centers.length;
+    if (count === 0) return;
+    this.#ensureSpatialCapacity(count);
+    const data = new ArrayBuffer(count * SPATIAL_INSTANCE_BYTES);
+    const floats = new Float32Array(data);
+    const uints = new Uint32Array(data);
+    let cursor = 0;
+    for (const bucket of this.#buckets) {
+      const base = cursor++ * 8;
+      floats[base] = bucket.cellX * bucket.cellSize;
+      floats[base + 1] = bucket.cellY * bucket.cellSize;
+      floats[base + 2] = bucket.cellSize;
+      floats[base + 3] = bucket.cellSize;
+      floats[base + 4] = bucket.cellSize;
+      uints[base + 5] = 0;
+    }
+    for (const center of this.#centers) {
+      const base = cursor++ * 8;
+      const size = 7 / Math.max(zoom, 0.001);
+      floats[base] = center.x - size / 2;
+      floats[base + 1] = center.y - size / 2;
+      floats[base + 2] = size;
+      floats[base + 3] = size;
+      floats[base + 4] = center.cellSize;
+      uints[base + 5] = 1;
+    }
+    this.#device.queue.writeBuffer(this.#spatialBuffer, 0, data);
+    pass.setPipeline(this.#spatialPipeline);
+    pass.setBindGroup(1, this.#spatialBindGroup);
+    pass.draw(6, count);
+  }
+
+  #ensureSpatialCapacity(count: number): void {
+    if (count <= this.#spatialCapacity) return;
+    while (this.#spatialCapacity < count) this.#spatialCapacity *= 2;
+    this.#spatialBuffer.destroy();
+    this.#spatialBuffer = this.#createSpatialBuffer(this.#spatialCapacity);
+    this.#spatialBindGroup = this.#createSpatialBindGroup();
+  }
+
+  #createSpatialBuffer(capacity: number): GPUBuffer {
+    return this.#device.createBuffer({
+      label: "Spatial debug instances",
+      size: capacity * SPATIAL_INSTANCE_BYTES,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+  }
+
+  #createSpatialBindGroup(): GPUBindGroup {
+    return this.#device.createBindGroup({
+      label: "Spatial debug bind group",
+      layout: this.#spatialLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.#viewportBuffer } },
+        { binding: 1, resource: { buffer: this.#spatialBuffer } },
+      ],
+    });
+  }
+}

--- a/renderer/canvas-debug.wgsl
+++ b/renderer/canvas-debug.wgsl
@@ -1,0 +1,119 @@
+struct ViewportUniforms {
+  matrix_row0: vec4f,
+  matrix_row1: vec4f,
+  matrix_row2: vec4f,
+  resolution: vec2f,
+  zoom: f32,
+  _padding: f32,
+}
+
+struct AlphaUniforms {
+  position: vec2f,
+  size: vec2f,
+  rotation: f32,
+  cols: u32,
+  rows: u32,
+  _padding: u32,
+}
+
+struct SpatialInstance {
+  position: vec2f,
+  size: vec2f,
+  level: f32,
+  kind: u32,
+  _padding: vec2u,
+}
+
+@group(0) @binding(0) var<uniform> viewport: ViewportUniforms;
+@group(0) @binding(1) var<uniform> alpha: AlphaUniforms;
+@group(0) @binding(2) var<storage, read> alphaCells: array<u32>;
+
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) uv: vec2f,
+  @location(1) @interpolate(flat) level: f32,
+  @location(2) @interpolate(flat) kind: u32,
+}
+
+fn worldToClip(world: vec2f) -> vec4f {
+  return vec4f(
+    viewport.matrix_row0.x * world.x + viewport.matrix_row1.x * world.y + viewport.matrix_row2.x,
+    viewport.matrix_row0.y * world.x + viewport.matrix_row1.y * world.y + viewport.matrix_row2.y,
+    0.0,
+    1.0,
+  );
+}
+
+fn quadVertex(index: u32) -> vec2f {
+  let vertices = array<vec2f, 6>(
+    vec2f(0.0, 0.0), vec2f(1.0, 0.0), vec2f(0.0, 1.0),
+    vec2f(0.0, 1.0), vec2f(1.0, 0.0), vec2f(1.0, 1.0),
+  );
+  return vertices[index];
+}
+
+@vertex
+fn vs_alpha(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+  let uv = quadVertex(vertexIndex);
+  let local = (uv - 0.5) * alpha.size;
+  let c = cos(alpha.rotation);
+  let s = sin(alpha.rotation);
+  let world = alpha.position + alpha.size * 0.5 + vec2f(local.x * c - local.y * s, local.x * s + local.y * c);
+  var output: VertexOutput;
+  output.position = worldToClip(world);
+  output.uv = uv;
+  output.level = 0.0;
+  output.kind = 0u;
+  return output;
+}
+
+@fragment
+fn fs_alpha(input: VertexOutput) -> @location(0) vec4f {
+  let grid = input.uv * vec2f(f32(alpha.cols), f32(alpha.rows));
+  let cell = min(vec2u(grid), vec2u(alpha.cols - 1u, alpha.rows - 1u));
+  let occupied = alphaCells[cell.y * alpha.cols + cell.x] != 0u;
+  let edge = min(min(fract(grid.x), 1.0 - fract(grid.x)), min(fract(grid.y), 1.0 - fract(grid.y)));
+  let lineWidth = max(fwidth(grid.x), fwidth(grid.y)) * 0.8;
+  let line = 1.0 - smoothstep(lineWidth, lineWidth * 1.5, edge);
+  let fill = select(vec4f(1.0, 0.18, 0.25, 0.12), vec4f(0.1, 0.95, 0.45, 0.14), occupied);
+  return mix(fill, vec4f(1.0, 0.82, 0.12, 0.8), line);
+}
+
+@group(1) @binding(0) var<uniform> spatialViewport: ViewportUniforms;
+@group(1) @binding(1) var<storage, read> spatialInstances: array<SpatialInstance>;
+
+@vertex
+fn vs_spatial(
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32,
+) -> VertexOutput {
+  let instance = spatialInstances[instanceIndex];
+  let uv = quadVertex(vertexIndex);
+  var output: VertexOutput;
+  let world = instance.position + uv * instance.size;
+  output.position = vec4f(
+    spatialViewport.matrix_row0.x * world.x + spatialViewport.matrix_row1.x * world.y + spatialViewport.matrix_row2.x,
+    spatialViewport.matrix_row0.y * world.x + spatialViewport.matrix_row1.y * world.y + spatialViewport.matrix_row2.y,
+    0.0,
+    1.0,
+  );
+  output.uv = uv;
+  output.level = instance.level;
+  output.kind = instance.kind;
+  return output;
+}
+
+@fragment
+fn fs_spatial(input: VertexOutput) -> @location(0) vec4f {
+  let levelColor = 0.5 + 0.5 * sin(vec3f(0.0, 2.1, 4.2) + log2(max(input.level, 1.0)) * 1.7);
+  if (input.kind == 1u) {
+    let d = length(input.uv - 0.5);
+    if (d > 0.5) { discard; }
+    return vec4f(levelColor, 0.95);
+  }
+  let edge = min(min(input.uv.x, 1.0 - input.uv.x), min(input.uv.y, 1.0 - input.uv.y));
+  let lineWidth = 1.5 / max(input.level * spatialViewport.zoom, 1.0);
+  let line = 1.0 - smoothstep(lineWidth, lineWidth * 1.5, edge);
+  if (line < 0.01) { discard; }
+  return vec4f(levelColor, line * 0.8);
+}

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -8,6 +8,7 @@ import { MediaType, type Bounds, type ShaderCanvasEntity, type Viewport } from "
 import { CanvasLensing } from "#types/enums.ts";
 import { ActionLayerBlurPass } from "./action-layer-blur-pass.ts";
 import { CanvasCalloutPass } from "./canvas-callout-pass.ts";
+import { CanvasDebugPass } from "./canvas-debug-pass.ts";
 import { CompositionPass, type CompositionDrawItem } from "./composition-pass.ts";
 import { DisintegrationPass } from "./disintegration-pass.ts";
 import { EntityDrawItemPreparer } from "./entity-draw-item-preparer.ts";
@@ -69,6 +70,7 @@ export class InfiniteCanvasRenderer {
   // Entity label pass (Canvas 2D rasterized → GPU textured quad)
   #entityLabelPass: EntityLabelPass | null = null;
   #canvasCalloutPass: CanvasCalloutPass | null = null;
+  #canvasDebugPass: CanvasDebugPass | null = null;
 
   // Cached canvas dimensions (updated by ResizeObserver, avoids getBoundingClientRect in render loop)
   #cachedCanvasWidth = 0;
@@ -316,6 +318,14 @@ export class InfiniteCanvasRenderer {
       this.#viewportUniforms.buffer,
     );
     this.#canvasCalloutPass.initialize();
+
+    if (import.meta.env.DEV) {
+      this.#canvasDebugPass = new CanvasDebugPass(
+        this.#device,
+        this.#canvasFormat,
+        this.#viewportUniforms.buffer,
+      );
+    }
 
     // Set up ResizeObserver to cache canvas dimensions (avoids getBoundingClientRect in render loop)
     this.#resizeObserver = new ResizeObserver((entries) => {
@@ -583,6 +593,19 @@ export class InfiniteCanvasRenderer {
         height,
         dragSelectBounds: state.dragSelectBounds,
         multiSelectBounds: state.multiSelectBounds,
+      });
+    }
+
+    if (import.meta.env.DEV && state.debugView !== "none" && this.#canvasDebugPass) {
+      this.#canvasDebugPass.encode({
+        encoder,
+        targetView: sceneTargetView,
+        view: state.debugView,
+        viewport,
+        width,
+        height,
+        entities: entityDrawItems.map((item) => item.entity),
+        spatialIndex: state.entitySpatialIndex,
       });
     }
 
@@ -916,6 +939,8 @@ export class InfiniteCanvasRenderer {
     this.#entityLabelPass = null;
     this.#canvasCalloutPass?.destroy();
     this.#canvasCalloutPass = null;
+    this.#canvasDebugPass?.destroy();
+    this.#canvasDebugPass = null;
 
     this.#wlurOverlayPass?.destroy();
     this.#wlurOverlayPass = null;


### PR DESCRIPTION
- Extend `DebugType` with `alpha`, `spatial`, and `all` variants.
- Add `debugView` field to `RenderState` and initialize it in the bench setup.
- Update `CanvasProvider` to compute the debug flag and set the appropriate debug view based on environment and selected debug type.
- Export `SpatialDebugBucket` and `SpatialDebugCenter` interfaces from `entity-spatial-index`.
- Implement `CanvasDebugPass` for visualizing alpha hit‑test occupancy and spatial index buckets, including a new WGSL shader.
- Import and integrate `CanvasDebugPass` in the main canvas renderer.
- Add a test verifying `collectDebugGeometry` correctly gathers buckets and centers across index levels.