### PR TITLE
Remove mobile drawer background indentation and dimming

### DIFF
--- a/components/mobile-layout.tsx
+++ b/components/mobile-layout.tsx
@@ -19,7 +19,6 @@ import { CopyPasteDrawer } from "./action-layer/copy-paste-drawer.tsx";
 import { IonDuplicateOutline } from "./icons/duplicate.tsx";
 import { MaterialSymbolsResetImage } from "./icons/reset-image.tsx";
 import { MobileExportDrawer } from "./export-knobs/export-knobs.mobile.tsx";
-import { Drawer } from "#ui/drawer/index.tsx";
 import {
   useCanvasCommands,
   useDebugMode,
@@ -131,18 +130,11 @@ function MobileFloat() {
 
 export default function MobileLayout() {
   return (
-    <Drawer.Provider>
-      <div className="drawer-indent-root">
-        <Drawer.IndentBackground className="drawer-indent-bg" />
-        <Drawer.Indent className="drawer-indent">
-          <div className="mobile-layout">
-            <div className="content mobile-content">
-              <Canvas />
-            </div>
-            <MobileFloat />
-          </div>
-        </Drawer.Indent>
+    <div className="mobile-layout">
+      <div className="content mobile-content">
+        <Canvas />
       </div>
-    </Drawer.Provider>
+      <MobileFloat />
+    </div>
   );
 }

--- a/components/ui/drawer/drawer.css
+++ b/components/ui/drawer/drawer.css
@@ -1,25 +1,9 @@
 @layer components {
   .drawer-overlay {
-    --backdrop-opacity: 0.5;
     position: fixed;
     inset: 0;
     min-height: 100dvh;
-    background-color: black;
-    opacity: calc(var(--backdrop-opacity) * (1 - var(--drawer-swipe-progress)));
-    transition: opacity 450ms cubic-bezier(0.32, 0.72, 0, 1);
-
-    &[data-starting-style],
-    &[data-ending-style] {
-      opacity: 0;
-    }
-
-    &[data-swiping] {
-      transition-duration: 0ms;
-    }
-
-    &[data-ending-style] {
-      transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
-    }
+    background: transparent;
   }
 
   .drawer-viewport {
@@ -86,17 +70,6 @@
       border-top-right-radius: calc(var(--drawer-radius) * 1.8);
     }
 
-    &::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      border-top-left-radius: var(--drawer-radius);
-      border-top-right-radius: var(--drawer-radius);
-      background: transparent;
-      pointer-events: none;
-      transition: background-color 450ms cubic-bezier(0.32, 0.72, 0, 1);
-    }
-
     &[data-swiping] {
       user-select: none;
     }
@@ -109,10 +82,6 @@
     &[data-nested-drawer-open] {
       height: calc(var(--stack-height) + var(--bleed));
       overflow: hidden;
-
-      &::after {
-        background: rgb(0 0 0 / 0.05);
-      }
     }
 
     &[data-starting-style],
@@ -165,43 +134,6 @@
   .drawer-popup[data-nested-drawer-open][data-nested-drawer-swiping] > .drawer-handle,
   .drawer-popup[data-nested-drawer-open][data-nested-drawer-swiping] .drawer-content {
     opacity: 1;
-  }
-
-  .drawer-indent-root {
-    position: relative;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  .drawer-indent-bg {
-    position: absolute;
-    inset: 0;
-    background-color: black;
-  }
-
-  .drawer-indent {
-    height: 100%;
-    background-color: var(--background);
-    --indent-progress: var(--drawer-swipe-progress);
-    /* calculate indent radius based on safe area inset. Larger radius if safe area inset is present. */
-    --indent-radius-base: max(1.5rem, min(36px, calc(1.5rem + env(safe-area-inset-top, 0px))));
-    --indent-radius: calc(var(--indent-radius-base) * (1 - var(--indent-progress)));
-    --indent-transition: calc(1 - clamp(0, calc(var(--drawer-swipe-progress) * 100000), 1));
-    position: relative;
-    transition:
-      transform 0.4s cubic-bezier(0.32, 0.72, 0, 1),
-      border-radius 0.25s cubic-bezier(0.32, 0.72, 0, 1);
-    transition-duration:
-      calc(400ms * var(--indent-transition)), calc(250ms * var(--indent-transition));
-    transform-origin: center top;
-    will-change: transform;
-
-    &[data-active] {
-      transform: scale(calc(0.94 + (0.06 * var(--indent-progress))))
-        translateY(calc(14px * (1 - var(--indent-progress))));
-      border-radius: var(--indent-radius);
-      overflow: hidden;
-    }
   }
 
   .drawer-snap-area-default {

--- a/components/ui/drawer/drawer.tsx
+++ b/components/ui/drawer/drawer.tsx
@@ -72,7 +72,5 @@ export const Drawer = {
   Popup,
   Content,
   Provider: BaseDrawer.Provider,
-  Indent: BaseDrawer.Indent,
-  IndentBackground: BaseDrawer.IndentBackground,
   DefaultSnapContentArea,
 };


### PR DESCRIPTION
### Motivation
- The mobile drawer UI currently scales and dims the app background when a drawer opens, which is no longer desired on modern mobile (iOS 26) where background should remain unchanged and not dimmed.

### Description
- Removed the indentation wrapper usage from the mobile composition by deleting the `Drawer.Indent` and `Drawer.IndentBackground` usage in `components/mobile-layout.tsx` so the app layout is no longer wrapped/scaled when drawers open.
- Eliminated the indentation-related CSS and overlay dimming from `components/ui/drawer/drawer.css`, including `.drawer-indent-root`, `.drawer-indent-bg`, `.drawer-indent`, the overlay opacity vars, and the drawer `::after` background adjustments; the drawer backdrop (`.drawer-overlay`) is now transparent.
- Removed the indentation primitives from the exported `Drawer` namespace in `components/ui/drawer/drawer.tsx` since consumers no longer use them.

### Testing
- Ran lint with `bun run lint:all`, which completed successfully.
- Ran the test suite with `bun run test`, which completed successfully with `733` tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6128b379b883328bba01d07237f982)