### PR TITLE
Optimize engine and renderer hot paths

### DIFF
--- a/__tests__/engine/canvas-store.spec.ts
+++ b/__tests__/engine/canvas-store.spec.ts
@@ -188,12 +188,12 @@ describe("canvasStore.seekVideo", () => {
 
   test("marks texture as dirty", () => {
     const entity = createTestEntity({ mediaType: "video", videoDuration: 100 });
-    entity.textureDirty = false;
+    const previousRevision = entity.textureRevision;
     canvasStore.addEntity(entity);
 
     canvasStore.seekVideo(entity.id, 50);
 
-    expect(entity.textureDirty).toBe(true);
+    expect(entity.textureRevision).toBe(previousRevision + 1);
   });
 });
 
@@ -323,7 +323,7 @@ describe("canvasStore.pauseVideo", () => {
     await Promise.resolve();
 
     expect(previousClose).toHaveBeenCalledOnce();
-    expect(entity.textureDirty).toBe(true);
+    expect(entity.textureRevision).toBe(1);
   });
 });
 
@@ -365,12 +365,12 @@ describe("canvasStore.seekGif", () => {
 
   test("marks texture as dirty", () => {
     const entity = createTestEntity({ mediaType: "gif", gifDuration: 2, gifFrameCount: 20 });
-    entity.textureDirty = false;
+    const previousRevision = entity.textureRevision;
     canvasStore.addEntity(entity);
 
     canvasStore.seekGif(entity.id, 1.0);
 
-    expect(entity.textureDirty).toBe(true);
+    expect(entity.textureRevision).toBe(previousRevision + 1);
   });
 });
 

--- a/__tests__/engine/game-loop.spec.ts
+++ b/__tests__/engine/game-loop.spec.ts
@@ -142,6 +142,26 @@ describe("Render loop errors", () => {
   });
 });
 
+describe("Idle frame scheduling", () => {
+  test("sleeps after a clean static frame and wakes on render invalidation", () => {
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation(() => 1);
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+    const renderer = createLoopRenderer();
+
+    gl.setRenderer(renderer);
+    gl.start();
+
+    expect(renderer.render).toHaveBeenCalledOnce();
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+
+    canvasStore.panBy({ x: 1, y: 0 });
+
+    expect(requestAnimationFrame).toHaveBeenCalledOnce();
+  });
+});
+
 describe("Animated media render scheduling", () => {
   test("incrementally reclassifies bulk entity edits without a fixed count cutoff", () => {
     const renderer = createLoopRenderer();

--- a/__tests__/helpers/test-entity.ts
+++ b/__tests__/helpers/test-entity.ts
@@ -45,8 +45,6 @@ export interface CreateEntityOptions {
   zIndex?: number;
   /** Rotation in degrees */
   rotation?: number;
-  /** Whether entity is selected */
-  selected?: boolean;
   /** Whether entity is locked */
   locked?: boolean;
   /** Whether entity has been edited */
@@ -82,7 +80,6 @@ export interface CreateEntityOptions {
  *   id: "my-entity",
  *   shaderType: "halftone",
  *   shaderParams: { size: 20 },
- *   selected: true,
  * });
  *
  * @example
@@ -122,8 +119,7 @@ export function createTestEntity(options: CreateEntityOptions = {}): ShaderCanva
     originalSize: { width, height },
     shaderType: (options.shaderType ?? config.defaults.shader) as ShaderType,
     shaderParams,
-    textureDirty: false,
-    selected: options.selected ?? false,
+    textureRevision: 0,
     locked: options.locked ?? false,
     edited: options.edited ?? false,
   };

--- a/__tests__/helpers/undo-helpers.ts
+++ b/__tests__/helpers/undo-helpers.ts
@@ -62,7 +62,6 @@ export function captureEntityState(entityId: string): Record<string, unknown> | 
     size: { ...entity.size },
     zIndex: entity.zIndex,
     rotation: entity.rotation,
-    selected: entity.selected,
     locked: entity.locked,
     edited: entity.edited,
   };

--- a/__tests__/lib/entity-spatial-index.spec.ts
+++ b/__tests__/lib/entity-spatial-index.spec.ts
@@ -81,6 +81,35 @@ describe("EntitySpatialIndex", () => {
     expect(index.queryBounds({ x: 99, y: -1, width: 30, height: 10 }, [])).toEqual([first, second]);
   });
 
+  test("keeps full-scene containment valid when an interior entity translates", () => {
+    const index = new EntitySpatialIndex(10);
+    const left = createTestEntity({
+      id: "bounds-left",
+      position: { x: 0, y: 0 },
+      size: { width: 2, height: 2 },
+      zIndex: 1,
+    });
+    const interior = createTestEntity({
+      id: "bounds-interior",
+      position: { x: 5, y: 0 },
+      size: { width: 2, height: 2 },
+      zIndex: 2,
+    });
+    const right = createTestEntity({
+      id: "bounds-right",
+      position: { x: 10, y: 0 },
+      size: { width: 2, height: 2 },
+      zIndex: 3,
+    });
+    for (const entity of [left, interior, right]) index.upsert(entity);
+    const ordered = [left, interior, right];
+
+    interior.position.x++;
+    index.translateEntities([interior.id], { x: 1, y: 0 });
+
+    expect(index.queryBounds({ x: -1, y: -1, width: 14, height: 4 }, [], ordered)).toBe(ordered);
+  });
+
   test("removes entities and includes very large entities without indexing every cell", () => {
     const index = new EntitySpatialIndex(1);
     const large = createTestEntity({

--- a/__tests__/renderer/composition-pass.spec.ts
+++ b/__tests__/renderer/composition-pass.spec.ts
@@ -168,8 +168,8 @@ describe("CompositionPass instancing", () => {
       normalInstanceUploadBytes: 0,
     });
     expect(secondFramePass.draw).toHaveBeenCalledWith(6, 2, 0, 0);
-    expect(first.textureDirty).toBe(false);
-    expect(second.textureDirty).toBe(false);
+    expect(first.textureRevision).toBe(0);
+    expect(second.textureRevision).toBe(0);
 
     pass.destroy();
     releaseImageEntity(first);

--- a/__tests__/renderer/entity-draw-item-preparer.spec.ts
+++ b/__tests__/renderer/entity-draw-item-preparer.spec.ts
@@ -278,7 +278,7 @@ describe("EntityDrawItemPreparer full-scene batching", () => {
     const changed = {
       ...scene.entities[1]!,
       shaderParams: structuredClone(scene.entities[1]!.shaderParams),
-      textureDirty: true,
+      textureRevision: scene.entities[1]!.textureRevision + 1,
     };
     changed.shaderParams.size += 1;
     scene.entities[1] = changed;
@@ -303,7 +303,7 @@ describe("EntityDrawItemPreparer full-scene batching", () => {
     const changed = {
       ...scene.entities[1]!,
       shaderParams: structuredClone(scene.entities[1]!.shaderParams),
-      textureDirty: true,
+      textureRevision: scene.entities[1]!.textureRevision + 1,
     };
     changed.shaderParams.size += 1;
     scene.entities[1] = changed;
@@ -331,7 +331,7 @@ describe("EntityDrawItemPreparer full-scene batching", () => {
       const entity = entities[index]!;
       entity.shaderParams = structuredClone(entity.shaderParams);
       entity.shaderParams.size += 1;
-      entity.textureDirty = true;
+      entity.textureRevision++;
       dirtyEntityIds.add(entity.id);
     }
     harness.options.entityVersion++;

--- a/__tests__/renderer/entity-processed-texture-sharing.spec.ts
+++ b/__tests__/renderer/entity-processed-texture-sharing.spec.ts
@@ -64,7 +64,7 @@ describe("EntityTexturePipeline processed image sharing", () => {
       id: "processed-second",
       shaderParams: structuredClone(first.shaderParams),
       mediaSource: { type: "image", asset: first.mediaSource.asset },
-      textureDirty: true,
+      textureRevision: first.textureRevision + 1,
     };
 
     const sourceTexture = createTexture();
@@ -104,7 +104,6 @@ describe("EntityTexturePipeline processed image sharing", () => {
       processedTextureCount: 1,
       processedTextureAllocations: 1,
     });
-    first.textureDirty = false;
     expect(
       pipeline.getReusableStaticCompositionSource(
         first,
@@ -115,14 +114,14 @@ describe("EntityTexturePipeline processed image sharing", () => {
     expect(
       pipeline.getReusableStaticCompositionSource(first, { width: 100, height: 75 }, false),
     ).toBeNull();
-    first.textureDirty = true;
+    first.textureRevision++;
     expect(
       pipeline.getReusableStaticCompositionSource(
         first,
         { width: processedTexture.width, height: processedTexture.height },
         false,
       ),
-    ).toBeNull();
+    ).toEqual(firstResult);
 
     pipeline.removeEntity(first.id);
     expect(processedTexture.destroy).not.toHaveBeenCalled();
@@ -143,7 +142,7 @@ describe("EntityTexturePipeline processed image sharing", () => {
       id: "lod-shared-second",
       shaderParams: structuredClone(first.shaderParams),
       mediaSource: { type: "image", asset: first.mediaSource.asset },
-      textureDirty: true,
+      textureRevision: first.textureRevision + 1,
     };
 
     const detailSource = createTexture(200, 150);
@@ -157,8 +156,6 @@ describe("EntityTexturePipeline processed image sharing", () => {
 
     pipeline.renderEntityToTexture(first, encoder);
     pipeline.renderEntityToTexture(second, encoder);
-    first.textureDirty = false;
-    second.textureDirty = false;
 
     // A shared demotion is one small render followed by cache rebinds, so it can safely
     // start while the viewport is still moving.
@@ -202,7 +199,7 @@ describe("EntityTexturePipeline processed image sharing", () => {
 
     entity.shaderParams = structuredClone(entity.shaderParams);
     entity.shaderParams.size += 1;
-    entity.textureDirty = true;
+    entity.textureRevision++;
 
     expect(pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder)).toEqual({
       kind: "texture",
@@ -228,13 +225,11 @@ describe("EntityTexturePipeline processed image sharing", () => {
     const device = createDevice([detailTexture, overviewTexture]);
     const pipeline = createPipeline(device);
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder);
-    entity.textureDirty = false;
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder, { width: 100, height: 75 });
-    entity.textureDirty = false;
 
     expect(pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder)).toEqual({
       kind: "texture",
@@ -257,16 +252,14 @@ describe("EntityTexturePipeline processed image sharing", () => {
     const device = createDevice(textures);
     const pipeline = createPipeline(device);
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder);
-    entity.textureDirty = false;
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder, { width: 100, height: 75 });
-    entity.textureDirty = false;
 
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder);
-    entity.textureDirty = true;
+    entity.textureRevision++;
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder, { width: 100, height: 75 });
 
     expect(device.createTexture).toHaveBeenCalledTimes(4);
@@ -279,7 +272,7 @@ describe("EntityTexturePipeline processed image sharing", () => {
     const entity = createTestEntity({ id: "video-demotion", mediaType: "video" });
     const pipeline = createPipeline(createDevice([createTexture(200, 150)]));
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     pipeline.renderEntityToTexture(entity, {} as GPUCommandEncoder);
     pipeline.beginFrame(false);
 

--- a/__tests__/renderer/entity-texture-pipeline.spec.ts
+++ b/__tests__/renderer/entity-texture-pipeline.spec.ts
@@ -57,7 +57,7 @@ describe("EntityTexturePipeline shared image sources", () => {
       ...first,
       id: "image-second",
       mediaSource: { type: "image", asset: first.mediaSource.asset },
-      textureDirty: true,
+      textureRevision: first.textureRevision + 1,
     };
 
     const sourceTexture = createTexture(200, 150);
@@ -116,7 +116,6 @@ describe("EntityTexturePipeline shared image sources", () => {
     pipeline.endFrame();
     expect(pipeline.getResidencyStats().residentBytes).toBe(200 * 150 * 4 * 2);
 
-    second.textureDirty = false;
     pipeline.renderEntityToTexture(second, encoder);
     pipeline.endFrame();
 
@@ -246,7 +245,7 @@ describe("EntityTexturePipeline shared image sources", () => {
       ...first,
       id: "resident-second",
       mediaSource: { type: "image", asset: first.mediaSource.asset },
-      textureDirty: true,
+      textureRevision: first.textureRevision + 1,
     };
     const pipeline = new EntityTexturePipeline({
       device: createDevice([createTexture(200, 150)]),

--- a/application/canvas/debug-canvas.ts
+++ b/application/canvas/debug-canvas.ts
@@ -45,7 +45,7 @@ export async function debugCanvas(store: CanvasStore) {
     shaderType: ShaderType.ascii,
     size: { width: imageBitmap.width, height: imageBitmap.height },
     zIndex: 0,
-    textureDirty: true,
+    textureRevision: 1,
     edited: true,
   });
 }

--- a/bench/README.md
+++ b/bench/README.md
@@ -141,6 +141,16 @@ commit separately:
 bun run --bun vitest bench bench/large-selection-operations.bench.ts --run
 ```
 
+Run the bounded engine/renderer CPU hot-path benchmarks separately:
+
+```bash
+bun run --bun vitest bench bench/engine-renderer-hot-paths.bench.ts --run
+```
+
+This covers a 131k-entity interior translation followed by a full-bounds
+spatial query, a z-order-only entity update, clean dirty-state checks, and
+eviction under a 16k-entry renderer cache workload.
+
 ### Mixed-media zoom regression
 
 The zoom scenarios model the reported interactive workspace rather than a

--- a/bench/engine-renderer-hot-paths.bench.ts
+++ b/bench/engine-renderer-hot-paths.bench.ts
@@ -1,0 +1,100 @@
+import { bench, describe } from "vitest";
+import { CanvasStore } from "#engine";
+import { EntitySpatialIndex } from "#lib/entity-spatial-index.ts";
+import { ByteBudgetCache } from "#renderer/byte-budget-cache.ts";
+import type { ShaderCanvasEntity } from "#types/canvas.ts";
+import { createTestEntity } from "../__tests__/helpers/test-entity.ts";
+
+const LARGE_ENTITY_COUNT = 131_072;
+const EVICTION_ENTRY_COUNT = 16_384;
+const EVICTION_BUDGET = EVICTION_ENTRY_COUNT / 2;
+
+function createLargeEntitySet(): ShaderCanvasEntity[] {
+  const base = createTestEntity({
+    id: "hot-path-0",
+    size: { width: 6, height: 6 },
+    zIndex: 0,
+  });
+  const entities = new Array<ShaderCanvasEntity>(LARGE_ENTITY_COUNT);
+  entities[0] = base;
+  for (let index = 1; index < LARGE_ENTITY_COUNT; index++) {
+    entities[index] = {
+      ...base,
+      id: `hot-path-${index}`,
+      position: { x: (index % 512) * 8, y: Math.floor(index / 512) * 8 },
+      zIndex: index,
+    };
+  }
+  return entities;
+}
+
+describe("131k engine hot paths", () => {
+  const entities = createLargeEntitySet();
+  const orderedEntities = [...entities];
+  const spatialIndex = new EntitySpatialIndex();
+  for (const entity of entities) spatialIndex.upsert(entity);
+  const queryOutput: ShaderCanvasEntity[] = [];
+  const fullBounds = { x: -16, y: -16, width: 4_160, height: 2_112 };
+  let translatedEntity = entities[Math.floor(entities.length / 2) + 256]!;
+  let direction = 1;
+
+  bench(
+    "translate one interior entity then query full bounds",
+    () => {
+      const delta = { x: direction, y: 0 };
+      translatedEntity.position.x += delta.x;
+      spatialIndex.translateEntities([translatedEntity.id], delta);
+      spatialIndex.queryBounds(fullBounds, queryOutput, orderedEntities);
+      direction *= -1;
+    },
+    { time: 0, iterations: 8, warmupTime: 0, warmupIterations: 2 },
+  );
+
+  const store = new CanvasStore();
+  store.addEntities(entities);
+  let zIndex = entities.length + 1;
+
+  bench(
+    "update one entity z-index",
+    () => {
+      store.updateEntity(translatedEntity.id, { zIndex: zIndex++ });
+      store.getRenderState();
+      store.clearDirtyFlags();
+    },
+    { time: 0, iterations: 8, warmupTime: 0, warmupIterations: 2 },
+  );
+
+  bench(
+    "clean render-change check",
+    () => {
+      for (let index = 0; index < 100_000; index++) store.hasRenderChanges();
+    },
+    { time: 0, iterations: 8, warmupTime: 0, warmupIterations: 2 },
+  );
+});
+
+describe("renderer cache pressure", () => {
+  const caches: ByteBudgetCache[] = [];
+  for (let iteration = 0; iteration < 32; iteration++) {
+    const cache = new ByteBudgetCache(EVICTION_BUDGET);
+    for (let index = 0; index < EVICTION_ENTRY_COUNT; index++) {
+      cache.register(`entry-${iteration}-${index}`, 1, () => {});
+    }
+    cache.endFrame();
+    for (let index = EVICTION_ENTRY_COUNT / 4; index < EVICTION_ENTRY_COUNT; index++) {
+      cache.markUsed(`entry-${iteration}-${index}`);
+    }
+    caches.push(cache);
+  }
+  let cacheIndex = 0;
+
+  bench(
+    "evict an over-budget 16k-entry cache",
+    () => {
+      const cache = caches[cacheIndex]!;
+      cacheIndex += 1;
+      cache.endFrame();
+    },
+    { time: 0, iterations: 8, warmupTime: 0, warmupIterations: 2 },
+  );
+});

--- a/bench/render-bench.ts
+++ b/bench/render-bench.ts
@@ -857,7 +857,7 @@ async function createEntities(scenario: BenchScenario): Promise<BenchEntitySet> 
         entities: [createdEntity],
         beforeFrame: (frameIndex) => {
           synthetic.drawFrame(frameIndex);
-          createdEntity.textureDirty = true;
+          createdEntity.textureRevision++;
         },
         cleanup: () => {
           disposeBenchCleanupActions(synthetic.cleanup, () =>
@@ -917,7 +917,7 @@ async function createEntities(scenario: BenchScenario): Promise<BenchEntitySet> 
       beforeFrame:
         scenario.dirtyMode === "texture"
           ? () => {
-              for (const entity of entities) entity.textureDirty = true;
+              for (const entity of entities) entity.textureRevision++;
             }
           : undefined,
       cleanup: () => disposeBenchEntities(entities),
@@ -1040,7 +1040,7 @@ async function createZoomStressEntitySet(
               syntheticVideos[index]!.drawFrame(videoFrameIndex + index * 3);
             }
             for (const entity of entities) {
-              if (entity.mediaSource.type === MediaType.video) entity.textureDirty = true;
+              if (entity.mediaSource.type === MediaType.video) entity.textureRevision++;
             }
           }
         : undefined,
@@ -1334,8 +1334,7 @@ function createEntity(options: CreateEntityOptions): ShaderCanvasEntity {
         options.params.glass?.kind === GlassKind.flowing &&
         options.params.timeAutoPlay !== false,
     ),
-    textureDirty: true,
-    selected: false,
+    textureRevision: 1,
     locked: false,
     edited: false,
   };
@@ -1383,6 +1382,7 @@ function createRenderState(
     entityVersion: 0,
     geometryVersion: 0,
     selectionVersion: selectedEntityIds.size > 0 ? 1 : 0,
+    dirtyMask: dirty ? 0xffff_ffff : 0,
     dirtyEntityIds: new Set(),
     selectedEntityIds,
     debugMode,
@@ -1486,7 +1486,11 @@ async function runFrames(params: {
     if (parameterTargetIndex >= 0) {
       const previous = params.entities[parameterTargetIndex]!;
       const shaderParams = { ...previous.shaderParams, size: 1 + (frameIndex % 24) * 0.125 };
-      const next = { ...previous, shaderParams, textureDirty: true };
+      const next = {
+        ...previous,
+        shaderParams,
+        textureRevision: previous.textureRevision + 1,
+      };
       params.entities[parameterTargetIndex] = next;
       dirtyEntityIds.clear();
       dirtyEntityIds.add(next.id);
@@ -1661,7 +1665,7 @@ async function runScenario(scenario: BenchScenario): Promise<BenchResult> {
         await benchRenderer.waitForGPU();
         for (const entity of entitySet.entities) {
           benchRenderer.removeEntityTexture(entity.id);
-          entity.textureDirty = true;
+          entity.textureRevision++;
         }
       }
       const startFrameIndex = frameIndex;

--- a/context/canvas-context.tsx
+++ b/context/canvas-context.tsx
@@ -59,6 +59,7 @@ import {
   gameLoop,
   viewportAnimation,
   perfOverlay,
+  type CanvasEntityPatch,
   type CanvasEntityUpdate,
 } from "#engine";
 import { PerfGraphRenderer } from "#renderer/perf-graph-renderer.ts";
@@ -579,7 +580,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
       shaderType: renderStateRef.current.shader as ShaderType,
       shaderParams,
       mediaSource: entity.mediaSource as any,
-      textureDirty: true,
+      textureRevision: entity.textureRevision + 1,
       edited: false,
     };
 
@@ -650,13 +651,14 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     return id;
   };
 
-  const updateEntity = (id: string, updates: Partial<ShaderCanvasEntity>) => {
+  const updateEntity = (id: string, updates: CanvasEntityPatch) => {
     const entity = canvasStore.getState().entities.get(id);
     if (!entity) return;
 
     // Capture only the fields being changed (before mutation)
-    const previousValues: Partial<ShaderCanvasEntity> = {};
-    for (const key of Object.keys(updates) as (keyof ShaderCanvasEntity)[]) {
+    const previousValues: CanvasEntityPatch = {};
+    for (const key of Object.keys(updates) as (keyof ShaderCanvasEntity | "textureDirty")[]) {
+      if (key === "textureDirty") continue;
       // Deep clone to avoid reference issues
       const value = entity[key];
       // Use type assertion since we know we're copying valid entity fields
@@ -965,9 +967,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
           shaderParams: { ...entity.shaderParams },
           originalPalette: entity.originalPalette,
           playback,
-          texture: undefined,
-          textureDirty: true,
-          selected: false,
+          textureRevision: entity.textureRevision + 1,
           edited: false,
         };
 
@@ -1347,7 +1347,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
         ? { ...shaderParams, palette: clonedPalette }
         : shaderParams;
 
-      const updates: Partial<ShaderCanvasEntity> = {
+      const updates: CanvasEntityPatch = {
         shaderType,
         shaderParams: pastedParams,
         textureDirty: true,
@@ -1384,7 +1384,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
           ? { ...shaderParams, palette: clonedPalette }
           : shaderParams;
 
-        const updates: Partial<ShaderCanvasEntity> = {
+        const updates: CanvasEntityPatch = {
           shaderType,
           shaderParams: pastedParams,
           textureDirty: true,

--- a/engine/canvas-store.ts
+++ b/engine/canvas-store.ts
@@ -18,8 +18,20 @@ import { getFrameAtTime } from "#lib/gif-decoder.ts";
 import { completeOnboardingStarterSelectionFromEvent } from "#lib/onboarding-runtime.ts";
 import { EntitySpatialIndex } from "#lib/entity-spatial-index.ts";
 import { CanvasLensing } from "#types/enums.ts";
+import { createEnum } from "#types/index.ts";
 
 export type DragSelectMode = "replace" | "additive" | "subtractive";
+
+export const CanvasDirtyFlag = createEnum({
+  viewport: 1 << 0,
+  entityContent: 1 << 1,
+  geometry: 1 << 2,
+  selection: 1 << 3,
+  container: 1 << 4,
+  callouts: 1 << 5,
+});
+
+export type CanvasDirtyFlag = typeof CanvasDirtyFlag.infer;
 
 export interface CanvasState {
   // Core state
@@ -47,12 +59,8 @@ export interface CanvasState {
   canvasLensing: CanvasLensing;
 
   // Dirty flags for optimization
-  viewportDirty: boolean;
   entitiesDirty: Set<string>;
-  geometryDirty: boolean;
-  selectionDirty: boolean;
-  containerSizeDirty: boolean;
-  canvasCalloutsDirty: boolean;
+  dirtyMask: number;
 
   // Frame counter for debugging
   frameCount: number;
@@ -60,6 +68,7 @@ export interface CanvasState {
   // Version counters for React change detection (selective subscriptions)
   version: number; // Overall version (for backward compat)
   entityVersion: number; // Entity membership/reference/animation classification changes
+  membershipVersion: number; // Entity additions, removals, and workspace replacement
   geometryVersion: number; // Imperative position changes that do not notify React
   viewportVersion: number; // Incremented only on viewport changes
   selectionVersion: number; // Incremented on selection/entity changes
@@ -85,9 +94,14 @@ export interface CanvasState {
   canvasCallouts: readonly CanvasCallout[];
 }
 
+export type CanvasEntityPatch = Partial<ShaderCanvasEntity> & {
+  /** Request a new texture revision without exposing renderer-owned state. */
+  textureDirty?: boolean;
+};
+
 export interface CanvasEntityUpdate {
   id: string;
-  updates: Partial<ShaderCanvasEntity>;
+  updates: CanvasEntityPatch;
 }
 
 // Snapshot types for selective subscriptions
@@ -194,6 +208,7 @@ export interface RenderState {
   entityVersion: number;
   geometryVersion: number;
   selectionVersion: number;
+  dirtyMask: number;
   /** Entity references changed since the previous render; valid until dirty flags clear. */
   dirtyEntityIds: ReadonlySet<string>;
   selectedEntityIds: ReadonlySet<string>;
@@ -235,6 +250,7 @@ export interface ParamResult<T> {
 export class CanvasStore extends Store<CanvasState> {
   #logger: Logger;
   #viewportListeners = new Set<() => void>();
+  #renderInvalidationListeners = new Set<() => void>();
   #selectedEntitiesCache: ShaderCanvasEntity[] = [];
   #selectedEntitiesVersion = -1;
   #selectionStateCache: { entities: ShaderCanvasEntity[]; value: SelectionState } | null = null;
@@ -271,6 +287,7 @@ export class CanvasStore extends Store<CanvasState> {
     entityVersion: 0,
     geometryVersion: 0,
     selectionVersion: 0,
+    dirtyMask: 0,
     dirtyEntityIds: new Set<string>(),
     selectedEntityIds: new Set<string>(),
     debugMode: false,
@@ -318,15 +335,12 @@ export class CanvasStore extends Store<CanvasState> {
       fancyDelete: true,
       haptics: true,
       canvasLensing: CanvasLensing.off,
-      viewportDirty: false,
       entitiesDirty: new Set(),
-      geometryDirty: false,
-      selectionDirty: false,
-      containerSizeDirty: false,
-      canvasCalloutsDirty: false,
+      dirtyMask: 0,
       frameCount: 0,
       version: 0,
       entityVersion: 0,
+      membershipVersion: 0,
       geometryVersion: 0,
       viewportVersion: 0,
       selectionVersion: 0,
@@ -474,14 +488,14 @@ export class CanvasStore extends Store<CanvasState> {
   // Viewport mutations (only notify viewport subscribers)
   setViewport(viewport: Viewport): void {
     this.state.viewport = { ...viewport, offset: { ...viewport.offset } };
-    this.state.viewportDirty = true;
+    this.#markDirty(CanvasDirtyFlag.viewport);
     this.notifyViewportChange();
   }
 
   panBy(delta: Point): void {
     this.state.viewport.offset.x += delta.x;
     this.state.viewport.offset.y += delta.y;
-    this.state.viewportDirty = true;
+    this.#markDirty(CanvasDirtyFlag.viewport);
     this.notifyViewportChange();
   }
 
@@ -494,6 +508,8 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.entityIds.push(entity.id);
     this.#entitySpatialIndex.upsert(entity);
     this.state.entitiesDirty.add(entity.id);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
+    this.state.membershipVersion++;
     this.notifyEntityChange();
   }
 
@@ -508,6 +524,8 @@ export class CanvasStore extends Store<CanvasState> {
       this.#entitySpatialIndex.upsert(entity);
       this.state.entitiesDirty.add(entity.id);
     }
+    this.#markDirty(CanvasDirtyFlag.entityContent);
+    this.state.membershipVersion++;
     this.notifyEntityChange();
   }
 
@@ -542,15 +560,14 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.actionLayerEntityIds = new Set();
     this.state.actionLayerTouchOrigin = { x: 0, y: 0 };
     this.state.canvasCallouts = [];
-    // Every restored entity is already textureDirty. One scene-level dirty flag is
+    // Every restored entity has a fresh texture revision. One scene-level dirty flag is
     // sufficient; retaining 131k duplicate IDs until the first frame is wasted memory.
     this.state.entitiesDirty.clear();
-    this.state.selectionDirty = true;
-    this.state.viewportDirty = true;
-    this.state.containerSizeDirty = false;
-    this.state.canvasCalloutsDirty = false;
+    this.state.dirtyMask = 0;
+    this.#markDirty(CanvasDirtyFlag.selection | CanvasDirtyFlag.viewport);
     this.state.version++;
     this.state.entityVersion++;
+    this.state.membershipVersion++;
     this.state.geometryVersion++;
     this.state.selectionVersion++;
     this.state.viewportVersion++;
@@ -564,7 +581,7 @@ export class CanvasStore extends Store<CanvasState> {
     for (const listener of this.#viewportListeners) listener();
   }
 
-  updateEntity(id: string, updates: Partial<ShaderCanvasEntity>): void {
+  updateEntity(id: string, updates: CanvasEntityPatch): void {
     this.updateEntities([{ id, updates }]);
   }
 
@@ -576,9 +593,14 @@ export class CanvasStore extends Store<CanvasState> {
     for (const { id, updates } of batch) {
       const entity = this.state.entities.get(id);
       if (!entity) continue;
-      const updatedEntity = { ...entity, ...updates } as ShaderCanvasEntity;
+      const { textureDirty, ...entityUpdates } = updates;
+      const updatedEntity = {
+        ...entity,
+        ...entityUpdates,
+        textureRevision: textureDirty ? entity.textureRevision + 1 : entity.textureRevision,
+      } as ShaderCanvasEntity;
       this.state.entities.set(id, updatedEntity);
-      if (hasSpatialEntityUpdates(updates)) {
+      if (hasSpatialEntityUpdates(entityUpdates)) {
         this.#entitySpatialIndex.upsert(updatedEntity);
       } else {
         this.#entitySpatialIndex.updateEntityReference(updatedEntity);
@@ -588,6 +610,7 @@ export class CanvasStore extends Store<CanvasState> {
     }
 
     if (updatedCount === 0) return 0;
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.notifyEntityChange();
     this.#logger.debug("Updated entity batch", { entityCount: updatedCount });
     return updatedCount;
@@ -598,11 +621,11 @@ export class CanvasStore extends Store<CanvasState> {
     if (entity) {
       entity.position.x += delta.x;
       entity.position.y += delta.y;
-      this.#entitySpatialIndex.upsert(entity);
+      this.#entitySpatialIndex.translateEntities([id], delta);
       this.state.geometryVersion++;
       // Position-only updates still change the composed scene and must invalidate
       // renderer caches such as the fullscreen wlur overlay during drag.
-      this.state.geometryDirty = true;
+      this.#markDirty(CanvasDirtyFlag.geometry);
     }
   }
 
@@ -620,7 +643,7 @@ export class CanvasStore extends Store<CanvasState> {
     if (movedCount === 0) return 0;
     this.#entitySpatialIndex.translateEntities(entityIds, delta);
     this.state.geometryVersion++;
-    this.state.geometryDirty = true;
+    this.#markDirty(CanvasDirtyFlag.geometry);
     return movedCount;
   }
 
@@ -634,7 +657,8 @@ export class CanvasStore extends Store<CanvasState> {
 
     this.state.entitiesDirty.delete(id);
     // Always mark dirty since entity list changed (needed for undo/redo re-render)
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.entityContent | CanvasDirtyFlag.selection);
+    this.state.membershipVersion++;
     // Remove from selection if present (immutable update for React)
     if (this.state.selectedEntityIds.has(id)) {
       const newSelection = new Set(this.state.selectedEntityIds);
@@ -669,7 +693,8 @@ export class CanvasStore extends Store<CanvasState> {
       if (!entityIds.has(id)) nextSelection.add(id);
     }
     this.state.selectedEntityIds = nextSelection;
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.entityContent | CanvasDirtyFlag.selection);
+    this.state.membershipVersion++;
     this.notifyEntityChange();
     this.#logger.debug("Removed entity batch", { entityCount: removedCount });
     return removedCount;
@@ -683,7 +708,7 @@ export class CanvasStore extends Store<CanvasState> {
   addToSelection(id: string): void {
     if (!this.state.entities.has(id)) return;
     this.state.selectedEntityIds = new Set(this.state.selectedEntityIds).add(id);
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     completeOnboardingStarterSelectionFromEvent(this.state.selectedEntityIds);
     this.#logger.debug(`Added to selection: ${id}`, this.state.entities.get(id));
     this.notifySelectionChange();
@@ -694,7 +719,7 @@ export class CanvasStore extends Store<CanvasState> {
     const newSelection = new Set(this.state.selectedEntityIds);
     newSelection.delete(id);
     this.state.selectedEntityIds = newSelection;
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     this.#logger.debug(`Removed from selection: ${id}`);
     this.notifySelectionChange();
   }
@@ -717,7 +742,7 @@ export class CanvasStore extends Store<CanvasState> {
       }
     }
     this.state.selectedEntityIds = newSelection;
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     completeOnboardingStarterSelectionFromEvent(this.state.selectedEntityIds);
     this.#logger.debug("Selection replaced", {
       entityCount: newSelection.size,
@@ -737,7 +762,7 @@ export class CanvasStore extends Store<CanvasState> {
       return;
     }
     this.state.selectedEntityIds = new Set(this.state.entityIds);
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     completeOnboardingStarterSelectionFromEvent(this.state.selectedEntityIds);
     this.#logger.debug("All entities selected", { entityCount: this.state.selectedEntityIds.size });
     this.notifySelectionChange();
@@ -747,7 +772,7 @@ export class CanvasStore extends Store<CanvasState> {
   replaceTransientSelection(ids: Set<string>): Set<string> {
     const previousSelection = this.state.selectedEntityIds;
     this.state.selectedEntityIds = ids;
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     return previousSelection;
   }
 
@@ -763,7 +788,7 @@ export class CanvasStore extends Store<CanvasState> {
   /** Clear all selection */
   clearSelection(): void {
     this.state.selectedEntityIds = new Set();
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     this.#logger.debug(`Selection cleared`);
     this.notifySelectionChange();
   }
@@ -832,7 +857,7 @@ export class CanvasStore extends Store<CanvasState> {
 
   setContextOpenEntity(id: string | null): void {
     this.state.contextOpenEntityId = id;
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
     if (id) {
       this.#logger.debug(`context menu opened for entity: ${id}`, this.state.entities.get(id));
     }
@@ -849,7 +874,7 @@ export class CanvasStore extends Store<CanvasState> {
     }
 
     this.state.contextOpenEntityId = null;
-    this.state.selectionDirty = true;
+    this.#markDirty(CanvasDirtyFlag.selection);
 
     this.notifySelectionChange();
   }
@@ -875,13 +900,11 @@ export class CanvasStore extends Store<CanvasState> {
     this.state.actionLayerTouchOrigin = { x: 0, y: 0 };
     this.state.canvasCallouts = [];
     this.state.entitiesDirty.clear();
-    this.state.selectionDirty = false;
-    this.state.viewportDirty = false;
-    this.state.containerSizeDirty = false;
-    this.state.canvasCalloutsDirty = false;
+    this.state.dirtyMask = 0;
     // Increment versions to invalidate cached snapshots
     this.state.version++;
     this.state.entityVersion++;
+    this.state.membershipVersion++;
     this.state.geometryVersion++;
     this.state.selectionVersion++;
     this.state.viewportVersion++;
@@ -899,7 +922,7 @@ export class CanvasStore extends Store<CanvasState> {
   // Debug mode toggle
   toggleDebugMode(): void {
     this.state.version++;
-    this.state.viewportDirty = true;
+    this.#markDirty(CanvasDirtyFlag.viewport);
     this.state.debugMode = !this.state.debugMode;
     this.#logger.setLevel(this.state.debugMode ? LogLevel.DEBUG : LogLevel.ERROR);
     this.notifySelectionChange();
@@ -908,7 +931,7 @@ export class CanvasStore extends Store<CanvasState> {
 
   setDebugMode(enabled: boolean): void {
     this.state.version++;
-    this.state.viewportDirty = true;
+    this.#markDirty(CanvasDirtyFlag.viewport);
     this.state.debugMode = enabled;
     this.#logger.setLevel(enabled ? LogLevel.DEBUG : LogLevel.ERROR);
     this.notifySelectionChange();
@@ -964,7 +987,7 @@ export class CanvasStore extends Store<CanvasState> {
   setTransientEntityDragOffset(offset: Point): void {
     this.#transientEntityDragOffset.x = offset.x;
     this.#transientEntityDragOffset.y = offset.y;
-    this.state.geometryDirty = true;
+    this.#markDirty(CanvasDirtyFlag.geometry);
   }
 
   getTransientEntityDragOffset(): Readonly<Point> {
@@ -1001,7 +1024,7 @@ export class CanvasStore extends Store<CanvasState> {
   setCanvasCallouts(callouts: readonly CanvasCallout[]): void {
     if (sameCanvasCallouts(this.state.canvasCallouts, callouts)) return;
     this.state.canvasCallouts = callouts;
-    this.state.canvasCalloutsDirty = true;
+    this.#markDirty(CanvasDirtyFlag.callouts);
   }
 
   setMultiSelectMode(enabled: boolean): void {
@@ -1042,6 +1065,7 @@ export class CanvasStore extends Store<CanvasState> {
       entity.playback.currentTime = video.currentTime;
     }
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.notifyEntityChange();
   }
 
@@ -1056,6 +1080,7 @@ export class CanvasStore extends Store<CanvasState> {
     entity.playback.muted = muted;
     entity.mediaSource.videoElement.muted = muted;
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.notifySelectionChange();
   }
 
@@ -1097,13 +1122,15 @@ export class CanvasStore extends Store<CanvasState> {
           }
           entity.imageBitmap = bitmap;
           previousBitmap.close();
-          entity.textureDirty = true;
+          entity.textureRevision++;
           this.state.entitiesDirty.add(entityId);
+          this.#markDirty(CanvasDirtyFlag.entityContent);
         })
         .catch((e) => logger.error(e));
     }
 
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.notifyEntityChange();
   }
 
@@ -1124,8 +1151,9 @@ export class CanvasStore extends Store<CanvasState> {
       entity.playback.currentTime = clampedTime;
     }
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.state.playbackVersion++;
     this.notify();
   }
@@ -1155,8 +1183,9 @@ export class CanvasStore extends Store<CanvasState> {
     const entity = this.state.entities.get(entityId);
     if (!entity) return;
 
-    entity.textureDirty = true;
+    entity.textureRevision++;
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
   }
 
   // GIF playback controls
@@ -1168,6 +1197,7 @@ export class CanvasStore extends Store<CanvasState> {
       entity.playback.isPlaying = true;
     }
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.notifyEntityChange();
   }
 
@@ -1180,8 +1210,9 @@ export class CanvasStore extends Store<CanvasState> {
     }
 
     // Snapshot current frame for static display (already set by advanceGifPlayback)
-    entity.textureDirty = true;
+    entity.textureRevision++;
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.notifyEntityChange();
   }
 
@@ -1203,8 +1234,9 @@ export class CanvasStore extends Store<CanvasState> {
     // Update frame to match seek position
     const frame = getFrameAtTime(frames, clampedTime, entity.playback?.loop ?? true);
     entity.imageBitmap = frame.bitmap;
-    entity.textureDirty = true;
+    entity.textureRevision++;
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     this.state.playbackVersion++;
     this.notify();
   }
@@ -1289,26 +1321,20 @@ export class CanvasStore extends Store<CanvasState> {
 
     entity.imageBitmap = frame.bitmap;
     // Mark as dirty so renderer picks up the new frame
-    entity.textureDirty = true;
+    entity.textureRevision++;
     this.state.entitiesDirty.add(entityId);
+    this.#markDirty(CanvasDirtyFlag.entityContent);
     return true;
   }
 
   // Mark container as needing resize handling (no React notification needed)
   setContainerDirty(): void {
-    this.state.containerSizeDirty = true;
+    this.#markDirty(CanvasDirtyFlag.container);
   }
 
   // Snapshot for rendering (called once per frame)
   hasRenderChanges(): boolean {
-    return (
-      this.state.viewportDirty ||
-      this.state.entitiesDirty.size > 0 ||
-      this.state.geometryDirty ||
-      this.state.selectionDirty ||
-      this.state.containerSizeDirty ||
-      this.state.canvasCalloutsDirty
-    );
+    return this.state.dirtyMask !== 0;
   }
 
   getRenderState(): RenderState {
@@ -1355,6 +1381,7 @@ export class CanvasStore extends Store<CanvasState> {
     renderState.entityVersion = this.state.entityVersion;
     renderState.geometryVersion = this.state.geometryVersion;
     renderState.selectionVersion = this.state.selectionVersion;
+    renderState.dirtyMask = this.state.dirtyMask;
     renderState.dirtyEntityIds = this.state.entitiesDirty;
     renderState.selectedEntityIds = this.state.selectedEntityIds;
     renderState.debugMode = this.state.debugMode;
@@ -1382,12 +1409,8 @@ export class CanvasStore extends Store<CanvasState> {
 
   // Clear dirty flags after render
   clearDirtyFlags(): void {
-    this.state.viewportDirty = false;
     this.state.entitiesDirty.clear();
-    this.state.geometryDirty = false;
-    this.state.selectionDirty = false;
-    this.state.containerSizeDirty = false;
-    this.state.canvasCalloutsDirty = false;
+    this.state.dirtyMask = 0;
     this.state.frameCount++;
   }
 
@@ -1401,6 +1424,11 @@ export class CanvasStore extends Store<CanvasState> {
     return () => this.#viewportListeners.delete(listener);
   };
 
+  subscribeRenderInvalidation = (listener: () => void): (() => void) => {
+    this.#renderInvalidationListeners.add(listener);
+    return () => this.#renderInvalidationListeners.delete(listener);
+  };
+
   // ============================================================================
   // Notification Helpers (use base class notify())
   // ============================================================================
@@ -1412,6 +1440,13 @@ export class CanvasStore extends Store<CanvasState> {
     for (const listener of this.#viewportListeners) {
       listener();
     }
+  }
+
+  #markDirty(flags: number): void {
+    const previous = this.state.dirtyMask;
+    this.state.dirtyMask |= flags;
+    if (previous !== 0) return;
+    for (const listener of this.#renderInvalidationListeners) listener();
   }
 
   private notifySelectionChange(): void {
@@ -1547,10 +1582,7 @@ export class CanvasStore extends Store<CanvasState> {
 
 function hasSpatialEntityUpdates(updates: Partial<ShaderCanvasEntity>): boolean {
   return (
-    updates.position !== undefined ||
-    updates.size !== undefined ||
-    updates.rotation !== undefined ||
-    updates.zIndex !== undefined
+    updates.position !== undefined || updates.size !== undefined || updates.rotation !== undefined
   );
 }
 

--- a/engine/frame-loop.ts
+++ b/engine/frame-loop.ts
@@ -67,13 +67,13 @@ export class FrameLoop {
   #renderer: CanvasRendererPort | null = null;
   #running = false;
   #animationFrameId: number | null = null;
+  #unsubscribeRenderInvalidation: (() => void) | null = null;
   #videoFrameTrackers = new Map<string, VideoFrameTracker>();
   #videoFrameTrackerGeneration = 0;
   #firstFrameRendered = false;
   #lastFrameTime: number | null = null;
   #activeEntityVersion = -1;
-  #activeEntityCount = 0;
-  readonly #classifiedEntityIds = new Set<string>();
+  #activeMembershipVersion = -1;
   #playingGifs = new Map<string, ShaderCanvasEntity>();
   #playingVideos = new Map<string, ShaderCanvasEntity>();
   #continuousShaderEntities = new Map<string, ShaderCanvasEntity>();
@@ -92,17 +92,24 @@ export class FrameLoop {
     );
     this.#firstFrameRendered = false;
     this.#activeEntityVersion = -1;
+    this.#activeMembershipVersion = -1;
+    this.requestFrame();
   }
 
   start(): void {
     if (this.#running) return;
     this.#running = true;
+    this.#unsubscribeRenderInvalidation = canvasStore.subscribeRenderInvalidation(
+      this.requestFrame,
+    );
     this.#tick();
   }
 
   stop(): void {
     this.#running = false;
     this.#lastFrameTime = null;
+    this.#unsubscribeRenderInvalidation?.();
+    this.#unsubscribeRenderInvalidation = null;
     this.#clearVideoFrameTrackers();
     if (this.#animationFrameId !== null) {
       cancelAnimationFrame(this.#animationFrameId);
@@ -110,8 +117,14 @@ export class FrameLoop {
     }
   }
 
+  requestFrame = (): void => {
+    if (!this.#running || this.#animationFrameId !== null) return;
+    this.#animationFrameId = requestAnimationFrame(this.#tick);
+  };
+
   #tick = (): void => {
     if (!this.#running) return;
+    this.#animationFrameId = null;
 
     // 1. Compute delta time for GIF playback advancement
     const now = performance.now();
@@ -166,6 +179,7 @@ export class FrameLoop {
       this.#renderer?.hasPendingRenderWork();
 
     // 8. Render only when needed (skip idle frames)
+    let renderedSuccessfully = false;
     if (this.#renderer?.isReady && needsRender) {
       // Snapshot the O(entity count) render array only after deciding that a frame is needed.
       const renderState = canvasStore.getRenderState();
@@ -179,6 +193,7 @@ export class FrameLoop {
       try {
         this.#renderer.render(renderState);
         this.#firstFrameRendered = true;
+        renderedSuccessfully = true;
         this.#deps.perf.onRender(this.#renderer.getFrameStats(), debugMode);
       } catch (error) {
         this.#callbacks.onRenderError(error);
@@ -186,14 +201,24 @@ export class FrameLoop {
     }
 
     // 10. Clear dirty flags
-    canvasStore.clearDirtyFlags();
+    if (renderedSuccessfully) canvasStore.clearDirtyFlags();
 
     // 11. Run frame-end work after the final touch-driven viewport has passed
     // through this render tick.
     this.#callbacks.onAfterFrame();
 
-    // 12. Schedule next frame
-    this.#animationFrameId = requestAnimationFrame(this.#tick);
+    if (
+      this.#playingGifs.size > 0 ||
+      this.#playingVideos.size > 0 ||
+      this.#continuousShaderEntities.size > 0 ||
+      this.#deps.scheduler.hasActive ||
+      this.#callbacks.isPointerDragging() ||
+      this.#callbacks.isDragSelectActive() ||
+      this.#renderer?.hasPendingRenderWork() ||
+      canvasStore.hasRenderChanges()
+    ) {
+      this.requestFrame();
+    }
   };
 
   #refreshActiveEntities(): void {
@@ -202,19 +227,11 @@ export class FrameLoop {
 
     const hasActiveSnapshot = this.#activeEntityVersion >= 0;
     this.#activeEntityVersion = state.entityVersion;
-    let canPatch =
+    const canPatch =
       hasActiveSnapshot &&
-      this.#activeEntityCount === state.entities.size &&
+      this.#activeMembershipVersion === state.membershipVersion &&
       state.entitiesDirty.size > 0;
-    if (canPatch) {
-      for (const entityId of state.entitiesDirty) {
-        if (!this.#classifiedEntityIds.has(entityId)) {
-          canPatch = false;
-          break;
-        }
-      }
-    }
-    this.#activeEntityCount = state.entities.size;
+    this.#activeMembershipVersion = state.membershipVersion;
     if (canPatch) {
       for (const entityId of state.entitiesDirty) {
         this.#playingGifs.delete(entityId);
@@ -229,9 +246,7 @@ export class FrameLoop {
     this.#playingGifs.clear();
     this.#playingVideos.clear();
     this.#continuousShaderEntities.clear();
-    this.#classifiedEntityIds.clear();
     for (const entity of state.entities.values()) {
-      this.#classifiedEntityIds.add(entity.id);
       this.#classifyActiveEntity(entity);
     }
   }

--- a/engine/game-loop.ts
+++ b/engine/game-loop.ts
@@ -64,6 +64,7 @@ export class GameLoop {
 
   setSpaceHeld(held: boolean): void {
     this.#input.setSpaceHeld(held);
+    this.#frameLoop.requestFrame();
   }
 
   get spacePanMode(): SpacePanMode {
@@ -96,26 +97,32 @@ export class GameLoop {
 
   handlePointerDown(screenPoint: Point, shiftKey: boolean = false): void {
     this.#input.handlePointerDown(screenPoint, shiftKey);
+    this.#frameLoop.requestFrame();
   }
 
   handlePointerMove(screenPoint: Point): void {
     this.#input.handlePointerMove(screenPoint);
+    this.#frameLoop.requestFrame();
   }
 
   handlePointerUp(screenPoint: Point): void {
     this.#input.handlePointerUp(screenPoint);
+    this.#frameLoop.requestFrame();
   }
 
   handleWheel(deltaX: number, deltaY: number, screenPoint: Point, ctrlKey: boolean): void {
     this.#input.handleWheel(deltaX, deltaY, screenPoint, ctrlKey);
+    this.#frameLoop.requestFrame();
   }
 
   handleContextMenu(screenPoint: Point): void {
     this.#input.handleContextMenu(screenPoint);
+    this.#frameLoop.requestFrame();
   }
 
   handleContextMenuClose(): void {
     this.#input.handleContextMenuClose();
+    this.#frameLoop.requestFrame();
   }
 
   getDragSelectBounds(): Bounds | null {

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -1,8 +1,9 @@
-export { CanvasStore, canvasStore } from "./canvas-store.ts";
+export { CanvasDirtyFlag, CanvasStore, canvasStore } from "./canvas-store.ts";
 export type {
   CanvasState,
   RenderState,
   CanvasEntityUpdate,
+  CanvasEntityPatch,
   ActionLayerRenderState,
   DragVisualRenderState,
   DisintegrationRenderOverlay,

--- a/lib/entity-spatial-index.ts
+++ b/lib/entity-spatial-index.ts
@@ -80,6 +80,12 @@ export class EntitySpatialIndex {
     for (const entityId of entityIds) {
       const entry = this.#entries.get(entityId);
       if (!entry) continue;
+      if (
+        !this.#overallBoundsDirty &&
+        movesExistingBoundsEdgeInward(entry.bounds, this.#overallBounds, delta)
+      ) {
+        this.#overallBoundsDirty = true;
+      }
       entry.bounds.x += delta.x;
       entry.bounds.y += delta.y;
       const nextCellX = this.#cellCoordinate(
@@ -96,9 +102,9 @@ export class EntitySpatialIndex {
         entry.cellY = nextCellY;
         this.#addToCell(entry);
       }
+      if (!this.#overallBoundsDirty) expandBounds(this.#overallBounds, entry.bounds, false);
       translatedCount++;
     }
-    if (translatedCount > 0) this.#overallBoundsDirty = true;
     return translatedCount;
   }
 
@@ -316,6 +322,19 @@ function touchesBoundsEdge(inner: Bounds, outer: Bounds): boolean {
     inner.y <= outer.y ||
     inner.x + inner.width >= outer.x + outer.width ||
     inner.y + inner.height >= outer.y + outer.height
+  );
+}
+
+function movesExistingBoundsEdgeInward(
+  inner: Bounds,
+  outer: Bounds,
+  delta: { x: number; y: number },
+): boolean {
+  return (
+    (delta.x > 0 && inner.x <= outer.x) ||
+    (delta.x < 0 && inner.x + inner.width >= outer.x + outer.width) ||
+    (delta.y > 0 && inner.y <= outer.y) ||
+    (delta.y < 0 && inner.y + inner.height >= outer.y + outer.height)
   );
 }
 

--- a/lib/media-loader.ts
+++ b/lib/media-loader.ts
@@ -456,8 +456,7 @@ export function createImageEntityData(
     rotation: 0,
     shaderType: config.defaults.shader,
     shaderParams: config.defaults.shaderParams,
-    textureDirty: true,
-    selected: false,
+    textureRevision: 1,
     locked: false,
     edited: false,
   };
@@ -509,8 +508,7 @@ export function createGifEntityData(
     rotation: 0,
     shaderType: config.defaults.shader,
     shaderParams: config.defaults.shaderParams,
-    textureDirty: true,
-    selected: false,
+    textureRevision: 1,
     locked: false,
     edited: false,
     playback: createPlaybackState({ isPlaying: true }), // Autoplay when added
@@ -607,8 +605,7 @@ export function createSvgEntityData(
     rotation: 0,
     shaderType: config.defaults.shader,
     shaderParams: config.defaults.shaderParams,
-    textureDirty: true,
-    selected: false,
+    textureRevision: 1,
     locked: false,
     edited: false,
   };
@@ -644,8 +641,7 @@ export function createVideoEntityData(
     rotation: 0,
     shaderType: config.defaults.shader,
     shaderParams: config.defaults.shaderParams,
-    textureDirty: true,
-    selected: false,
+    textureRevision: 1,
     locked: false,
     edited: false,
     playback: createPlaybackState({ isPlaying: true }), // Autoplay when added

--- a/lib/serialization/deserialize.ts
+++ b/lib/serialization/deserialize.ts
@@ -728,8 +728,7 @@ function createDeserializedEntityBase(
     edited: serialized.edited,
     shaderType,
     shaderParams,
-    textureDirty: true as const,
-    selected: false as const,
+    textureRevision: 1,
     ...(originalPalette && {
       originalPalette,
     }),

--- a/renderer/byte-budget-cache.ts
+++ b/renderer/byte-budget-cache.ts
@@ -36,6 +36,10 @@ export class ByteBudgetCache {
     const entry = this.#entries.get(key);
     if (!entry) throw new Error(`Byte-budget cache does not contain ${key}`);
     entry.lastUsedFrame = this.#currentFrame;
+    // Map iteration order is the LRU queue. Reinsert in O(1) instead of sorting
+    // the entire cache when pressure eventually requires eviction.
+    this.#entries.delete(key);
+    this.#entries.set(key, entry);
   }
 
   endFrame(): void {
@@ -62,12 +66,11 @@ export class ByteBudgetCache {
   #evictToBudget(): void {
     if (this.#residentBytes <= this.#budgetBytes) return;
 
-    const candidates = [...this.#entries.entries()]
-      .filter(([, entry]) => entry.lastUsedFrame !== this.#currentFrame)
-      .sort((a, b) => a[1].lastUsedFrame - b[1].lastUsedFrame);
-
-    for (const [key, entry] of candidates) {
+    for (const [key, entry] of this.#entries) {
       if (this.#residentBytes <= this.#budgetBytes) break;
+      // Current-frame entries were most recently reinserted at the tail. Once
+      // one is reached, every remaining entry is protected for this frame.
+      if (entry.lastUsedFrame === this.#currentFrame) break;
       this.#entries.delete(key);
       this.#residentBytes -= entry.byteSize;
       this.#evictions++;

--- a/renderer/canvas-callout-pass.ts
+++ b/renderer/canvas-callout-pass.ts
@@ -43,6 +43,9 @@ export class CanvasCalloutPass {
   #viewport: Viewport | null = null;
   #dpr = 1;
   #isMobile = false;
+  readonly #activeIds = new Set<string>();
+  readonly #uniformData = new Float32Array(UNIFORM_SIZE / 4);
+  readonly #resolvedPosition = { x: 0, y: 0 };
 
   constructor(device: GPUDevice, canvasFormat: GPUTextureFormat, viewportUniformBuffer: GPUBuffer) {
     this.#device = device;
@@ -108,18 +111,20 @@ export class CanvasCalloutPass {
   drawCallouts(
     pass: GPURenderPassEncoder,
     callouts: readonly CanvasCallout[],
-    entitiesById: ReadonlyMap<string, ShaderCanvasEntity>,
+    entities: readonly ShaderCanvasEntity[],
+    entityIndices: ReadonlyMap<string, number>,
   ): void {
     if (!this.#pipeline || !this.#viewport) return;
 
-    const activeIds = new Set<string>();
+    const activeIds = this.#activeIds;
+    activeIds.clear();
     for (const callout of callouts) {
       activeIds.add(callout.id);
       const entry = this.#getEntry(callout);
-      const position = this.#resolveWorldPosition(callout, entry, entitiesById);
+      const position = this.#resolveWorldPosition(callout, entry, entities, entityIndices);
       if (!position) continue;
 
-      const data = new Float32Array(UNIFORM_SIZE / 4);
+      const data = this.#uniformData;
       data[0] = position.x;
       data[1] = position.y;
       data[2] = entry.textureWidth / this.#viewport.zoom;
@@ -152,7 +157,8 @@ export class CanvasCalloutPass {
   #resolveWorldPosition(
     callout: CanvasCallout,
     entry: CalloutCacheEntry,
-    entitiesById: ReadonlyMap<string, ShaderCanvasEntity>,
+    entities: readonly ShaderCanvasEntity[],
+    entityIndices: ReadonlyMap<string, number>,
   ): { x: number; y: number } | null {
     const viewport = this.#viewport;
     if (!viewport) return null;
@@ -165,28 +171,28 @@ export class CanvasCalloutPass {
     if (callout.anchor.type === "screen") {
       const x = viewport.offset.x + (callout.anchor.position.x * this.#dpr) / viewport.zoom;
       const y = viewport.offset.y + (callout.anchor.position.y * this.#dpr) / viewport.zoom;
-      return {
-        x: x - (callout.anchor.align === "center" ? worldWidth / 2 : 0) + offsetX,
-        y: y + offsetY,
-      };
+      const result = this.#resolvedPosition;
+      result.x = x - (callout.anchor.align === "center" ? worldWidth / 2 : 0) + offsetX;
+      result.y = y + offsetY;
+      return result;
     }
 
-    const entity = entitiesById.get(callout.anchor.entityId);
+    const entityIndex = entityIndices.get(callout.anchor.entityId);
+    const entity = entityIndex === undefined ? undefined : entities[entityIndex];
     if (!entity) return null;
 
     const x = entity.position.x + entity.size.width / 2 - worldWidth / 2 + offsetX;
+    const result = this.#resolvedPosition;
+    result.x = x;
     if (callout.anchor.placement === "top") {
-      return {
-        x,
-        y: entity.position.y - (ENTITY_GAP * this.#dpr) / viewport.zoom - worldHeight + offsetY,
-      };
+      result.y =
+        entity.position.y - (ENTITY_GAP * this.#dpr) / viewport.zoom - worldHeight + offsetY;
+      return result;
     }
 
-    return {
-      x,
-      y:
-        entity.position.y + entity.size.height + (ENTITY_GAP * this.#dpr) / viewport.zoom + offsetY,
-    };
+    result.y =
+      entity.position.y + entity.size.height + (ENTITY_GAP * this.#dpr) / viewport.zoom + offsetY;
+    return result;
   }
 
   #getEntry(callout: CanvasCallout): CalloutCacheEntry {

--- a/renderer/canvas-renderer.ts
+++ b/renderer/canvas-renderer.ts
@@ -94,6 +94,7 @@ export class InfiniteCanvasRenderer {
   #entityTexturePipeline: EntityTexturePipeline | null = null;
   readonly #protectedFullSceneTextureOwners = new Set<string>();
   readonly #deferredEntityTextureRemovals = new Set<string>();
+  readonly #debugEntities: ShaderCanvasEntity[] = [];
 
   // Export service for rendering entities to blobs/bitmaps
   #exportService: ExportService | null = null;
@@ -118,6 +119,11 @@ export class InfiniteCanvasRenderer {
   #mixedBatchLodRefreshStarted = false;
   readonly #visibilityViewportBounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
   readonly #visibilityEntityBounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
+  #visibilityOffsetX = Number.NaN;
+  #visibilityOffsetY = Number.NaN;
+  #visibilityZoom = Number.NaN;
+  #visibilityWidth = Number.NaN;
+  #visibilityHeight = Number.NaN;
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
@@ -141,15 +147,30 @@ export class InfiniteCanvasRenderer {
     const height = Math.floor(this.#cachedCanvasHeight * dpr);
     if (width <= 0 || height <= 0) return true;
 
-    return boundsIntersect(
-      getRotatedAABB(entity.position, entity.size, entity.rotation, this.#visibilityEntityBounds),
+    if (
+      viewport.offset.x !== this.#visibilityOffsetX ||
+      viewport.offset.y !== this.#visibilityOffsetY ||
+      viewport.zoom !== this.#visibilityZoom ||
+      width !== this.#visibilityWidth ||
+      height !== this.#visibilityHeight
+    ) {
       getViewportWorldBounds(
         viewport,
         width,
         height,
         config.canvas.cullingBufferFraction,
         this.#visibilityViewportBounds,
-      ),
+      );
+      this.#visibilityOffsetX = viewport.offset.x;
+      this.#visibilityOffsetY = viewport.offset.y;
+      this.#visibilityZoom = viewport.zoom;
+      this.#visibilityWidth = width;
+      this.#visibilityHeight = height;
+    }
+
+    return boundsIntersect(
+      getRotatedAABB(entity.position, entity.size, entity.rotation, this.#visibilityEntityBounds),
+      this.#visibilityViewportBounds,
     );
   }
 
@@ -656,7 +677,8 @@ export class InfiniteCanvasRenderer {
       this.#canvasCalloutPass.drawCallouts(
         calloutPass,
         state.canvasCallouts,
-        new Map(entities.map((entity) => [entity.id, entity])),
+        entities,
+        state.entityIndices,
       );
       calloutPass.end();
     }
@@ -683,6 +705,8 @@ export class InfiniteCanvasRenderer {
     }
 
     if (import.meta.env.DEV && state.debugView !== "none" && this.#canvasDebugPass) {
+      this.#debugEntities.length = 0;
+      for (const item of entityDrawItems) this.#debugEntities.push(item.entity);
       this.#canvasDebugPass.encode({
         encoder,
         targetView: sceneTargetView,
@@ -690,7 +714,7 @@ export class InfiniteCanvasRenderer {
         viewport,
         width,
         height,
-        entities: entityDrawItems.map((item) => item.entity),
+        entities: this.#debugEntities,
         spatialIndex: state.entitySpatialIndex,
       });
     }

--- a/renderer/composition-pass.ts
+++ b/renderer/composition-pass.ts
@@ -691,7 +691,6 @@ export class CompositionPass {
         selectedEntityIds.has(entity.id),
         options.debugMode,
       );
-      entity.textureDirty = false;
     }
     const uploadBytes = entities.length * INSTANCE_STRIDE_BYTES;
     this.#device.queue.writeBuffer(buffer, 0, this.#instanceData, 0, uploadBytes);
@@ -735,7 +734,6 @@ export class CompositionPass {
         selectedEntityIds.has(entity.id),
         options.debugMode,
       );
-      entity.textureDirty = false;
     }
     const uploadBytes = entities.length * INSTANCE_STRIDE_BYTES;
     this.#device.queue.writeBuffer(buffer, 0, this.#instanceData, 0, uploadBytes);
@@ -922,7 +920,6 @@ export class CompositionPass {
 
     for (const { index, entity, isSelected } of sortedPatches) {
       this.#writeFullSceneInstance(index, entity, isSelected, key.debugMode);
-      entity.textureDirty = false;
     }
     for (let start = 0; start < sortedPatches.length;) {
       let end = start + 1;

--- a/renderer/disintegration-pass.ts
+++ b/renderer/disintegration-pass.ts
@@ -25,6 +25,8 @@ export class DisintegrationPass {
   readonly #compositionPass: CompositionPass;
   readonly #particleSystem: DisintegrationParticleSystem;
   readonly #overlays = new Map<string, DisintegrationOverlayGpu>();
+  readonly #liveIds = new Set<string>();
+  readonly #completedIds: string[] = [];
 
   constructor(options: DisintegrationPassOptions) {
     this.#device = options.device;
@@ -85,8 +87,11 @@ export class DisintegrationPass {
 
     // Clean up GPU resources for overlays whose animations have completed.
     // The engine snapshot omits overlays once their animation has completed.
-    const liveIds = new Set(overlays.map((overlay) => overlay.id));
-    const completedIds: string[] = [];
+    const liveIds = this.#liveIds;
+    liveIds.clear();
+    for (const overlay of overlays) liveIds.add(overlay.id);
+    const completedIds = this.#completedIds;
+    completedIds.length = 0;
     for (const id of this.#overlays.keys()) {
       if (!liveIds.has(id)) {
         completedIds.push(id);

--- a/renderer/entity-draw-item-preparer.ts
+++ b/renderer/entity-draw-item-preparer.ts
@@ -253,7 +253,7 @@ export class EntityDrawItemPreparer {
     for (const entity of visibleEntities) {
       // Check if texture needs regeneration. Animated media is marked dirty by the
       // game loop only when the decoded frame changes.
-      const textureWasDirty = !!entity.textureDirty;
+      const textureWasDirty = options.dirtyEntityIds.has(entity.id);
       const needsContinuousRender = this.#texturePipeline.needsContinuousRenderForEntity(entity);
       if (textureWasDirty || needsContinuousRender) {
         hasAnimatingContent = true;
@@ -294,9 +294,6 @@ export class EntityDrawItemPreparer {
         );
       }
       if (!compositionSource) continue;
-
-      // Clear dirty flag
-      entity.textureDirty = false;
 
       // Determine whether this entity is selected.
       const isSelected = allEntitiesSelected || selectedEntityIds.has(entity.id);
@@ -454,8 +451,6 @@ export class EntityDrawItemPreparer {
       );
     }
     if (compositionSource?.kind !== "texture") return null;
-    representative.textureDirty = false;
-
     const key = this.#fullSceneBatchKey ?? {
       entityVersion,
       geometryVersion,
@@ -822,7 +817,6 @@ export class EntityDrawItemPreparer {
       }
       if (source?.kind !== "texture") return false;
 
-      run.representative.textureDirty = false;
       run.texture = source.texture;
       if (source.texture !== previousTexture) {
         previousTexture = source.texture;
@@ -911,7 +905,6 @@ export class EntityDrawItemPreparer {
         return null;
       }
 
-      entity.textureDirty = false;
       if (source.texture !== previousTexture) {
         previousTexture = source.texture;
         fullTextureRunCount++;

--- a/renderer/entity-texture-pipeline.ts
+++ b/renderer/entity-texture-pipeline.ts
@@ -40,11 +40,11 @@ interface CachedEntityTexture {
 interface CachedSourceTexture extends CachedEntityTexture {
   width: number;
   height: number;
-  entityIds: Set<string>;
+  entityCount: number;
 }
 
 interface CachedProcessedTexture extends CachedEntityTexture {
-  entityIds: Set<string>;
+  entityCount: number;
 }
 
 interface GifResizeSurface {
@@ -92,7 +92,6 @@ export class EntityTexturePipeline {
   #textureCacheRevision = 0;
   readonly #residentTextureEntries = new WeakMap<GPUTexture, CachedEntityTexture>();
   readonly #lodCacheLookups = new Map<object, LodCacheLookup>();
-  #entityContentRevisions = new Map<string, number>();
   #gifResizeSurfaces = new Map<string, GifResizeSurface>();
   #renderEntityView: EffectRenderEntity | null = null;
   #sourceBytes = 0;
@@ -190,29 +189,29 @@ export class EntityTexturePipeline {
     const needsContinuousShaderRender =
       !entity.shaderParams.showOriginal && this.#runtime.needsContinuousRender(entity);
 
-    if (!entity.textureDirty) {
-      if (entity.shaderParams.showOriginal && !useExternalVideoSource) {
-        const currentSource = this.#entitySourceBindings.get(entity.id);
-        if (
-          currentSource &&
-          currentSource.width === width &&
-          currentSource.height === height &&
-          currentSource.contentRevision === contentRevision
-        ) {
-          currentSource.lastUsedFrame = this.#currentFrame;
-          return currentSource.compositionSource;
-        }
-      } else if (!entity.shaderParams.showOriginal && !needsContinuousShaderRender) {
-        const currentProcessed = this.#entityProcessedBindings.get(entity.id);
-        if (
-          currentProcessed &&
-          currentProcessed.texture.width === width &&
-          currentProcessed.texture.height === height &&
-          currentProcessed.contentRevision === contentRevision
-        ) {
-          currentProcessed.lastUsedFrame = this.#currentFrame;
-          return currentProcessed.compositionSource;
-        }
+    if (entity.shaderParams.showOriginal && !useExternalVideoSource) {
+      const currentSource = this.#entitySourceBindings.get(entity.id);
+      if (
+        currentSource &&
+        currentSource.width === width &&
+        currentSource.height === height &&
+        currentSource.contentRevision === contentRevision
+      ) {
+        this.#touchTexture(currentSource);
+        return currentSource.compositionSource;
+      }
+    } else if (!entity.shaderParams.showOriginal && !needsContinuousShaderRender) {
+      const currentProcessed = this.#entityProcessedBindings.get(entity.id);
+      if (
+        currentProcessed &&
+        currentProcessed.key ===
+          this.#getProcessedCacheKey(entity, width, height, needsContinuousShaderRender) &&
+        currentProcessed.texture.width === width &&
+        currentProcessed.texture.height === height &&
+        currentProcessed.contentRevision === contentRevision
+      ) {
+        this.#touchTexture(currentProcessed);
+        return currentProcessed.compositionSource;
       }
     }
 
@@ -225,16 +224,13 @@ export class EntityTexturePipeline {
     );
     let cachedTexture = this.#processedTextures.get(processedKey);
     const processedKeyWasCached = !!cachedTexture;
-    const canReuseDirtyTexture =
-      entity.mediaSource.type === MediaType.image && !needsContinuousShaderRender;
     if (
       !entity.shaderParams.showOriginal &&
       !needsContinuousShaderRender &&
       cachedTexture &&
-      cachedTexture.contentRevision === contentRevision &&
-      (!entity.textureDirty || canReuseDirtyTexture)
+      cachedTexture.contentRevision === contentRevision
     ) {
-      cachedTexture.lastUsedFrame = this.#currentFrame;
+      this.#touchTexture(cachedTexture);
       this.#bindEntityToProcessed(entity.id, processedKey, cachedTexture);
       return cachedTexture.compositionSource;
     }
@@ -284,7 +280,7 @@ export class EntityTexturePipeline {
           byteSize: getTextureByteSize(width, height, "rgba8unorm"),
           lastUsedFrame: this.#currentFrame,
           contentRevision,
-          entityIds: new Set(),
+          entityCount: 0,
         };
         this.#uploadStaticEntitySourceToTexture(entity, sourceTexture, width, height);
         this.#sourceTextures.set(sourceKey, cachedSource);
@@ -293,7 +289,7 @@ export class EntityTexturePipeline {
         this.#textureCacheRevision++;
       } else {
         sourceTexture = cachedSource.texture;
-        cachedSource.lastUsedFrame = this.#currentFrame;
+        this.#touchTexture(cachedSource);
         if (cachedSource.contentRevision !== contentRevision) {
           this.#uploadStaticEntitySourceToTexture(entity, sourceTexture, width, height);
           cachedSource.contentRevision = contentRevision;
@@ -323,9 +319,9 @@ export class EntityTexturePipeline {
         previousCached &&
         previousCached.texture.width === width &&
         previousCached.texture.height === height &&
-        previousCached.entityIds.size === 1;
+        previousCached.entityCount === 1;
       if (canRecyclePrevious && !cachedTexture) {
-        previousCached.entityIds.delete(entity.id);
+        previousCached.entityCount--;
         this.#entityProcessedBindings.delete(entity.id);
         this.#processedTextures.delete(previousProcessedKey);
         recycledTexture = previousCached;
@@ -390,7 +386,7 @@ export class EntityTexturePipeline {
       byteSize: getTextureByteSize(width, height, this.#colorConfig.intermediateFormat),
       lastUsedFrame: this.#currentFrame,
       contentRevision,
-      entityIds: cachedTexture?.entityIds ?? recycledTexture?.entityIds ?? new Set(),
+      entityCount: cachedTexture?.entityCount ?? recycledTexture?.entityCount ?? 0,
     };
     this.#processedTextures.set(processedKey, processedEntry);
     this.#residentTextureEntries.set(outputTexture, processedEntry);
@@ -427,11 +423,7 @@ export class EntityTexturePipeline {
     desired: { width: number; height: number },
     needsContinuousRender: boolean,
   ): EntityCompositionSource | null {
-    if (
-      entity.textureDirty ||
-      entity.mediaSource.type !== MediaType.image ||
-      needsContinuousRender
-    ) {
+    if (entity.mediaSource.type !== MediaType.image || needsContinuousRender) {
       return null;
     }
 
@@ -440,13 +432,17 @@ export class EntityTexturePipeline {
       : this.#entityProcessedBindings.get(entity.id);
     if (
       !entry ||
+      entry.key !==
+        (entity.shaderParams.showOriginal
+          ? this.#getSourceCacheKey(entity, desired.width, desired.height)
+          : this.#getProcessedCacheKey(entity, desired.width, desired.height, false)) ||
       entry.texture.width !== desired.width ||
       entry.texture.height !== desired.height
     ) {
       return null;
     }
 
-    entry.lastUsedFrame = this.#currentFrame;
+    this.#touchTexture(entry);
     return entry.compositionSource;
   }
 
@@ -487,7 +483,7 @@ export class EntityTexturePipeline {
     // frame even though they all use the same source and processed texture.
     const lookupToken = current ?? getSharedImageAsset(entity);
     const canReuseSharedTier =
-      !current || (currentEntry?.entityIds.size ?? 0) > 1 || this.#lodCacheLookups.has(current);
+      !current || (currentEntry?.entityCount ?? 0) > 1 || this.#lodCacheLookups.has(current);
     if (
       lookupToken &&
       canReuseSharedTier &&
@@ -515,7 +511,7 @@ export class EntityTexturePipeline {
     const allowAnimatedDemotion = isAnimatedEntity(entity) && pixelCost < currentPixelCount;
     const allowSharedImageDemotion =
       entity.mediaSource.type === MediaType.image &&
-      (currentEntry?.entityIds.size ?? 0) > 1 &&
+      (currentEntry?.entityCount ?? 0) > 1 &&
       pixelCost < currentPixelCount;
     if (
       !this.#tryAdmitLodTransition(pixelCost, allowAnimatedDemotion || allowSharedImageDemotion)
@@ -542,7 +538,7 @@ export class EntityTexturePipeline {
   pinCachedTexture(texture: GPUTexture): boolean {
     const entry = this.#residentTextureEntries.get(texture);
     if (!entry) return false;
-    entry.lastUsedFrame = this.#currentFrame;
+    this.#touchTexture(entry);
     return true;
   }
 
@@ -573,7 +569,6 @@ export class EntityTexturePipeline {
 
     this.#releaseEntitySourceTexture(entityId);
 
-    this.#entityContentRevisions.delete(entityId);
     const resizeSurface = this.#gifResizeSurfaces.get(entityId);
     if (resizeSurface) {
       resizeSurface.canvas.width = 1;
@@ -614,7 +609,6 @@ export class EntityTexturePipeline {
       canvas.height = 1;
     }
     this.#gifResizeSurfaces.clear();
-    this.#entityContentRevisions.clear();
 
     this.#runtime.destroy();
   }
@@ -659,14 +653,7 @@ export class EntityTexturePipeline {
   }
 
   #resolveContentRevision(entity: ShaderCanvasEntity): number {
-    if (!isAnimatedEntity(entity)) return 0;
-
-    const current = this.#entityContentRevisions.get(entity.id) ?? 0;
-    if (!entity.textureDirty) return current;
-
-    const next = current + 1;
-    this.#entityContentRevisions.set(entity.id, next);
-    return next;
+    return isAnimatedEntity(entity) ? entity.textureRevision : 0;
   }
 
   #getRenderEntityView(
@@ -796,13 +783,12 @@ export class EntityTexturePipeline {
     const previous = this.#entityProcessedBindings.get(entityId);
     const previousKey = previous?.key;
     if (previousKey === processedKey) {
-      cachedProcessed.entityIds.add(entityId);
       this.#entityProcessedBindings.set(entityId, cachedProcessed);
       return;
     }
     if (previousKey) this.#releaseEntityProcessedTexture(entityId, false);
 
-    cachedProcessed.entityIds.add(entityId);
+    cachedProcessed.entityCount++;
     this.#entityProcessedBindings.set(entityId, cachedProcessed);
   }
 
@@ -812,8 +798,8 @@ export class EntityTexturePipeline {
 
     this.#entityProcessedBindings.delete(entityId);
 
-    cachedProcessed.entityIds.delete(entityId);
-    if (destroyOrphan && cachedProcessed.entityIds.size === 0) {
+    cachedProcessed.entityCount--;
+    if (destroyOrphan && cachedProcessed.entityCount === 0) {
       cachedProcessed.texture.destroy();
       this.#residentTextureEntries.delete(cachedProcessed.texture);
       this.#processedTextures.delete(cachedProcessed.key);
@@ -831,7 +817,7 @@ export class EntityTexturePipeline {
     if (previousKey === sourceKey) return;
     if (previousKey) this.#releaseEntitySourceTexture(entityId, false);
 
-    cachedSource.entityIds.add(entityId);
+    cachedSource.entityCount++;
     this.#entitySourceBindings.set(entityId, cachedSource);
   }
 
@@ -841,8 +827,8 @@ export class EntityTexturePipeline {
 
     this.#entitySourceBindings.delete(entityId);
 
-    cachedSource.entityIds.delete(entityId);
-    if (destroyOrphan && cachedSource.entityIds.size === 0) {
+    cachedSource.entityCount--;
+    if (destroyOrphan && cachedSource.entityCount === 0) {
       cachedSource.texture.destroy();
       this.#residentTextureEntries.delete(cachedSource.texture);
       this.#sourceTextures.delete(cachedSource.key);
@@ -854,47 +840,84 @@ export class EntityTexturePipeline {
     if (this.#sourceBytes + this.#processedBytes <= this.#textureBudgetBytes) return;
 
     let residentBytes = this.#sourceBytes + this.#processedBytes;
-    const candidates: Array<
-      | { kind: "processed"; key: string; cached: CachedProcessedTexture }
-      | { kind: "source"; key: string; cached: CachedSourceTexture }
-    > = [];
+    const evictedProcessed = new Set<CachedProcessedTexture>();
+    const evictedSources = new Set<CachedSourceTexture>();
 
-    for (const [key, cached] of this.#processedTextures) {
-      if (cached.lastUsedFrame !== this.#currentFrame) {
-        candidates.push({ kind: "processed", key, cached });
-      }
-    }
-    for (const [key, cached] of this.#sourceTextures) {
-      if (cached.lastUsedFrame !== this.#currentFrame) {
-        candidates.push({ kind: "source", key, cached });
-      }
-    }
-    candidates.sort((a, b) => a.cached.lastUsedFrame - b.cached.lastUsedFrame);
+    while (residentBytes > this.#textureBudgetBytes) {
+      const processed = this.#oldestEvictable(this.#processedTextures);
+      const source = this.#oldestEvictable(this.#sourceTextures);
+      if (!processed && !source) break;
 
-    for (const candidate of candidates) {
-      if (residentBytes <= this.#textureBudgetBytes) break;
-      candidate.cached.texture.destroy();
-      this.#residentTextureEntries.delete(candidate.cached.texture);
-      residentBytes -= candidate.cached.byteSize;
+      const evictProcessed =
+        !!processed && (!source || processed.lastUsedFrame <= source.lastUsedFrame);
+      const cached = evictProcessed ? processed! : source!;
+      cached.texture.destroy();
+      this.#residentTextureEntries.delete(cached.texture);
+      residentBytes -= cached.byteSize;
       this.#evictions++;
       this.#textureCacheRevision++;
 
-      if (candidate.kind === "processed") {
-        this.#processedTextures.delete(candidate.key);
-        this.#processedBytes -= candidate.cached.byteSize;
-        for (const entityId of candidate.cached.entityIds) {
-          this.#entityProcessedBindings.delete(entityId);
-        }
-        this.#onTextureEvicted?.(candidate.cached.entityIds);
+      if (evictProcessed) {
+        const processedEntry = cached as CachedProcessedTexture;
+        this.#processedTextures.delete(processedEntry.key);
+        this.#processedBytes -= processedEntry.byteSize;
+        evictedProcessed.add(processedEntry);
         continue;
       }
 
-      this.#sourceTextures.delete(candidate.key);
-      this.#sourceBytes -= candidate.cached.byteSize;
-      for (const entityId of candidate.cached.entityIds) {
-        this.#entitySourceBindings.delete(entityId);
+      const sourceEntry = cached as CachedSourceTexture;
+      this.#sourceTextures.delete(sourceEntry.key);
+      this.#sourceBytes -= sourceEntry.byteSize;
+      evictedSources.add(sourceEntry);
+    }
+
+    this.#deleteBindingsForEntries(this.#entityProcessedBindings, evictedProcessed);
+    this.#deleteBindingsForEntries(this.#entitySourceBindings, evictedSources);
+  }
+
+  #touchTexture(entry: CachedEntityTexture): void {
+    if (entry.lastUsedFrame === this.#currentFrame) return;
+
+    entry.lastUsedFrame = this.#currentFrame;
+    if (Object.is(this.#processedTextures.get(entry.key), entry)) {
+      const processed = entry as CachedProcessedTexture;
+      this.#processedTextures.delete(entry.key);
+      this.#processedTextures.set(entry.key, processed);
+      return;
+    }
+    if (Object.is(this.#sourceTextures.get(entry.key), entry)) {
+      const source = entry as CachedSourceTexture;
+      this.#sourceTextures.delete(entry.key);
+      this.#sourceTextures.set(entry.key, source);
+    }
+  }
+
+  #oldestEvictable<T extends CachedEntityTexture>(cache: Map<string, T>): T | null {
+    const oldest = cache.values().next().value as T | undefined;
+    return oldest && oldest.lastUsedFrame !== this.#currentFrame ? oldest : null;
+  }
+
+  #deleteBindingsForEntries<T extends CachedEntityTexture>(
+    bindings: Map<string, T>,
+    evictedEntries: ReadonlySet<T>,
+  ): void {
+    if (evictedEntries.size === 0) return;
+
+    const entityIdsByEntry = new Map<T, Set<string>>();
+    for (const [entityId, boundEntry] of bindings) {
+      if (!evictedEntries.has(boundEntry)) continue;
+      bindings.delete(entityId);
+      let entityIds = entityIdsByEntry.get(boundEntry);
+      if (!entityIds) {
+        entityIds = new Set();
+        entityIdsByEntry.set(boundEntry, entityIds);
       }
-      this.#onTextureEvicted?.(candidate.cached.entityIds);
+      entityIds.add(entityId);
+    }
+    if (this.#onTextureEvicted) {
+      for (const entityIds of entityIdsByEntry.values()) {
+        this.#onTextureEvicted(entityIds);
+      }
     }
   }
 }

--- a/renderer/wlur-overlay-pass.ts
+++ b/renderer/wlur-overlay-pass.ts
@@ -31,7 +31,7 @@ export class WlurOverlayPass {
   readonly #sourceCopyPass: CopyPass;
   readonly #presentCopyPass: CopyPass;
 
-  #config: WlurOverlayConfig | null = null;
+  #resolvedConfig: ResolvedWlurOverlayConfig | null = null;
   #textures: {
     width: number;
     height: number;
@@ -39,8 +39,6 @@ export class WlurOverlayPass {
     output: GPUTexture;
   } | null = null;
   #cacheValid = false;
-  #cacheKey = "";
-  #lastQualityKey = "";
 
   constructor(options: WlurOverlayPassOptions) {
     this.#device = options.device;
@@ -57,10 +55,9 @@ export class WlurOverlayPass {
   }
 
   setConfig(config: WlurOverlayConfig | null): void {
-    this.#config = config;
-    this.#lastQualityKey = "";
-    if (config?.quality) {
-      this.#wlurPass.updateConfig({ quality: config.quality });
+    this.#resolvedConfig = resolveWlurOverlayRuntimeConfig(config, 2, 1);
+    if (this.#resolvedConfig) {
+      this.#wlurPass.updateConfig({ quality: this.#resolvedConfig.quality });
     } else if (!config) {
       this.#destroyTextures();
     }
@@ -69,36 +66,17 @@ export class WlurOverlayPass {
 
   invalidateCache(): void {
     this.#cacheValid = false;
-    this.#cacheKey = "";
   }
 
   encode(options: EncodeWlurOverlayOptions): boolean {
-    const resolvedConfig = resolveWlurOverlayRuntimeConfig(
-      this.#config,
-      options.height,
-      options.devicePixelRatio,
-    );
+    const resolvedConfig = this.#resolvedConfig;
     if (!resolvedConfig) {
       this.invalidateCache();
       return false;
     }
 
     const textures = this.#getOrCreateTextures(options.width, options.height);
-    const cacheKey = this.#buildCacheKey(options.width, options.height, resolvedConfig);
-    const needsUpdate =
-      !resolvedConfig.cache ||
-      !this.#cacheValid ||
-      this.#cacheKey !== cacheKey ||
-      options.contentDirty;
-
-    const qualityKey = [
-      resolvedConfig.quality.kernelSize,
-      resolvedConfig.quality.resolutionScale,
-    ].join("|");
-    if (qualityKey !== this.#lastQualityKey) {
-      this.#wlurPass.updateConfig({ quality: resolvedConfig.quality });
-      this.#lastQualityKey = qualityKey;
-    }
+    const needsUpdate = !resolvedConfig.cache || !this.#cacheValid || options.contentDirty;
 
     if (needsUpdate) {
       let wlurSource = options.sourceTexture;
@@ -123,7 +101,6 @@ export class WlurOverlayPass {
 
       if (resolvedConfig.cache) {
         this.#cacheValid = true;
-        this.#cacheKey = cacheKey;
       } else {
         this.invalidateCache();
       }
@@ -144,8 +121,7 @@ export class WlurOverlayPass {
 
   destroy(): void {
     this.#wlurPass.destroy();
-    this.#config = null;
-    this.#lastQualityKey = "";
+    this.#resolvedConfig = null;
     this.#destroyTextures();
     this.invalidateCache();
   }
@@ -192,25 +168,5 @@ export class WlurOverlayPass {
 
     this.#textures = { width, height, input, output };
     return this.#textures;
-  }
-
-  #buildCacheKey(width: number, height: number, resolvedConfig: ResolvedWlurOverlayConfig): string {
-    const { params, quality } = resolvedConfig;
-    return [
-      width,
-      height,
-      quality.kernelSize,
-      quality.resolutionScale,
-      params.radius,
-      params.offset,
-      params.interpolation,
-      params.direction,
-      params.noise,
-      params.curve?.join(",") ?? "",
-      params.mixCurve?.join(",") ?? "",
-      params.tint?.color.join(",") ?? "",
-      params.tint?.amount ?? "",
-      params.tint?.curve?.join(",") ?? "",
-    ].join("|");
   }
 }

--- a/types/canvas.ts
+++ b/types/canvas.ts
@@ -508,12 +508,8 @@ type ShaderCanvasEntityBase = {
   /** Shader parameters */
   shaderParams: ShaderParams;
 
-  /** Cached processed texture (managed by renderer) */
-  texture?: GPUTexture;
-  /** True when shader params changed and texture needs re-render */
-  textureDirty?: boolean;
-  /** Whether entity is currently selected */
-  selected?: boolean;
+  /** Monotonic visual-content revision consumed by renderer-owned caches. */
+  textureRevision: number;
   /** Whether entity is locked (cannot be moved) */
   locked?: boolean;
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,14 +1,12 @@
 export type Thunk<T = void> = () => Promise<T>;
 export type ThunkSync<T = void> = () => T;
 
-export type EnumOf<T extends PropertyKey> = {
-  [K in T]: K;
-} & { infer: T };
+export type EnumOf<T extends Record<PropertyKey, PropertyKey>> = Readonly<T> & {
+  infer: T[keyof T];
+};
 
-export function createEnum<const T extends Record<PropertyKey, PropertyKey>>(
-  source: T,
-): EnumOf<T[keyof T]> {
+export function createEnum<const T extends Record<PropertyKey, PropertyKey>>(source: T): EnumOf<T> {
   const result = source;
   Object.freeze(result);
-  return result as unknown as EnumOf<T[keyof T]>;
+  return result as unknown as EnumOf<T>;
 }


### PR DESCRIPTION
## Summary

- replace scene dirty booleans with a compact dirty bitmask and let the frame loop sleep until render/input invalidation
- use membership and texture revision counters to avoid retained full-scene ID sets and renderer-owned entity dirty state
- incrementally maintain spatial bounds for translations and keep z-index-only updates out of the spatial index
- remove hot-path allocations in cache eviction, callouts, disintegration, debug rendering, visibility checks, and WLUR configuration
- add a focused CPU benchmark harness under `bench/` and extend the browser benchmark scenarios/counters

## Why

Large canvases were paying avoidable CPU and memory costs from continuous idle RAF scheduling, full-bounds recomputation after interior moves, allocation-and-sort based cache eviction, reverse entity-ID ownership sets, and temporary collections created during render passes. These costs become visible at 100k+ entities and during cache churn.

The per-entity dirty set remains sparse: the benchmark showed clean dirty checks are already negligible, so introducing permanent dense numeric handles and a second identity table was not justified. The repeatedly checked scene-level dirty domains are now bitmasked.

## Benchmarks

Focused CPU harness, 131,072 entities:

| Workload | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Interior translation + full bounds query | 0.8009 ms | 0.0013 ms | -99.84% |
| 16k-entry cache eviction | 1.2876 ms | 0.6732 ms | -47.7% |
| Single z-index update | 10.1988 ms | 9.9620 ms | -2.3% |
| 100k clean dirty checks | 0.0339 ms | 0.0318 ms | effectively noise |

Browser guards:

- 262k overview pan: 12.239 -> 11.867 ms/frame
- 4k unique-thumbnail cache churn: 1.316 -> 1.219 ms/frame
- mixed paused-video scenario: 8.296 -> 8.293 ms/frame
- final same-machine cache-churn A/B CPU render p95: 0.4 -> 0.4 ms (pass)

## Validation

- `bun run lint:all`
- `bun run test` — 70 files, 735 tests
- `git diff --check`
